### PR TITLE
Update entries API to accept multiple errors

### DIFF
--- a/app/controllers/v1/submission_entries_controller.rb
+++ b/app/controllers/v1/submission_entries_controller.rb
@@ -52,6 +52,8 @@ class V1::SubmissionEntriesController < ApplicationController
   end
 
   def submission_entry_params
-    params.require(:submission_entry).permit(:status, source: {}, data: {}, validation_errors: {})
+    params
+      .require(:submission_entry)
+      .permit(:status, :type, source: {}, data: {}, validation_errors: [:message, location: {}])
   end
 end

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -131,13 +131,12 @@ RSpec.describe '/v1' do
         data: {
           type: 'submission_entries',
           attributes: {
-            validation_errors: {
-              location: {
-                row: 20,
-                column: 2
-              },
-              message: 'Required value error'
-            }
+            validation_errors: [
+              {
+                location: { row: 20, column: 2 },
+                message: 'Required value error'
+              }
+            ]
           }
         }
       }
@@ -153,7 +152,8 @@ RSpec.describe '/v1' do
 
       expect(response).to have_http_status(:no_content)
       expect(entry.reload).to be_pending
-      expect(entry.reload.validation_errors['message']).to eql 'Required value error'
+      expect(entry.validation_errors[0]['message']).to eq 'Required value error'
+      expect(entry.validation_errors[0]['location']).to eq('row' => 20, 'column' => 2)
     end
 
     it 'updates both the given entry\'s status and the validation errors received from DAVE' do
@@ -167,13 +167,12 @@ RSpec.describe '/v1' do
           type: 'submission_entries',
           attributes: {
             status: 'errored',
-            validation_errors: {
-              location: {
-                row: 20,
-                column: 2
-              },
-              message: 'Required value error'
-            }
+            validation_errors: [
+              {
+                location: { row: 20, column: 2 },
+                message: 'Required value error'
+              }
+            ]
           }
         }
       }
@@ -189,7 +188,8 @@ RSpec.describe '/v1' do
 
       expect(response).to have_http_status(:no_content)
       expect(entry.reload).to be_errored
-      expect(entry.reload.validation_errors['message']).to eql 'Required value error'
+      expect(entry.validation_errors[0]['message']).to eq 'Required value error'
+      expect(entry.validation_errors[0]['location']).to eq('row' => 20, 'column' => 2)
     end
   end
 


### PR DESCRIPTION
The lambda sends an array of validation errors when it finds errors.
This updates the API to accept the validation errors in the format they
are being sent in.

Note that the strong params gets complicated here because we are having
to accept an array of hashes, and Rails assumes that this will be for a
nested model. This isn't viable longer term where we may need to set
different keys on the validation errors. At that point it will probably
make sense to whitelist the validation error params separately to strong
params and assign them directly.