### PR TITLE
(233) User can complete a submission

### DIFF
--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -49,7 +49,7 @@ class V1::SubmissionsController < ApplicationController
     submission = Submission.find(params[:id])
     complete_submission!(submission)
 
-    if submission.save
+    if submission.errors.empty?
       head :no_content
     else
       render jsonapi_errors: submission.errors, status: :bad_request

--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -45,7 +45,22 @@ class V1::SubmissionsController < ApplicationController
     head :no_content
   end
 
+  def complete
+    submission = Submission.find(params[:id])
+    complete_submission!(submission)
+
+    if submission.save
+      head :no_content
+    else
+      render jsonapi_errors: submission.errors, status: :bad_request
+    end
+  end
+
   private
+
+  def complete_submission!(submission)
+    SubmissionCompletion.new(submission).perform!
+  end
 
   def create_submission_params
     params.require(:submission).permit(:task_id)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -18,5 +18,9 @@ class Submission < ApplicationRecord
     event :ready_for_review do
       transitions from: %i[pending processing], to: :in_review
     end
+
+    event :reviewed_and_accepted do
+      transitions from: :in_review, to: :completed
+    end
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -20,7 +20,15 @@ class Submission < ApplicationRecord
     end
 
     event :reviewed_and_accepted do
-      transitions from: :in_review, to: :completed
+      transitions from: :in_review, to: :completed, guard: :all_entries_valid?
+
+      error do |e|
+        errors.add(:aasm_state, message: e.message)
+      end
     end
+  end
+
+  def all_entries_valid?
+    entries.validated.count == entries.count
   end
 end

--- a/app/models/submission_completion.rb
+++ b/app/models/submission_completion.rb
@@ -6,19 +6,10 @@ class SubmissionCompletion
   end
 
   def perform!
-    return unless all_entries_valid?
-
-    Task.transaction do
-      Submission.transaction do
-        submission.reviewed_and_accepted!
-        submission.task.completed!
-      end
+    submission.reviewed_and_accepted! do
+      submission.task.completed!
     end
-  end
 
-  private
-
-  def all_entries_valid?
-    submission.entries.validated.count == submission.entries.count
+    submission
   end
 end

--- a/app/models/submission_completion.rb
+++ b/app/models/submission_completion.rb
@@ -1,0 +1,24 @@
+class SubmissionCompletion
+  attr_reader :submission
+
+  def initialize(submission)
+    @submission = submission
+  end
+
+  def perform!
+    return unless all_entries_valid?
+
+    Task.transaction do
+      Submission.transaction do
+        submission.reviewed_and_accepted!
+        submission.task.completed!
+      end
+    end
+  end
+
+  private
+
+  def all_entries_valid?
+    submission.entries.validated.count == submission.entries.count
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,9 +5,12 @@ class Task < ApplicationRecord
     state :draft
     state :unstarted, initial: true
     state :in_progress
-    state :in_review
     state :completed
     state :cancelled
+
+    event :completed do
+      transitions from: %i[in_progress], to: :completed
+    end
   end
 
   validates :status, presence: true

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -2,6 +2,7 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
   type 'submissions'
 
   belongs_to :framework
+  belongs_to :task
   has_many :entries
   has_many :files
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     resources :submissions, only: %i[show create update] do
       member do
         post 'calculate', to: 'submissions#calculate'
+        post 'complete', to: 'submissions#complete'
       end
 
       resources :files, only: %i[create update show], controller: 'submission_files'

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -24,5 +24,14 @@ FactoryBot.define do
         create_list(:errored_submission_entry, 1, submission: submission)
       end
     end
+
+    factory :submission_with_unprocessed_entries do
+      aasm_state :processing
+
+      after(:create) do |submission, _evaluator|
+        create_list(:validated_submission_entry, 2, submission: submission)
+        create_list(:submission_entry, 1, submission: submission)
+      end
+    end
   end
 end

--- a/spec/models/submission_completion_spec.rb
+++ b/spec/models/submission_completion_spec.rb
@@ -3,29 +3,40 @@ require 'rails_helper'
 RSpec.describe SubmissionCompletion do
   describe '#perform' do
     let(:complete_submission) { SubmissionCompletion.new(submission) }
+    let(:task) { FactoryBot.create(:task, status: :in_progress) }
 
     context 'given an "in review" submission' do
       context 'with validated entries' do
-        let(:submission) { FactoryBot.create(:submission_with_validated_entries, aasm_state: 'in_review') }
+        let(:submission) { FactoryBot.create(:submission_with_validated_entries, aasm_state: 'in_review', task: task) }
 
         it 'transitions the submission to completed' do
           complete_submission.perform!
 
           expect(submission).to be_completed
         end
+
+        it 'transitions the task to completed' do
+          complete_submission.perform!
+
+          expect(task).to be_completed
+        end
       end
 
       context 'with some invalid entries' do
-        let(:submission) { FactoryBot.create(:submission_with_invalid_entries) }
+        let(:submission) { FactoryBot.create(:submission_with_invalid_entries, task: task) }
 
         it 'leaves the submission in the "in_review" state' do
           expect { complete_submission.perform! }.not_to change { submission.aasm_state }
+        end
+
+        it 'leaves the task in the "in_progress" state' do
+          expect { complete_submission.perform! }.not_to change { task.status }
         end
       end
     end
 
     context 'given a "processing" submission' do
-      let(:submission) { FactoryBot.create(:submission_with_unprocessed_entries, aasm_state: :processing) }
+      let(:submission) { FactoryBot.create(:submission_with_unprocessed_entries, aasm_state: :processing, task: task) }
 
       it 'leaves the submission in its current state' do
         expect { complete_submission.perform! }.not_to change { submission.aasm_state }

--- a/spec/models/submission_completion_spec.rb
+++ b/spec/models/submission_completion_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionCompletion do
+  describe '#perform' do
+    let(:complete_submission) { SubmissionCompletion.new(submission) }
+
+    context 'given an "in review" submission' do
+      context 'with validated entries' do
+        let(:submission) { FactoryBot.create(:submission_with_validated_entries, aasm_state: 'in_review') }
+
+        it 'transitions the submission to completed' do
+          complete_submission.perform!
+
+          expect(submission).to be_completed
+        end
+      end
+
+      context 'with some invalid entries' do
+        let(:submission) { FactoryBot.create(:submission_with_invalid_entries) }
+
+        it 'leaves the submission in the "in_review" state' do
+          expect { complete_submission.perform! }.not_to change { submission.aasm_state }
+        end
+      end
+    end
+
+    context 'given a "processing" submission' do
+      let(:submission) { FactoryBot.create(:submission_with_unprocessed_entries, aasm_state: :processing) }
+
+      it 'leaves the submission in its current state' do
+        expect { complete_submission.perform! }.not_to change { submission.aasm_state }
+      end
+    end
+  end
+end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -241,4 +241,21 @@ RSpec.describe '/v1' do
       expect(response).to have_http_status(:no_content)
     end
   end
+
+  describe 'POST /submissions/:submission_id/complete' do
+    it 'marks the submission as complete' do
+      submission = FactoryBot.create(
+        :submission_with_validated_entries,
+        aasm_state: :in_review
+      )
+
+      post "/v1/submissions/#{submission.id}/complete"
+
+      expect(response).to be_successful
+
+      submission.reload
+
+      expect(submission).to be_completed
+    end
+  end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -243,23 +243,47 @@ RSpec.describe '/v1' do
   end
 
   describe 'POST /submissions/:submission_id/complete' do
-    it 'marks the submission as complete' do
-      task = FactoryBot.create(:task, status: :in_progress)
+    context 'given a valid submission' do
+      it 'marks the submission as complete' do
+        task = FactoryBot.create(:task, status: :in_progress)
 
-      submission = FactoryBot.create(
-        :submission_with_validated_entries,
-        aasm_state: :in_review,
-        task: task
-      )
+        submission = FactoryBot.create(
+          :submission_with_validated_entries,
+          aasm_state: :in_review,
+          task: task
+        )
 
-      post "/v1/submissions/#{submission.id}/complete"
+        post "/v1/submissions/#{submission.id}/complete"
 
-      expect(response).to be_successful
+        expect(response).to be_successful
 
-      submission.reload
+        submission.reload
 
-      expect(submission).to be_completed
-      expect(submission.task).to be_completed
+        expect(submission).to be_completed
+        expect(submission.task).to be_completed
+      end
+    end
+
+    context 'given an invalid submission' do
+      it 'returns an error' do
+        task = FactoryBot.create(:task, status: :in_progress)
+
+        submission = FactoryBot.create(
+          :submission_with_invalid_entries,
+          aasm_state: :in_review,
+          task: task
+        )
+
+        post "/v1/submissions/#{submission.id}/complete"
+
+        expect(response).to have_http_status(:bad_request)
+        expect(json['errors'][0]['title']).to eql 'Invalid aasm_state'
+
+        submission.reload
+
+        expect(submission).to be_in_review
+        expect(task).to be_in_progress
+      end
     end
   end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -244,9 +244,12 @@ RSpec.describe '/v1' do
 
   describe 'POST /submissions/:submission_id/complete' do
     it 'marks the submission as complete' do
+      task = FactoryBot.create(:task, status: :in_progress)
+
       submission = FactoryBot.create(
         :submission_with_validated_entries,
-        aasm_state: :in_review
+        aasm_state: :in_review,
+        task: task
       )
 
       post "/v1/submissions/#{submission.id}/complete"
@@ -256,6 +259,7 @@ RSpec.describe '/v1' do
       submission.reload
 
       expect(submission).to be_completed
+      expect(submission.task).to be_completed
     end
   end
 end


### PR DESCRIPTION
This adds a new endpoint `POST /v1/submissions/:submission_id/complete` which marks both a `Submission` and its associated `Task` as `completed`.

A submission can only be completed if its entries are all valid and it has a status of `in review`. Only when the submission is successfully completed do we mark the task as also completed. If either of these steps fail, we return a HTTP 400 Bad Request.