### PR TITLE
(223) Add timestamps to Submission and SubmissionFile models

### DIFF
--- a/db/migrate/20180727170406_add_missing_timestamps.rb
+++ b/db/migrate/20180727170406_add_missing_timestamps.rb
@@ -1,0 +1,20 @@
+class AddMissingTimestamps < ActiveRecord::Migration[5.2]
+  def change
+    # from: https://stackoverflow.com/questions/46520907/add-timestamps-to-existing-table-in-db-rails-5?rq=1
+    # add new column but allow null values
+    add_timestamps :submissions, null: true
+    add_timestamps :submission_files, null: true
+
+    # backfill existing record with created_at and updated_at
+    # values making clear that the records are faked
+    long_ago = DateTime.new(2000, 1, 1)
+    Submission.update_all(created_at: long_ago, updated_at: long_ago)
+    SubmissionFile.update_all(created_at: long_ago, updated_at: long_ago)
+
+    # change not null constraints
+    change_column_null :submissions, :created_at, false
+    change_column_null :submissions, :updated_at, false
+    change_column_null :submission_files, :created_at, false
+    change_column_null :submission_files, :updated_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_06_003625) do
+ActiveRecord::Schema.define(version: 2018_07_27_170406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -81,6 +81,8 @@ ActiveRecord::Schema.define(version: 2018_07_06_003625) do
   create_table "submission_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id", null: false
     t.integer "rows"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["submission_id"], name: "index_submission_files_on_submission_id"
   end
 
@@ -90,6 +92,8 @@ ActiveRecord::Schema.define(version: 2018_07_06_003625) do
     t.integer "levy"
     t.string "aasm_state"
     t.uuid "task_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["aasm_state"], name: "index_submissions_on_aasm_state"
     t.index ["framework_id"], name: "index_submissions_on_framework_id"
     t.index ["supplier_id"], name: "index_submissions_on_supplier_id"


### PR DESCRIPTION
Because we're using UUIDs instead of sequential IDs, it's hard to tell what the *last* submission is. Adding timestamps will make this possible.