### PR TITLE
Add coda_reference to the Supplier model

### DIFF
--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -5,4 +5,8 @@ class Supplier < ApplicationRecord
   has_many :memberships, dependent: :destroy
 
   validates :name, presence: true
+  validates :coda_reference, allow_nil: true, format: {
+    with: /\AC0\d{5}\z/,
+    message: 'must start with “C0” and have five additional numbers, for example: “C012345”'
+  }
 end

--- a/db/migrate/20180806154052_add_coda_reference_to_suppliers.rb
+++ b/db/migrate/20180806154052_add_coda_reference_to_suppliers.rb
@@ -1,0 +1,5 @@
+class AddCodaReferenceToSuppliers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :suppliers, :coda_reference, :string, limit: 7
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_27_170406) do
+ActiveRecord::Schema.define(version: 2018_08_06_154052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 2018_07_27_170406) do
 
   create_table "suppliers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
+    t.string "coda_reference", limit: 7
   end
 
   create_table "tasks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/supplier_spec.rb
+++ b/spec/models/supplier_spec.rb
@@ -7,4 +7,19 @@ RSpec.describe Supplier do
   it { is_expected.to have_many(:agreements) }
   it { is_expected.to have_many(:frameworks).through(:agreements) }
   it { is_expected.to have_many(:memberships) }
+
+  it 'validates coda_reference begins with C0 and ends with 5 more digits' do
+    valid_coda_references = %w[C012345 C002928 C099999]
+    invalid_coda_references = %w[C012 D012345 C0AB123]
+
+    valid_coda_references.each do |coda_reference|
+      expect(FactoryBot.create(:supplier, coda_reference: coda_reference)).to be_valid
+    end
+
+    invalid_coda_references.each do |coda_reference|
+      supplier = FactoryBot.build(:supplier, coda_reference: coda_reference)
+      expect(supplier).not_to be_valid
+      expect(supplier.errors[:coda_reference]).to be_present
+    end
+  end
 end


### PR DESCRIPTION
This reference will be used to match the supplier against their record in current finance system, called Coda.