### PR TITLE
Remove speculative states

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -13,7 +13,6 @@ class Submission < ApplicationRecord
     state :processing
     state :in_review
     state :completed
-    state :rejected
 
     event :ready_for_review do
       transitions from: %i[pending processing], to: :in_review

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,11 +2,9 @@ class Task < ApplicationRecord
   include AASM
 
   aasm column: 'status' do
-    state :draft
     state :unstarted, initial: true
     state :in_progress
     state :completed
-    state :cancelled
 
     event :completed do
       transitions from: %i[unstarted in_progress], to: :completed

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe '/v1' do
 
   describe 'GET /tasks' do
     it 'returns a list of tasks' do
-      task1 = FactoryBot.create(:task, status: 'draft')
       task2 = FactoryBot.create(:task, status: 'unstarted')
       task3 = FactoryBot.create(:task, status: 'in_progress')
 
@@ -51,14 +50,11 @@ RSpec.describe '/v1' do
 
       expect(response).to be_successful
 
-      expect(json['data'][0]).to have_id(task1.id)
-      expect(json['data'][0]).to have_attribute(:status).with_value('draft')
+      expect(json['data'][0]).to have_id(task2.id)
+      expect(json['data'][0]).to have_attribute(:status).with_value('unstarted')
 
-      expect(json['data'][1]).to have_id(task2.id)
-      expect(json['data'][1]).to have_attribute(:status).with_value('unstarted')
-
-      expect(json['data'][2]).to have_id(task3.id)
-      expect(json['data'][2]).to have_attribute(:status).with_value('in_progress')
+      expect(json['data'][1]).to have_id(task3.id)
+      expect(json['data'][1]).to have_attribute(:status).with_value('in_progress')
     end
 
     it 'can optionally include submissions' do
@@ -95,8 +91,8 @@ RSpec.describe '/v1' do
 
   describe 'GET /tasks?filter[status]=' do
     it 'returns a filtered list of tasks matching the statue value in the URL' do
-      FactoryBot.create(:task, status: 'draft')
-      FactoryBot.create(:task, status: 'draft')
+      FactoryBot.create(:task, status: 'unstarted')
+      FactoryBot.create(:task, status: 'unstarted')
       FactoryBot.create(:task, status: 'completed')
 
       get '/v1/tasks?filter[status]=completed'


### PR DESCRIPTION
These states are not currently used and it's not 100% clear that: we
will definitely need them; what business processes/user flows they
relate to; if they are appropriately named for their theorised use.
Until these states are definitely necessary and their use clearly
defined, we should avoid introducing them to the codebase.