### PR TITLE
187 Add task endpoint for submitting no business

### DIFF
--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -37,6 +37,13 @@ class V1::TasksController < ApplicationController
     end
   end
 
+  def no_business
+    task = Task.find(params[:id])
+    task.file_no_business!
+    submission = task.latest_submission
+    render jsonapi: submission, status: :created
+  end
+
   def complete
     task = Task.find(params[:id])
     task.status = 'completed'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,8 @@ Rails.application.routes.draw do
     end
     resources :tasks, only: %i[index show create update] do
       member do
-        post 'complete', to: 'tasks#complete'
+        post :complete
+        post :no_business
       end
     end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -34,4 +34,36 @@ RSpec.describe Task do
       expect(tasks).to_not include(task3)
     end
   end
+
+  describe '#latest_submission' do
+    let(:task) { FactoryBot.create(:task) }
+
+    it 'returns the most recent submission' do
+      _old_submission = FactoryBot.create(:submission, task: task)
+
+      travel 1.day do
+        latest_submission = FactoryBot.create(:submission, task: task)
+
+        expect(task.latest_submission).to eq latest_submission
+      end
+    end
+  end
+
+  describe '#file_no_business!' do
+    let(:task) { FactoryBot.create(:task) }
+
+    it 'creates an empty completed submission' do
+      expect { task.file_no_business! }.to change { task.submissions.count }.by 1
+
+      submission = task.latest_submission
+
+      expect(submission).to be_completed
+      expect(submission.entries).to be_empty
+    end
+
+    it 'transitions the task to "completed"' do
+      task.file_no_business!
+      expect(task.reload).to be_completed
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   config.include JSONAPI::RSpec
   config.include RequestHelpers, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
   Aws.config[:stub_responses] = true
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -170,6 +170,25 @@ RSpec.describe '/v1' do
     end
   end
 
+  describe 'POST /v1/tasks/:task_id/no_business' do
+    let(:task) { FactoryBot.create(:task) }
+
+    before { post "/v1/tasks/#{task.id}/no_business" }
+
+    it 'marks the task as completed' do
+      expect(task.reload).to be_completed
+    end
+
+    it 'creates and returns a completed submissions' do
+      expect(response).to have_http_status(:created)
+
+      submission = task.submissions.last
+
+      expect(json['data']).to have_id submission.id
+      expect(json['data']['attributes']['status']).to eq 'completed'
+    end
+  end
+
   describe 'POST /v1/tasks/:task_id/complete' do
     it "changes a task's status to completed" do
       task = FactoryBot.create(:task)


### PR DESCRIPTION
A submission is required every month, regardless of whether the supplier
had any business for the given framework. This endpoint will allow the
frontend app to report a task as having had no business, so suppliers
can fulfil their obligation to submit something.