### PR TITLE
Add coda_reference to the Framework model

### DIFF
--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -6,4 +6,8 @@ class Framework < ApplicationRecord
   has_many :suppliers, through: :agreements
 
   validates :short_name, presence: true, uniqueness: true
+  validates :coda_reference, allow_nil: true, format: {
+    with: /\A40\d{4}\z/,
+    message: 'must start with “40” and have four additional numbers, for example: “401234”'
+  }
 end

--- a/db/data_migrate/20180807083612_set_coda_reference_for_frameworks.rb
+++ b/db/data_migrate/20180807083612_set_coda_reference_for_frameworks.rb
@@ -1,0 +1,10 @@
+
+SHORT_NAME_TO_CODA_REFERENCE_MAPPING = {
+  'RM3786' => '401108',
+  'RM3756' => '401148',
+  'RM3787' => '401149'
+}.freeze
+
+SHORT_NAME_TO_CODA_REFERENCE_MAPPING.each_pair do |short_name, coda_reference|
+  Framework.find_by!(short_name: short_name).update!(coda_reference: coda_reference)
+end

--- a/db/migrate/20180806160648_add_coda_reference_to_frameworks.rb
+++ b/db/migrate/20180806160648_add_coda_reference_to_frameworks.rb
@@ -1,0 +1,5 @@
+class AddCodaReferenceToFrameworks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :frameworks, :coda_reference, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_06_154052) do
+ActiveRecord::Schema.define(version: 2018_08_06_160648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2018_08_06_154052) do
   create_table "frameworks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "short_name", null: false
+    t.integer "coda_reference"
     t.index ["short_name"], name: "index_frameworks_on_short_name", unique: true
   end
 

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -10,5 +10,20 @@ RSpec.describe Framework do
     subject { Framework.create(short_name: 'test') }
     it { is_expected.to validate_presence_of(:short_name) }
     it { is_expected.to validate_uniqueness_of(:short_name) }
+
+    it 'validates coda_reference is a 7 digit number, beginning with 40' do
+      valid_coda_references = %w[401234 400292 409999]
+      invalid_coda_references = %w[4012 501234 40AB12]
+
+      valid_coda_references.each do |coda_reference|
+        expect(FactoryBot.create(:framework, coda_reference: coda_reference)).to be_valid
+      end
+
+      invalid_coda_references.each do |coda_reference|
+        framework = FactoryBot.build(:framework, coda_reference: coda_reference)
+        expect(framework).not_to be_valid
+        expect(framework.errors[:coda_reference]).to be_present
+      end
+    end
   end
 end


### PR DESCRIPTION
This reference will be used to match the framework against their record
in current finance system, called Coda. The validations are based on the details on the ETL process in the [Finance file export notes document](https://docs.google.com/document/d/13uZvJXWB_MpybNt4dUZ5zyaZUT5SDkro4Vs3zZ5gtT4/edit#heading=h.q9kujjnus31w).

This PR also includes a script that can be used to set the coda reference for the three Frameworks currently in the new system.