### PR TITLE
Coda Finance Report tweaks

### DIFF
--- a/app/models/reports/coda_finance_report.rb
+++ b/app/models/reports/coda_finance_report.rb
@@ -42,7 +42,7 @@ module Reports
       data = CodaFinanceReportRow.new(submission, sector).data
 
       [
-        report_uid,
+        data['RunID'],
         data['Nominal'],
         data['Customer Code'],
         data['Customer Name'],
@@ -57,13 +57,6 @@ module Reports
         data['Month'],
         monthly_or_quarterly
       ]
-    end
-
-    # CCS require that each report has a unique reference in case they need to
-    # perform an audit and trace a particular entry in the finance system back
-    # to the report that generated it.
-    def report_uid
-      "DSS-#{Time.zone.now.to_i}"
     end
 
     # Used to indicate if the data in the report is for monthly or quarterly

--- a/app/models/reports/coda_finance_report_row.rb
+++ b/app/models/reports/coda_finance_report_row.rb
@@ -7,15 +7,19 @@ module Reports
       @sector = sector
     end
 
+    delegate :id, to: :submission, prefix: true
+    delegate :coda_reference, :name, to: :supplier, prefix: true
+    delegate :coda_reference, :name, :short_name, to: :framework, prefix: true
+
     def data
       @data ||= {
-        'RunID' => submission.id,
-        'Nominal' => framework.coda_reference,
-        'Contract ID' => framework.short_name,
-        'Lot Description' => framework.name,
-        'Customer Code' => supplier.coda_reference,
-        'Customer Name' => supplier.name,
-        'Submitter' => supplier.name,
+        'RunID' => submission_id,
+        'Nominal' => framework_coda_reference,
+        'Contract ID' => framework_short_name,
+        'Lot Description' => framework_name,
+        'Customer Code' => supplier_coda_reference,
+        'Customer Name' => supplier_name,
+        'Submitter' => supplier_name,
         'Month' => task_period,
         'End User' => sector_identifier,
         'Inf Sales' => format_money(total_sales),

--- a/app/models/reports/coda_finance_report_row.rb
+++ b/app/models/reports/coda_finance_report_row.rb
@@ -70,7 +70,7 @@ module Reports
     end
 
     def format_money(amount)
-      format '%.2f', amount.round(2)
+      format '%.2f', amount.truncate(2)
     end
 
     def format_percentage(percentage)

--- a/app/models/reports/coda_finance_report_row.rb
+++ b/app/models/reports/coda_finance_report_row.rb
@@ -9,6 +9,7 @@ module Reports
 
     def data
       @data ||= {
+        'RunID' => submission.id,
         'Nominal' => framework.coda_reference,
         'Contract ID' => framework.short_name,
         'Lot Description' => framework.name,

--- a/spec/models/reports/coda_finance_report_row_spec.rb
+++ b/spec/models/reports/coda_finance_report_row_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Reports::CodaFinanceReportRow do
   subject(:cg_report_row) { Reports::CodaFinanceReportRow.new(submission, Customer.sectors[:central_government]) }
   subject(:wps_report_row) { Reports::CodaFinanceReportRow.new(submission, Customer.sectors[:wider_public_sector]) }
 
+  it 'reports the submission ID as ‘RunID’' do
+    expect(cg_report_row.data['RunID']).to eq submission.id
+  end
+
   it 'reports the framework’s coda_reference as ‘Nominal’' do
     expect(cg_report_row.data['Nominal']).to eq framework.coda_reference
   end

--- a/spec/models/reports/coda_finance_report_row_spec.rb
+++ b/spec/models/reports/coda_finance_report_row_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Reports::CodaFinanceReportRow do
     end
 
     it 'reports the total management charge, scoped to the sector, as ‘Commission’' do
-      expect(cg_report_row.data['Commission']).to eq '18.46'
+      expect(cg_report_row.data['Commission']).to eq '18.45'
       expect(wps_report_row.data['Commission']).to eq '-6.43'
     end
 

--- a/spec/models/reports/coda_finance_report_spec.rb
+++ b/spec/models/reports/coda_finance_report_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe Reports::CodaFinanceReport do
   let(:expected_csv) do
     <<~CSV
       RunID,Nominal,Customer Code,Customer Name,Contract ID,Order Number,Lot Description,Inf Sales,Commission,Commission %,End User,Submitter,Month,M_Q
-      DSS-#{report_timestamp},409999,C011111,Mary,RM3787,,G CLOUD,802.00,12.03,0.015,UCGV,Mary,August 2018,M
-      DSS-#{report_timestamp},409999,C011111,Mary,RM3787,,G CLOUD,0.00,0.00,0.015,UWPS,Mary,August 2018,M
-      DSS-#{report_timestamp},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,0.015,UCGV,Bob,August 2018,M
-      DSS-#{report_timestamp},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,0.015,UWPS,Bob,August 2018,M
+      #{submission.id},409999,C011111,Mary,RM3787,,G CLOUD,802.00,12.03,0.015,UCGV,Mary,August 2018,M
+      #{submission.id},409999,C011111,Mary,RM3787,,G CLOUD,0.00,0.00,0.015,UWPS,Mary,August 2018,M
+      #{no_business_submission.id},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,0.015,UCGV,Bob,August 2018,M
+      #{no_business_submission.id},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,0.015,UWPS,Bob,August 2018,M
     CSV
   end
 


### PR DESCRIPTION
A couple of tweaks to the finance report, based on feedback from Dave Richardson:

- Dave Richardson has requested that we use this field to report the submission identifier, as it will enable them "to do proper reconciliation in the Data Warehouse and also with CODA." According to Dave, this field has no significance in the finance system, so it should be safe to re-purpose it for this.
- The levy calculation should be rounded down, rather than to the nearest penny