### PR TITLE
(122) Finish ingest of files - API Changes

### DIFF
--- a/app/controllers/v1/submission_files_controller.rb
+++ b/app/controllers/v1/submission_files_controller.rb
@@ -21,6 +21,12 @@ class V1::SubmissionFilesController < ApplicationController
     end
   end
 
+  def show
+    submission_file = SubmissionFile.find(params[:id])
+
+    render jsonapi: submission_file, status: :ok
+  end
+
   private
 
   def submission_file_params

--- a/app/controllers/v1/submission_files_controller.rb
+++ b/app/controllers/v1/submission_files_controller.rb
@@ -1,6 +1,7 @@
 class V1::SubmissionFilesController < ApplicationController
+  deserializable_resource :submission_file, only: %i[update]
   def create
-    submission = Submission.find(submission_file_params[:submission_id])
+    submission = Submission.find(params[:submission_id])
     submission_file = submission.files.new
 
     if submission_file.save
@@ -11,16 +12,18 @@ class V1::SubmissionFilesController < ApplicationController
   end
 
   def update
-    SubmissionFile.find(params[:id])
-
-    # TODO: Store the updated file
-
-    head :no_content
+    submission_file = SubmissionFile.find(params[:id])
+    submission_file.rows = submission_file_params[:rows]
+    if submission_file.save
+      head :no_content
+    else
+      render jsonapi: submission_file.errors, status: :bad_request
+    end
   end
 
   private
 
   def submission_file_params
-    params.permit(:submission_id)
+    params.require(:submission_file).permit(:rows)
   end
 end

--- a/app/controllers/v1/submission_files_controller.rb
+++ b/app/controllers/v1/submission_files_controller.rb
@@ -13,7 +13,7 @@ class V1::SubmissionFilesController < ApplicationController
 
   def update
     submission_file = SubmissionFile.find(params[:id])
-    submission_file.rows = submission_file_params[:rows]
+    submission_file.rows = submission_file_params[:rows] if submission_file_params[:rows]
     if submission_file.save
       head :no_content
     else

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -1,5 +1,5 @@
 class V1::TasksController < ApplicationController
-  deserializable_resource :task, only: [:create]
+  deserializable_resource :task, only: %i[create update]
 
   def create
     task = Task.new(task_params)
@@ -25,6 +25,17 @@ class V1::TasksController < ApplicationController
     render jsonapi: task, include: params.dig(:include)
   end
 
+  def update
+    task = Task.find(params[:id])
+    task.update(task_params)
+
+    if task.save
+      render jsonapi: task
+    else
+      render jsonapi_errors: task.errors, status: :bad_request
+    end
+  end
+
   def complete
     task = Task.find(params[:id])
     task.status = 'complete'
@@ -39,6 +50,7 @@ class V1::TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:supplier_id, :framework_id, :due_on, :period_month, :period_year, :description)
+    params.require(:task).permit(:supplier_id, :framework_id, :status, :due_on,
+                                 :period_month, :period_year, :description)
   end
 end

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -30,7 +30,7 @@ class V1::TasksController < ApplicationController
     task.update(task_params)
 
     if task.save
-      render jsonapi: task
+      head :no_content
     else
       render jsonapi_errors: task.errors, status: :bad_request
     end

--- a/app/deserializable/deserializable_submission_entry.rb
+++ b/app/deserializable/deserializable_submission_entry.rb
@@ -1,4 +1,6 @@
 class DeserializableSubmissionEntry < JSONAPI::Deserializable::Resource
   attribute :source
   attribute :data
+  attribute :status
+  attribute :validation_errors
 end

--- a/app/deserializable/deserializable_submission_file.rb
+++ b/app/deserializable/deserializable_submission_file.rb
@@ -1,0 +1,3 @@
+class DeserializableSubmissionFile < JSONAPI::Deserializable::Resource
+  attribute :rows
+end

--- a/app/serializable/serializable_submission_entry.rb
+++ b/app/serializable/serializable_submission_entry.rb
@@ -7,6 +7,8 @@ class SerializableSubmissionEntry < JSONAPI::Serializable::Resource
   attribute :source
   attribute :data
 
+  attribute :validation_errors
+
   attribute :status do
     @object.aasm.current_state
   end

--- a/app/serializable/serializable_submission_file.rb
+++ b/app/serializable/serializable_submission_file.rb
@@ -2,4 +2,5 @@ class SerializableSubmissionFile < JSONAPI::Serializable::Resource
   type 'submission_files'
 
   attribute :submission_id
+  attribute :rows
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     resources :suppliers, only: %i[index]
     resources :agreements, only: %i[create]
     resources :submissions, only: %i[show create update] do
-      resources :files, only: %i[create update], controller: 'submission_files'
+      resources :files, only: %i[create update show], controller: 'submission_files'
       resources :entries, only: %i[create], controller: 'submission_entries'
     end
     resources :tasks, only: %i[index show create update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       resources :files, only: %i[create update], controller: 'submission_files'
       resources :entries, only: %i[create], controller: 'submission_entries'
     end
-    resources :tasks, only: %i[index show create] do
+    resources :tasks, only: %i[index show create update] do
       member do
         post 'complete', to: 'tasks#complete'
       end

--- a/db/migrate/20180705143045_add_rows_to_submission_file.rb
+++ b/db/migrate/20180705143045_add_rows_to_submission_file.rb
@@ -1,0 +1,5 @@
+class AddRowsToSubmissionFile < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submission_files, :rows, :integer
+  end
+end

--- a/db/migrate/20180706003625_add_errors_to_submission_entry.rb
+++ b/db/migrate/20180706003625_add_errors_to_submission_entry.rb
@@ -1,0 +1,5 @@
+class AddErrorsToSubmissionEntry < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submission_entries, :validation_errors, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_02_191819) do
+ActiveRecord::Schema.define(version: 2018_07_05_143045) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2018_07_02_191819) do
 
   create_table "submission_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id", null: false
+    t.integer "rows"
     t.index ["submission_id"], name: "index_submission_files_on_submission_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_05_143045) do
+ActiveRecord::Schema.define(version: 2018_07_06_003625) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2018_07_05_143045) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "aasm_state"
+    t.jsonb "validation_errors"
     t.index ["aasm_state"], name: "index_submission_entries_on_aasm_state"
     t.index ["submission_file_id"], name: "index_submission_entries_on_submission_file_id"
     t.index ["submission_id"], name: "index_submission_entries_on_submission_id"

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe '/v1' do
   end
 
   describe 'PATCH /files/:file_id/entries/:id' do
-    it 'updates the given entry' do
+    it "updates the given entry's validation status and errors received from DAVE" do
       file = FactoryBot.create(:submission_file)
       entry = FactoryBot.create(:submission_entry,
                                 submission_file: file,
@@ -103,7 +103,8 @@ RSpec.describe '/v1' do
         data: {
           type: 'submission_entries',
           attributes: {
-            valid: true
+            status: 'errored',
+            validation_errors: { message: 'Invalid data' }
           }
         }
       }
@@ -116,6 +117,8 @@ RSpec.describe '/v1' do
       patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
 
       expect(response).to have_http_status(:no_content)
+      expect(entry.reload.aasm.current_state).to eql :errored
+      expect(entry.reload.validation_errors['message']).to eql 'Invalid data'
     end
   end
 end

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe '/v1' do
   end
 
   describe 'PATCH /files/:file_id/entries/:id' do
-    it "updates the given entry's validation status and errors received from DAVE" do
+    it 'updates the given entry\'s validation status received from DAVE' do
       file = FactoryBot.create(:submission_file)
       entry = FactoryBot.create(:submission_entry,
                                 submission_file: file,
@@ -103,8 +103,7 @@ RSpec.describe '/v1' do
         data: {
           type: 'submission_entries',
           attributes: {
-            status: 'errored',
-            validation_errors: { message: 'Invalid data' }
+            status: 'validated'
           }
         }
       }
@@ -117,8 +116,74 @@ RSpec.describe '/v1' do
       patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
 
       expect(response).to have_http_status(:no_content)
-      expect(entry.reload.aasm.current_state).to eql :errored
-      expect(entry.reload.validation_errors['message']).to eql 'Invalid data'
+      expect(entry.reload).to be_validated
+    end
+
+    it 'updates the given entry\'s validation errors received from DAVE' do
+      file = FactoryBot.create(:submission_file)
+      entry = FactoryBot.create(:submission_entry,
+                                submission_file: file,
+                                data: { test: 'test' })
+
+      params = {
+        data: {
+          type: 'submission_entries',
+          attributes: {
+            validation_errors: {
+              location: {
+                row: 20,
+                column: 2
+              },
+              message: 'Required value error'
+            }
+          }
+        }
+      }
+
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:no_content)
+      expect(entry.reload).to be_pending
+      expect(entry.reload.validation_errors['message']).to eql 'Required value error'
+    end
+
+    it 'updates both the given entry\'s status and the validation errors received from DAVE' do
+      file = FactoryBot.create(:submission_file)
+      entry = FactoryBot.create(:submission_entry,
+                                submission_file: file,
+                                data: { test: 'test' })
+
+      params = {
+        data: {
+          type: 'submission_entries',
+          attributes: {
+            status: 'errored',
+            validation_errors: {
+              location: {
+                row: 20,
+                column: 2
+              },
+              message: 'Required value error'
+            }
+          }
+        }
+      }
+
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:no_content)
+      expect(entry.reload).to be_errored
+      expect(entry.reload.validation_errors['message']).to eql 'Required value error'
     end
   end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -130,6 +130,23 @@ RSpec.describe '/v1' do
     end
   end
 
+  describe 'GET /submissions/:submission_id/files/:id' do
+    it 'retrieves a submission file data associated with a submission' do
+      submission = FactoryBot.create(:submission)
+      file = FactoryBot.create(:submission_file, submission_id: submission.id, rows: 40)
+
+      get "/v1/submissions/#{submission.id}/files/#{file.id}"
+
+      expect(response).to have_http_status(:ok)
+
+      expect(json['data']).to have_id(file.id)
+
+      expect(json['data']).to have_attribute(:rows).with_value(file.rows)
+
+      expect(json.dig('data', 'attributes', 'rows')).to eql 40
+    end
+  end
+
   describe 'POST /submissions/:submission_id/entries' do
     it 'stores a submission entry, not associated with a file' do
       submission = FactoryBot.create(:submission)

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -80,7 +80,20 @@ RSpec.describe '/v1' do
     it 'creates a new submission file and returns its id' do
       submission = FactoryBot.create(:submission)
 
-      post "/v1/submissions/#{submission.id}/files"
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      params = {
+        data: {
+          type: 'submission_files',
+          attributes: {
+          }
+        }
+      }
+
+      post "/v1/submissions/#{submission.id}/files", params: params.to_json, headers: headers
 
       expect(response).to have_http_status(:created)
 
@@ -101,9 +114,19 @@ RSpec.describe '/v1' do
         'Accept': 'application/vnd.api+json'
       }
 
-      patch "/v1/submissions/#{submission.id}/files/#{file.id}", params: {}, headers: headers
+      params = {
+        data: {
+          type: 'submission_files',
+          attributes: {
+            rows: 1000
+          }
+        }
+      }
+
+      patch "/v1/submissions/#{submission.id}/files/#{file.id}", params: params.to_json, headers: headers
 
       expect(response).to have_http_status(204)
+      expect(file.reload.rows).to eql 1000
     end
   end
 

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -85,15 +85,7 @@ RSpec.describe '/v1' do
         'Accept': 'application/vnd.api+json'
       }
 
-      params = {
-        data: {
-          type: 'submission_files',
-          attributes: {
-          }
-        }
-      }
-
-      post "/v1/submissions/#{submission.id}/files", params: params.to_json, headers: headers
+      post "/v1/submissions/#{submission.id}/files", params: {}, headers: headers
 
       expect(response).to have_http_status(:created)
 
@@ -142,8 +134,6 @@ RSpec.describe '/v1' do
       expect(json['data']).to have_id(file.id)
 
       expect(json['data']).to have_attribute(:rows).with_value(file.rows)
-
-      expect(json.dig('data', 'attributes', 'rows')).to eql 40
     end
   end
 

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -162,4 +162,32 @@ RSpec.describe '/v1' do
       expect(task).to be_complete
     end
   end
+
+  describe 'PATCH /v1/tasks/:task_id' do
+    it "updates a task's attributes" do
+      task = FactoryBot.create(:task)
+
+      params = {
+        data: {
+          type: 'tasks',
+          attributes: {
+            status: 'in_progress'
+          }
+        }
+      }
+
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      patch "/v1/tasks/#{task.id}", params: params.to_json, headers: headers
+
+      expect(response).to be_successful
+
+      task.reload
+
+      expect(task).to be_in_progress
+    end
+  end
 end


### PR DESCRIPTION
1) Update SubmissionFile with number of rows to be ingested
    -- Add rows column to SubmissionFile
    -- Modify PATCH v1/submissions/:submission_id/files/:id endpoint to update rows column and add tests
   -- Modify POST and PATCH endpoints for submission_file_controller and tests to json api format

2) API endpoint `PATCH /v1/files/:file_id/entries/:entry_id` stores validation status and errors received from DAVE

3) Add `PATCH /v1/tasks/:task_id` endpoint for updating a task's attributes

4) Add `Add `GET v1/files/:id` endpoint to retrieve submission_file details and add validation_errors to submission_entry json response