### PR TITLE
(11) Trigger levy calculation when validations complete (and transition errored to in_review)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-17
 
 DEPENDENCIES
   aasm
@@ -289,4 +290,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/app/controllers/v1/submission_entries_controller.rb
+++ b/app/controllers/v1/submission_entries_controller.rb
@@ -18,7 +18,7 @@ class V1::SubmissionEntriesController < ApplicationController
     submission_file = SubmissionFile.find(params[:file_id])
     entry = submission_file.entries.find(params[:id])
     entry.aasm.current_state = submission_entry_params[:status]
-    entry.validation_errors = submission_entry_params[:validation_errors] if submission_entry_params[:validation_errors]
+    entry.validation_errors = submission_entry_params[:validation_errors]
 
     if entry.save
       head :no_content

--- a/app/controllers/v1/submission_entries_controller.rb
+++ b/app/controllers/v1/submission_entries_controller.rb
@@ -21,6 +21,7 @@ class V1::SubmissionEntriesController < ApplicationController
     entry.validation_errors = submission_entry_params[:validation_errors]
 
     if entry.save
+      submission_status_update!(submission_file.submission)
       head :no_content
     else
       render jsonapi_errors: entry.errors, status: :bad_request
@@ -35,6 +36,10 @@ class V1::SubmissionEntriesController < ApplicationController
   end
 
   private
+
+  def submission_status_update!(submission)
+    SubmissionStatusUpdate.new(submission).perform!
+  end
 
   def initialize_submission_entry
     if params[:file_id].present?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -14,5 +14,9 @@ class Submission < ApplicationRecord
     state :in_review
     state :completed
     state :rejected
+
+    event :ready_for_review do
+      transitions from: %i[pending processing], to: :in_review
+    end
   end
 end

--- a/app/models/submission_status_update.rb
+++ b/app/models/submission_status_update.rb
@@ -1,0 +1,23 @@
+class SubmissionStatusUpdate
+  attr_reader :submission
+
+  def initialize(submission)
+    @submission = submission
+  end
+
+  def perform!
+    return unless submission.entries.any?
+
+    trigger_levy_calculation if all_entries_valid?
+  end
+
+  private
+
+  def all_entries_valid?
+    submission.entries.validated.count == submission.entries.count
+  end
+
+  def trigger_levy_calculation
+    AWSLambdaService.new(submission_id: submission.id).trigger
+  end
+end

--- a/app/models/submission_status_update.rb
+++ b/app/models/submission_status_update.rb
@@ -9,12 +9,25 @@ class SubmissionStatusUpdate
     return unless submission.entries.any?
 
     trigger_levy_calculation if all_entries_valid?
+    transition_to_in_review if no_entries_pending? && some_entries_errored?
   end
 
   private
 
   def all_entries_valid?
     submission.entries.validated.count == submission.entries.count
+  end
+
+  def transition_to_in_review
+    submission.ready_for_review!
+  end
+
+  def no_entries_pending?
+    submission.entries.pending.none?
+  end
+
+  def some_entries_errored?
+    submission.entries.errored.any?
   end
 
   def trigger_levy_calculation

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -3,5 +3,26 @@ FactoryBot.define do
     framework
     supplier
     task
+
+    factory :submission_with_pending_entries do
+      after(:create) do |submission, _evaluator|
+        create_list(:submission_entry, 3, submission: submission)
+      end
+    end
+
+    factory :submission_with_validated_entries do
+      after(:create) do |submission, _evaluator|
+        create_list(:validated_submission_entry, 3, submission: submission)
+      end
+    end
+
+    factory :submission_with_invalid_entries do
+      aasm_state :in_review
+
+      after(:create) do |submission, _evaluator|
+        create_list(:validated_submission_entry, 2, submission: submission)
+        create_list(:errored_submission_entry, 1, submission: submission)
+      end
+    end
   end
 end

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -4,5 +4,13 @@ FactoryBot.define do
     submission_file
     data(test_key: 'some data')
     source(sheet: 'InvoicesReceived', row: 1)
+
+    factory :validated_submission_entry do
+      aasm_state :validated
+    end
+
+    factory :errored_submission_entry do
+      aasm_state :errored
+    end
   end
 end

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :submission_entry do
     submission
     submission_file
-    data {}
-    source {}
+    data(test_key: 'some data')
+    source(sheet: 'InvoicesReceived', row: 1)
   end
 end

--- a/spec/models/submission_status_update_spec.rb
+++ b/spec/models/submission_status_update_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe SubmissionStatusUpdate do
       context 'with no "pending" entries remaining, but some having failed validation' do
         let(:submission) { FactoryBot.create(:submission_with_invalid_entries, aasm_state: :processing) }
 
+        it 'transitions the submission to "in_review"' do
+          submission_status_check.perform!
+
+          expect(submission).to be_in_review
+        end
+
         it 'does not trigger a levy calculation' do
           expect(aws_lambda_service_double).not_to receive(:trigger)
 

--- a/spec/models/submission_status_update_spec.rb
+++ b/spec/models/submission_status_update_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionStatusUpdate do
+  describe '#perform' do
+    let(:aws_lambda_service_double) { double(trigger: true) }
+    let(:submission_status_check) { SubmissionStatusUpdate.new(submission) }
+
+    before do
+      allow(AWSLambdaService).to receive(:new).and_return(aws_lambda_service_double)
+    end
+
+    context 'given a "processing" submission' do
+      context 'with "pending" entries' do
+        let(:submission) { FactoryBot.create(:submission_with_pending_entries, aasm_state: :processing) }
+
+        it 'leaves the submission in a "processing" state' do
+          submission_status_check.perform!
+
+          expect(submission).to be_processing
+        end
+
+        it 'does not trigger a levy calculation' do
+          expect(aws_lambda_service_double).not_to receive(:trigger)
+
+          submission_status_check.perform!
+        end
+      end
+
+      context 'with all entries validated' do
+        let(:submission) { FactoryBot.create(:submission_with_validated_entries, aasm_state: :processing) }
+
+        it 'leaves the submission in a "processing" state' do
+          submission_status_check.perform!
+
+          expect(submission).to be_processing
+        end
+
+        it 'triggers a levy calculation' do
+          expect(aws_lambda_service_double).to receive(:trigger)
+
+          submission_status_check.perform!
+        end
+      end
+
+      context 'with some "pending" entries and some "errored" entries' do
+        let(:submission) do
+          FactoryBot.create(:submission_with_pending_entries, aasm_state: :processing).tap do |submission|
+            create(:errored_submission_entry, submission: submission)
+          end
+        end
+
+        it 'leaves the submission in a "processing"' do
+          submission_status_check.perform!
+
+          expect(submission).to be_processing
+        end
+
+        it 'does not trigger a levy calculation' do
+          expect(aws_lambda_service_double).not_to receive(:trigger)
+
+          submission_status_check.perform!
+        end
+      end
+
+      context 'with no "pending" entries remaining, but some having failed validation' do
+        let(:submission) { FactoryBot.create(:submission_with_invalid_entries, aasm_state: :processing) }
+
+        it 'does not trigger a levy calculation' do
+          expect(aws_lambda_service_double).not_to receive(:trigger)
+
+          submission_status_check.perform!
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -113,13 +113,15 @@ RSpec.describe '/v1' do
         'Accept': 'application/vnd.api+json'
       }
 
+      expect_submission_status_update_to_be_performed(file.submission)
+
       patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
 
       expect(response).to have_http_status(:no_content)
       expect(entry.reload).to be_validated
     end
 
-    it 'updates the given entry\'s validation errors received from DAVE' do
+    it 'updates the given entry\'s validation errors received from DAVE and performs a status update' do
       file = FactoryBot.create(:submission_file)
       entry = FactoryBot.create(:submission_entry,
                                 submission_file: file,
@@ -144,6 +146,8 @@ RSpec.describe '/v1' do
         'Content-Type': 'application/vnd.api+json',
         'Accept': 'application/vnd.api+json'
       }
+
+      expect_submission_status_update_to_be_performed(file.submission)
 
       patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
 
@@ -179,11 +183,19 @@ RSpec.describe '/v1' do
         'Accept': 'application/vnd.api+json'
       }
 
+      expect_submission_status_update_to_be_performed(file.submission)
+
       patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
 
       expect(response).to have_http_status(:no_content)
       expect(entry.reload).to be_errored
       expect(entry.reload.validation_errors['message']).to eql 'Required value error'
     end
+  end
+
+  def expect_submission_status_update_to_be_performed(submission)
+    status_update_double = double
+    expect(status_update_double).to receive(:perform!)
+    expect(SubmissionStatusUpdate).to receive(:new).with(submission).and_return(status_update_double)
   end
 end


### PR DESCRIPTION
This does two things:

1. Updates the API such that once the last submission entry has validated, the levy calculation is triggered
2. If there are any errored entries, the submission is transitioned to "in_review" so the user sees the status of the submission and can review the errors.