### PR TITLE
(123) Do Levy Calculation (API Changes)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,33 +5,29 @@ ruby '2.5.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'
-# Use postgresql as the database for Active Record
-gem 'pg', '>= 0.18', '< 2.0'
-# Use Puma as the app server
-gem 'puma', '~> 3.11'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.5'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
 
-# Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
+# State machine
+gem 'aasm'
 
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
-# Reduces boot times through caching; required in config/boot.rb
+gem 'aws-sdk-lambda'
 gem 'bootsnap', '>= 1.1.0', require: false
 
-# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
-gem 'rubocop'
+# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+gem 'jbuilder', '~> 2.5'
+
+# JSON API
+gem 'jsonapi-rails'
+
+# Use postgresql as the database for Active Record
+gem 'pg', '>= 0.18', '< 2.0'
+
+# Use Puma as the app server
+gem 'puma', '~> 3.11'
 
 # Audit log
 gem 'rails_event_store'
 
-# JSON API
-gem 'jsonapi-rails'
+gem 'rubocop'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
@@ -39,9 +35,6 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rspec-rails'
 end
-
-# State machine
-gem 'aasm'
 
 group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,17 @@ GEM
     arkency-command_bus (0.4.0)
       thread_safe
     ast (2.4.0)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.95.0)
+    aws-sdk-core (3.22.1)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-lambda (1.8.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
     bounded_context (0.30.0)
@@ -75,6 +86,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jmespath (1.4.0)
     jsonapi-deserializable (0.2.0)
     jsonapi-parser (0.1.1)
     jsonapi-rails (0.3.1)
@@ -228,6 +240,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
+  aws-sdk-lambda
   bootsnap (>= 1.1.0)
   byebug
   database_cleaner

--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -28,6 +28,7 @@ class V1::SubmissionsController < ApplicationController
   def update
     submission = Submission.find(params[:id])
     submission.levy = update_submission_params[:levy] * 100
+    submission.aasm.current_state = 'complete' if update_submission_params[:levy]
 
     if submission.save
       head :no_content

--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -42,7 +42,7 @@ class V1::SubmissionsController < ApplicationController
     # Trigger lambda invocation
     AWSLambdaService.new(submission_id: submission.id).trigger
 
-    head :no_content # Should we can check for lambda[:status_code] to handle error?
+    head :no_content
   end
 
   private

--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -36,6 +36,14 @@ class V1::SubmissionsController < ApplicationController
     end
   end
 
+  def calculate
+    submission = Submission.find(params[:id])
+    # Trigger lambda invocation
+    AWSLambdaService.new(submission_id: submission.id).trigger
+
+    head :no_content # Should we can check for lambda[:status_code] to handle error?
+  end
+
   private
 
   def create_submission_params

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -1,6 +1,7 @@
 class SerializableSubmission < JSONAPI::Serializable::Resource
   type 'submissions'
 
+  belongs_to :framework
   has_many :entries
   has_many :files
 

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -6,6 +6,8 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
 
   attributes :framework_id, :supplier_id, :task_id
 
+  attribute :levy
+
   attribute :status do
     @object.aasm.current_state
   end

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -2,6 +2,7 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
   type 'submissions'
 
   has_many :entries
+  has_many :files
 
   attributes :framework_id, :supplier_id, :task_id
 

--- a/app/services/aws_lambda_service.rb
+++ b/app/services/aws_lambda_service.rb
@@ -1,0 +1,25 @@
+class AWSLambdaService
+  def initialize(submission_id:)
+    @payload = { submission_id: submission_id }
+  end
+
+  def client
+    @client ||= Aws::Lambda::Client.new(
+      region: ENV['AWS_S3_REGION'],
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+    )
+  end
+
+  def trigger
+    # This operation invokes a Lambda function
+    resp = client.invoke(
+      function_name: ENV['AWS_LAMBDA_CALCULATE'],
+      invocation_type: 'Event', # asynchronously OR can be changed to 'RequestResponse' to wait for the response
+      payload: @payload.to_json,
+      log_type: 'Tail',
+    )
+
+    resp.to_h
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
     resources :memberships, only: %i[index create destroy]
     resources :agreements, only: %i[create]
     resources :submissions, only: %i[show create update] do
+      member do
+        get 'calculate', to: 'submissions#calculate'
+      end
+
       resources :files, only: %i[create update show], controller: 'submission_files'
       resources :entries, only: %i[create], controller: 'submission_entries'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     resources :agreements, only: %i[create]
     resources :submissions, only: %i[show create update] do
       member do
-        get 'calculate', to: 'submissions#calculate'
+        post 'calculate', to: 'submissions#calculate'
       end
 
       resources :files, only: %i[create update show], controller: 'submission_files'

--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -1,4 +1,4 @@
-DATABASE_URL=
+DATABASE_URL=DATABASE_URL=postgres://postgres@db:5432/DataSubmissionServiceApi_development?template=template0&pool=5&encoding=unicode
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_S3_REGION=

--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -1,1 +1,5 @@
-DATABASE_URL=postgres://postgres@db:5432/DataSubmissionServiceApi_development?template=template0&pool=5&encoding=unicode
+DATABASE_URL=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_S3_REGION=
+AWS_LAMBDA_CALCULATE=

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,6 +9,8 @@ services:
     environment:
       RAILS_ENV: "test"
       DATABASE_URL: "postgres://postgres@db-test:5432/DataSubmissionServiceApi_test?template=template0&pool=5&encoding=unicode"
+      AWS_S3_REGION: 'eu-west-2'
+      AWS_LAMBDA_CALCULATE: "dummy"
     env_file:
       - docker-compose.env
     volumes:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   config.include JSONAPI::RSpec
   config.include RequestHelpers, type: :request
+  Aws.config[:stub_responses] = true
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -177,4 +177,14 @@ RSpec.describe '/v1' do
       expect(json.dig('data', 'attributes', 'data', 'test')).to eql 'test'
     end
   end
+
+  describe 'GET /submissions/:submission_id/calculate' do
+    it 'invokes the calculate lambda function successfully' do
+      submission = FactoryBot.create(:submission)
+
+      get "/v1/submissions/#{submission.id}/calculate"
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -13,7 +13,53 @@ RSpec.describe '/v1' do
     end
 
     it 'optionally includes submission entries' do
-      # TODO: finish this
+      submission = FactoryBot.create(:submission)
+      file = FactoryBot.create(:submission_file)
+      entry = FactoryBot.create(:submission_entry,
+                                submission: submission,
+                                submission_file: file,
+                                source: { sheet: 'Orders', row: 23 },
+                                data: { test: 'test' })
+
+      get "/v1/submissions/#{submission.id}?include=entries"
+
+      expect(response).to be_successful
+      expect(json['data']).to have_id(submission.id)
+      expect(json['data'])
+        .to have_relationship(:entries)
+        .with_data([{ 'id' => entry.id, 'type' => 'submission_entries' }])
+      expect(json['included'][0])
+        .to have_attribute(:submission_file_id).with_value(file.id)
+      expect(json['included'][0].dig('attributes', 'source', 'sheet')).to eql 'Orders'
+      expect(json['included'][0].dig('attributes', 'source', 'row')).to eql 23
+      expect(json['included'][0].dig('attributes', 'data', 'test')).to eql 'test'
+    end
+
+    it 'optionally includes submission files' do
+      submission = FactoryBot.create(:submission)
+      file = FactoryBot.create(:submission_file, submission: submission)
+
+      get "/v1/submissions/#{submission.id}?include=files"
+
+      expect(response).to be_successful
+      expect(json['data']).to have_id(submission.id)
+      expect(json['data'])
+        .to have_relationship(:files)
+        .with_data([{ 'id' => file.id, 'type' => 'submission_files' }])
+    end
+
+    it 'optionally includes submission framework' do
+      framework = FactoryBot.create(:framework, short_name: 'RM1234')
+      submission = FactoryBot.create(:submission, framework: framework)
+
+      get "/v1/submissions/#{submission.id}?include=framework"
+      expect(response).to be_successful
+
+      expect(json['data']).to have_id(submission.id)
+      expect(json['data'])
+        .to have_relationship(:framework)
+        .with_data('id' => framework.id, 'type' => 'frameworks')
+      expect(json['included'][0].dig('attributes', 'short_name')).to eql 'RM1234'
     end
   end
 

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -231,7 +231,12 @@ RSpec.describe '/v1' do
     it 'invokes the calculate lambda function successfully' do
       submission = FactoryBot.create(:submission)
 
-      get "/v1/submissions/#{submission.id}/calculate"
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      post "/v1/submissions/#{submission.id}/calculate", params: {}, headers: headers
 
       expect(response).to have_http_status(:no_content)
     end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -72,7 +72,10 @@ RSpec.describe '/v1' do
 
       expect(response).to have_http_status(:no_content)
 
-      expect(submission.reload.levy).to eql 4250
+      submission.reload
+
+      expect(submission.levy).to eql 4250
+      expect(submission).to be_complete
     end
   end
 

--- a/spec/services/aws_lambda_service_spec.rb
+++ b/spec/services/aws_lambda_service_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe AWSLambdaService do
+  let(:subject) { described_class.new(submission_id: 'id') }
+  describe '.trigger' do
+    it 'invokes the calculate lambda function with the accurate params' do
+      allow(ENV).to receive(:[]).with('AWS_LAMBDA_CALCULATE').and_return('test-calculate-function')
+      fake_client = Aws::Lambda::Client.new(stub_responses: true)
+      params = {
+        function_name: 'test-calculate-function',
+        invocation_type: 'Event',
+        payload: { submission_id: 'id' }.to_json,
+        log_type: 'Tail'
+      }
+
+      expect(subject).to receive(:client).and_return(fake_client)
+      expect(fake_client).to receive(:invoke).with(params)
+      response = subject.trigger
+
+      expect(response).to eq({})
+    end
+  end
+end

--- a/testspec.yml
+++ b/testspec.yml
@@ -15,7 +15,7 @@ phases:
       - docker exec test bundle install --with test --retry 3 --jobs 20
       - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake db:create"
       - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && rake db:setup"
-      - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && export API_ROOT='https://ccs.api/' && rake"
+      - docker exec test /bin/bash -c "export DATABASE_URL='postgres://postgres@pg:5432/test?template=template0&pool=5&encoding=unicode' && export API_ROOT='https://ccs.api/' && export AWS_S3_REGION='eu-west-2' && export AWS_LAMBDA_CALCULATE='dummy' && rake"
       - docker rm -f test pg
   post_build:
     commands:


### PR DESCRIPTION
# Description
This PR:
- Creates the API endpoint `GET /v1/submission/:submission_id/calculate`, and at the endpoint, connect to AWS (using the `aws-sdk-lambda` gem) and trigger the levy calculation lambda function
- Updates submission status at `PATCH v1/submission/:id` if levy is present
- Adds `GET /v1/submissions/:submission_id?include=framework` to optionally include framework details
- Adds tests for `GET /v1/submissions/:submission_id?include=entries`
- Adds tests for `GET /v1/submissions/:submission_id?include=files`

# Deployment and CI changes required
To get the CI build to pass and before deployment, the `docker-compose.env` file on all environments need to be updated with all the AWS credentials added [here](https://github.com/dxw/DataSubmissionServiceAPI/compare/feature/123-do-levy-calculation-api?expand=1#diff-ff991bc728aa537f2c7d9f49512f06cbR2)

# Status
Ready for review