### PR TITLE
234 API exposes the latest submission for a task

### DIFF
--- a/app/serializable/serializable_task.rb
+++ b/app/serializable/serializable_task.rb
@@ -1,6 +1,7 @@
 class SerializableTask < JSONAPI::Serializable::Resource
   type 'tasks'
 
+  has_one :latest_submission
   has_many :submissions
   belongs_to :framework
 

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe '/v1' do
       expect(json['data'][2]).to have_attribute(:status).with_value('in_progress')
     end
 
-    it 'can optionally return included models' do
+    it 'can optionally include submissions' do
       task = FactoryBot.create(:task)
       submission = FactoryBot.create(:submission, task: task, aasm_state: 'pending')
 
@@ -72,6 +72,22 @@ RSpec.describe '/v1' do
       expect(json['data'][0])
         .to have_relationship(:submissions)
         .with_data([{ 'id' => submission.id, 'type' => 'submissions' }])
+      expect(json['included'][0])
+        .to have_attribute(:status).with_value('pending')
+    end
+
+    it 'can optionally include the latest_submission' do
+      task = FactoryBot.create(:task)
+      submission = FactoryBot.create(:submission, task: task, aasm_state: 'pending')
+
+      get '/v1/tasks?include=latest_submission'
+
+      expect(response).to be_successful
+      expect(json['data'][0]).to have_id(task.id)
+      expect(json['data'][0])
+        .to have_relationship(:latest_submission)
+        .with_data('id' => submission.id, 'type' => 'submissions')
+
       expect(json['included'][0])
         .to have_attribute(:status).with_value('pending')
     end


### PR DESCRIPTION
To be able to show the user the status of their task, we need to be able
to get the most recent submission. This makes it available as part of
the API.