### PR TITLE
Transition to "in_review" after levy calculation

### DIFF
--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -28,7 +28,7 @@ class V1::SubmissionsController < ApplicationController
   def update
     submission = Submission.find(params[:id])
     submission.levy = update_submission_params[:levy] * 100
-    submission.aasm.current_state = 'completed' if update_submission_params[:levy]
+    submission.ready_for_review!
 
     if submission.save
       head :no_content

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe '/v1' do
       submission.reload
 
       expect(submission.levy).to eql 4250
-      expect(submission).to be_completed
+      expect(submission).to be_in_review
     end
   end
 


### PR DESCRIPTION
We're now calculating the levy before we show the user the screen to
review the submission. Therefor we need to transition it to "in_review",
rather than completed, otherwise the user never gets to confirm their
submission is correct.
