### PR TITLE
Handle numbers ingested with commas

### DIFF
--- a/app/models/reports/coda_finance_report_row.rb
+++ b/app/models/reports/coda_finance_report_row.rb
@@ -49,7 +49,7 @@ module Reports
       submission.entries
                 .sheet('InvoicesRaised')
                 .sector(sector)
-                .sum("(data->>'Total Cost (ex VAT)')::float")
+                .sum { |entry| numeric_string_to_number(entry.data['Total Cost (ex VAT)']) }
     end
 
     def management_charge
@@ -58,6 +58,10 @@ module Reports
 
     def management_charge_rate
       BigDecimal('1.5')
+    end
+
+    def numeric_string_to_number(numeric_string)
+      BigDecimal(numeric_string.delete(','))
     end
 
     def format_money(amount)

--- a/spec/models/reports/coda_finance_report_row_spec.rb
+++ b/spec/models/reports/coda_finance_report_row_spec.rb
@@ -101,6 +101,17 @@ RSpec.describe Reports::CodaFinanceReportRow do
       expect(wps_report_row.data['Commission']).to eq '-6.43'
     end
 
+    it 'handles sales amounts written as a human-readable number' do
+      FactoryBot.create(
+        :validated_submission_entry,
+        submission: submission,
+        source: { sheet: 'InvoicesRaised', row: 3 },
+        data: { 'Total Cost (ex VAT)' => ' 2,428.95 ', 'Customer URN' => health_dept.urn }
+      )
+      expect(cg_report_row.data['Inf Sales']).to eq '3659.40'
+      expect(cg_report_row.data['Commission']).to eq '54.89'
+    end
+
     it 'handles no business submissions, reporting them as zero sales and commission' do
       no_business_submission = FactoryBot.create(:no_business_submission)
       row = Reports::CodaFinanceReportRow.new(no_business_submission, Customer.sectors[:central_government])


### PR DESCRIPTION
Turns out the current version of the ingest script records the total
sales values as a string, includig in some instances with whitespace and
commas, for example " 9,234.23".