### PR TITLE
(26) The system can generate tasks for users to complete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
-
+gem 'business'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
       msgpack (~> 1.0)
     bounded_context (0.30.0)
     builder (3.2.3)
+    business (1.13.1)
     byebug (10.0.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -229,6 +230,7 @@ PLATFORMS
 DEPENDENCIES
   aasm
   bootsnap (>= 1.1.0)
+  business
   byebug
   database_cleaner
   factory_bot_rails

--- a/lib/task_generator.rb
+++ b/lib/task_generator.rb
@@ -1,0 +1,40 @@
+class TaskGenerator
+  def initialize(supplier:, framework:)
+    @supplier = supplier
+    @framework = framework
+  end
+
+  def create
+    Task.create!(
+      status: status,
+      description: description,
+      framework: @framework,
+      supplier: @supplier,
+      due_on: due_on,
+      period_month: period_month,
+      period_year: period_year
+    )
+  end
+
+  private
+
+  def description
+    "MI for #{period_month} #{period_year} #{@framework.name} #{@framework.short_name}"
+  end
+
+  def status
+    'unstarted'
+  end
+
+  def due_on
+    '09/07/2018'
+  end
+
+  def period_month
+    Date.parse(due_on).month
+  end
+
+  def period_year
+    Date.parse(due_on).year
+  end
+end

--- a/lib/tasks/tasks_generator.rake
+++ b/lib/tasks/tasks_generator.rake
@@ -1,0 +1,13 @@
+require 'task_generator'
+
+namespace :task_generator do
+  desc 'Generate a new task for each supplier on each framework'
+  task generate: [:environment] do
+    Framework.all.each do |framework|
+      framework.suppliers.each do |supplier|
+        puts "Creating task for Supplier: #{supplier.name} on Framework: #{framework.id}"
+        TaskGenerator.new(supplier: supplier, framework: framework).create
+      end
+    end
+  end
+end


### PR DESCRIPTION
What's done so far:
- can create generate a new task for each supplier on each framework using the rake command:
`rake task_generator:generate`

What's not done:
- Dynamic `due_on` to be 7th working day of the month. The current `due_on` is hardcoded as: `09/07/2018`
- Unit tests for the `task_generator` class

Status: Deprioritized