### PR TITLE
(125) Link users and suppliers

### DIFF
--- a/app/controllers/v1/memberships_controller.rb
+++ b/app/controllers/v1/memberships_controller.rb
@@ -1,9 +1,27 @@
 class V1::MembershipsController < ApplicationController
+  deserializable_resource :membership, only: [:create]
+
   def index
     memberships = Membership.where(nil)
     memberships = memberships.where(supplier_id: params.dig(:filter, :supplier_id)) if params.dig(:filter, :supplier_id)
     memberships = memberships.where(user_id: params.dig(:filter, :user_id)) if params.dig(:filter, :user_id)
 
     render jsonapi: memberships
+  end
+
+  def create
+    membership = Membership.new(create_membership_params)
+
+    if membership.save
+      render jsonapi: membership, status: :created
+    else
+      render jsonapi_errors: membership.errors, status: :bad_request
+    end
+  end
+
+  private
+
+  def create_membership_params
+    params.require(:membership).permit(:user_id, :supplier_id)
   end
 end

--- a/app/controllers/v1/memberships_controller.rb
+++ b/app/controllers/v1/memberships_controller.rb
@@ -1,0 +1,5 @@
+class V1::MembershipsController < ApplicationController
+  def index
+    render jsonapi: Membership.all
+  end
+end

--- a/app/controllers/v1/memberships_controller.rb
+++ b/app/controllers/v1/memberships_controller.rb
@@ -1,5 +1,9 @@
 class V1::MembershipsController < ApplicationController
   def index
-    render jsonapi: Membership.all
+    memberships = Membership.where(nil)
+    memberships = memberships.where(supplier_id: params.dig(:filter, :supplier_id)) if params.dig(:filter, :supplier_id)
+    memberships = memberships.where(user_id: params.dig(:filter, :user_id)) if params.dig(:filter, :user_id)
+
+    render jsonapi: memberships
   end
 end

--- a/app/controllers/v1/memberships_controller.rb
+++ b/app/controllers/v1/memberships_controller.rb
@@ -19,6 +19,13 @@ class V1::MembershipsController < ApplicationController
     end
   end
 
+  def destroy
+    membership = Membership.find(params[:id])
+    membership.destroy
+
+    head :no_content
+  end
+
   private
 
   def create_membership_params

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -15,6 +15,7 @@ class V1::TasksController < ApplicationController
     tasks = Task.where(nil)
     tasks = tasks.where(status: params.dig(:filter, :status)) if params.dig(:filter, :status)
     tasks = tasks.where(supplier_id: params.dig(:filter, :supplier_id)) if params.dig(:filter, :supplier_id)
+    tasks = tasks.for_user_id(params.dig(:filter, :user_id)) if params.dig(:filter, :user_id)
 
     render jsonapi: tasks, include: params.dig(:include)
   end

--- a/app/deserializable/deserializable_membership.rb
+++ b/app/deserializable/deserializable_membership.rb
@@ -1,0 +1,2 @@
+class DeserializableMembership < JSONAPI::Deserializable::Resource
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,6 @@
+class Membership < ApplicationRecord
+  belongs_to :supplier
+
+  validates :supplier_id, presence: true
+  validates :user_id, presence: true
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,6 +1,5 @@
 class Membership < ApplicationRecord
   belongs_to :supplier
 
-  validates :supplier_id, presence: true
   validates :user_id, presence: true
 end

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -2,6 +2,7 @@ class Supplier < ApplicationRecord
   has_many :agreements, dependent: :destroy
   has_many :frameworks, through: :agreements
   has_many :submissions, dependent: :nullify
+  has_many :memberships, dependent: :destroy
 
   validates :name, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,4 +16,12 @@ class Task < ApplicationRecord
   belongs_to :supplier
 
   has_many :submissions, dependent: :nullify
+
+  def self.for_user_id(user_id)
+    supplier_ids = Membership
+                   .where(user_id: user_id)
+                   .pluck(:supplier_id)
+
+    where(supplier_id: supplier_ids)
+  end
 end

--- a/app/serializable/serializable_membership.rb
+++ b/app/serializable/serializable_membership.rb
@@ -1,0 +1,5 @@
+class SerializableMembership < JSONAPI::Serializable::Resource
+  type 'memberships'
+
+  attributes :user_id, :supplier_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   namespace :v1, defaults: { format: :json } do
     resources :frameworks, only: %i[index show]
     resources :suppliers, only: %i[index]
+    resources :memberships, only: %i[index]
     resources :agreements, only: %i[create]
     resources :submissions, only: %i[show create update] do
       resources :files, only: %i[create update show], controller: 'submission_files'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   namespace :v1, defaults: { format: :json } do
     resources :frameworks, only: %i[index show]
     resources :suppliers, only: %i[index]
-    resources :memberships, only: %i[index]
+    resources :memberships, only: %i[index create]
     resources :agreements, only: %i[create]
     resources :submissions, only: %i[show create update] do
       resources :files, only: %i[create update show], controller: 'submission_files'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   namespace :v1, defaults: { format: :json } do
     resources :frameworks, only: %i[index show]
     resources :suppliers, only: %i[index]
-    resources :memberships, only: %i[index create]
+    resources :memberships, only: %i[index create destroy]
     resources :agreements, only: %i[create]
     resources :submissions, only: %i[show create update] do
       resources :files, only: %i[create update show], controller: 'submission_files'

--- a/db/migrate/20180705094621_create_membership.rb
+++ b/db/migrate/20180705094621_create_membership.rb
@@ -1,0 +1,11 @@
+class CreateMembership < ActiveRecord::Migration[5.2]
+  def change
+    create_table :memberships, id: :uuid do |t|
+      t.uuid :user_id, null: false
+      t.references :supplier, foreign_key: true, null: false, type: :uuid
+      t.timestamps
+    end
+
+    add_index :memberships, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,6 +55,15 @@ ActiveRecord::Schema.define(version: 2018_07_06_003625) do
     t.index ["short_name"], name: "index_frameworks_on_short_name", unique: true
   end
 
+  create_table "memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "supplier_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["supplier_id"], name: "index_memberships_on_supplier_id"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
+
   create_table "submission_entries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id", null: false
     t.uuid "submission_file_id"
@@ -107,6 +116,7 @@ ActiveRecord::Schema.define(version: 2018_07_06_003625) do
   end
 
   add_foreign_key "framework_lots", "frameworks"
+  add_foreign_key "memberships", "suppliers"
   add_foreign_key "submission_entries", "submission_files"
   add_foreign_key "submission_entries", "submissions"
   add_foreign_key "submission_files", "submissions"

--- a/spec/factories/membership.rb
+++ b/spec/factories/membership.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :membership do
+    user_id { SecureRandom.uuid }
+    supplier
+  end
+end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Membership do
+  it { is_expected.to belong_to(:supplier) }
+
+  it { is_expected.to validate_presence_of(:supplier_id) }
+  it { is_expected.to validate_presence_of(:user_id) }
+end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -2,7 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Membership do
   it { is_expected.to belong_to(:supplier) }
-
-  it { is_expected.to validate_presence_of(:supplier_id) }
   it { is_expected.to validate_presence_of(:user_id) }
 end

--- a/spec/models/supplier_spec.rb
+++ b/spec/models/supplier_spec.rb
@@ -6,4 +6,5 @@ RSpec.describe Supplier do
 
   it { is_expected.to have_many(:agreements) }
   it { is_expected.to have_many(:frameworks).through(:agreements) }
+  it { is_expected.to have_many(:memberships) }
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -7,4 +7,27 @@ RSpec.describe Task do
   it { is_expected.to belong_to(:supplier) }
 
   it { is_expected.to have_many(:submissions) }
+
+  describe '.for_user_id' do
+    it 'returns tasks for all suppliers that the current user is a member of' do
+      user_id = SecureRandom.uuid
+
+      users_supplier1 = FactoryBot.create(:supplier)
+      users_supplier2 = FactoryBot.create(:supplier)
+      other_supplier = FactoryBot.create(:supplier)
+
+      FactoryBot.create(:membership, supplier: users_supplier1, user_id: user_id)
+      FactoryBot.create(:membership, supplier: users_supplier2, user_id: user_id)
+
+      task1 = FactoryBot.create(:task, supplier: users_supplier1)
+      task2 = FactoryBot.create(:task, supplier: users_supplier2)
+      task3 = FactoryBot.create(:task, supplier: other_supplier)
+
+      tasks = Task.for_user_id(user_id)
+
+      expect(tasks).to include(task1)
+      expect(tasks).to include(task2)
+      expect(tasks).to_not include(task3)
+    end
+  end
 end

--- a/spec/requests/v1/memberships_spec.rb
+++ b/spec/requests/v1/memberships_spec.rb
@@ -99,4 +99,19 @@ RSpec.describe '/v1' do
       expect(json['data']).to have_attribute(:user_id).with_value(user_id)
     end
   end
+
+  describe 'DELETE /memberships/:membership_id' do
+    it 'deletes a membership, disassociating a user from a supplier' do
+      membership = FactoryBot.create(:membership)
+
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      expect do
+        delete "/v1/memberships/#{membership.id}", params: {}, headers: headers
+      end.to change { Membership.count }.from(1).to(0)
+    end
+  end
 end

--- a/spec/requests/v1/memberships_spec.rb
+++ b/spec/requests/v1/memberships_spec.rb
@@ -57,4 +57,46 @@ RSpec.describe '/v1' do
       expect(json['data'][0]).to have_attribute(:user_id).with_value(included_user_id)
     end
   end
+
+  describe 'POST /memberships' do
+    it 'creates a membership, which links a supplier to a user' do
+      supplier = FactoryBot.create(:supplier)
+      user_id = '7f77d6f6-1cca-4a58-9030-10a93fe1f32d'
+
+      params = {
+        data: {
+          type: 'memberships',
+          relationships: {
+            supplier: {
+              data: {
+                type: 'suppliers',
+                id: supplier.id
+              }
+            },
+            user: {
+              data: {
+                type: 'users',
+                id: user_id
+              }
+            }
+          }
+        }
+      }
+
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      post '/v1/memberships', params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:created)
+
+      membership = Membership.first
+
+      expect(json['data']).to have_id(membership.id)
+      expect(json['data']).to have_attribute(:supplier_id).with_value(supplier.id)
+      expect(json['data']).to have_attribute(:user_id).with_value(user_id)
+    end
+  end
 end

--- a/spec/requests/v1/memberships_spec.rb
+++ b/spec/requests/v1/memberships_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe '/v1' do
+  describe 'GET /memberships' do
+    it 'returns a list of memberships' do
+      supplier1 = FactoryBot.create(:supplier)
+      supplier2 = FactoryBot.create(:supplier)
+      user_id = '08223870-9ea3-4250-a14f-9b80ab466afb'
+
+      Membership.create!(user_id: user_id, supplier: supplier1)
+      Membership.create!(user_id: user_id, supplier: supplier2)
+
+      get '/v1/memberships'
+
+      expect(response).to have_http_status(:ok)
+
+      expect(json['data'][0]).to have_attribute(:user_id).with_value(user_id)
+      expect(json['data'][0]).to have_attribute(:supplier_id).with_value(supplier1.id)
+
+      expect(json['data'][1]).to have_attribute(:user_id).with_value(user_id)
+      expect(json['data'][1]).to have_attribute(:supplier_id).with_value(supplier2.id)
+    end
+  end
+end

--- a/spec/requests/v1/memberships_spec.rb
+++ b/spec/requests/v1/memberships_spec.rb
@@ -20,5 +20,41 @@ RSpec.describe '/v1' do
       expect(json['data'][1]).to have_attribute(:user_id).with_value(user_id)
       expect(json['data'][1]).to have_attribute(:supplier_id).with_value(supplier2.id)
     end
+
+    it 'can be filtered by supplier_id' do
+      supplier1 = FactoryBot.create(:supplier)
+      supplier2 = FactoryBot.create(:supplier)
+
+      user_id = 'e3913698-f379-4004-9dd8-98053f629a00'
+
+      Membership.create!(supplier: supplier1, user_id: user_id)
+      Membership.create!(supplier: supplier2, user_id: user_id)
+
+      get "/v1/memberships?filter[supplier_id]=#{supplier1.id}"
+
+      expect(response).to have_http_status(:ok)
+
+      expect(json['data'].size).to eql 1
+      expect(json['data'][0]).to have_attribute(:supplier_id).with_value(supplier1.id)
+      expect(json['data'][0]).to have_attribute(:user_id).with_value(user_id)
+    end
+
+    it 'can be filtered by user_id' do
+      supplier = FactoryBot.create(:supplier)
+
+      included_user_id = 'e3913698-f379-4004-9dd8-98053f629a00'
+      excluded_user_id = '2f0c98f2-5ce3-4ce3-9214-159cb2dbe276'
+
+      Membership.create!(supplier: supplier, user_id: included_user_id)
+      Membership.create!(supplier: supplier, user_id: excluded_user_id)
+
+      get "/v1/memberships?filter[user_id]=#{included_user_id}"
+
+      expect(response).to have_http_status(:ok)
+
+      expect(json['data'].size).to eql 1
+      expect(json['data'][0]).to have_attribute(:supplier_id).with_value(supplier.id)
+      expect(json['data'][0]).to have_attribute(:user_id).with_value(included_user_id)
+    end
   end
 end

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -109,6 +109,27 @@ RSpec.describe '/v1' do
     end
   end
 
+  describe 'GET /tasks?filter[user_id]=' do
+    it 'returns a filtered list of tasks for a user\'s suppliers' do
+      user_id = SecureRandom.uuid
+
+      current_supplier = FactoryBot.create(:supplier)
+      another_supplier = FactoryBot.create(:supplier)
+
+      FactoryBot.create(:membership, supplier: current_supplier, user_id: user_id)
+
+      FactoryBot.create(:task, supplier: current_supplier, description: 'hello')
+      FactoryBot.create(:task, supplier: another_supplier)
+
+      get "/v1/tasks?filter[user_id]=#{user_id}"
+
+      expect(response).to be_successful
+
+      expect(json['data'].size).to eql 1
+      expect(json['data'][0]).to have_attribute(:description).with_value('hello')
+    end
+  end
+
   describe 'GET /v1/tasks/:task_id' do
     it 'returns the details of a given task' do
       task = FactoryBot.create(


### PR DESCRIPTION
- Create a Membership model to link a `User` *(NB: not currently persisted in API application)* and one or more `Suppliers`.
- Allow tasks to be filtered by `user_id`, in order for the frontend to show a user their assigned tasks (NB: currently assigned to suppliers they are a member of)


