### PR TITLE
(264) Add 'brakeman' to find potential vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'rubocop'
 gem 'progress_bar', require: false
 
 group :development, :test do
+  gem 'brakeman', require: false
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'dotenv-rails'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     bootsnap (1.3.0)
       msgpack (~> 1.0)
     bounded_context (0.30.0)
+    brakeman (4.3.1)
     builder (3.2.3)
     byebug (10.0.2)
     coderay (1.1.2)
@@ -272,6 +273,7 @@ DEPENDENCIES
   auth0
   aws-sdk-lambda
   bootsnap (>= 1.1.0)
+  brakeman
   byebug
   database_cleaner
   dotenv-rails

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -1,0 +1,15 @@
+if Rails.env.development? || Rails.env.test?
+  namespace :brakeman do
+    desc 'Run Brakeman'
+    task :run do
+      require 'brakeman'
+
+      Brakeman.run(
+        app_path: '.',
+        quiet: true,
+        pager: false,
+        print_report: true
+      )
+    end
+  end
+end

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1,0 +1,1 @@
+task default: %i[rubocop brakeman:run spec] if Rails.env.test? || Rails.env.development?

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,13 +1,10 @@
 if Rails.env.development? || Rails.env.test?
-  require 'rubocop/rake_task'
-
   desc 'Run rubocop - configure in .rubocop.yml'
   task :rubocop do
+    require 'rubocop/rake_task'
+
     RuboCop::RakeTask.new(:rubocop) do |t|
       t.options = ['--display-cop-names']
     end
   end
-
-  task(:default).clear.enhance(%i[rubocop spec])
-  task(:default).comment = 'Run rubocop checks'
 end


### PR DESCRIPTION
This has been added to the default rake task that is run when you call
`bin/dspec` or `bin/drake` with no options. This will also be included
when CI gets run.

NB: I had to reorganise the rake tasks to ensure that RuboCop, RSpec and
Brakeman were run, as the original `rubocop.rake` was overwriting the
config.