### PR TITLE
 Endpoint for attaching file blobs on submissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'rails_event_store'
 # Auth0
 gem 'auth0', require: false
 
+gem 'aws-sdk-s3', require: false
+
 # Exception tracking
 gem 'rollbar'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,8 +60,15 @@ GEM
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
+    aws-sdk-kms (1.5.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
     aws-sdk-lambda (1.8.0)
       aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.13.0)
+      aws-sdk-core (~> 3, >= 3.21.2)
+      aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
     bootsnap (1.3.0)
@@ -272,6 +279,7 @@ DEPENDENCIES
   aasm
   auth0
   aws-sdk-lambda
+  aws-sdk-s3
   bootsnap (>= 1.1.0)
   brakeman
   byebug

--- a/app/controllers/v1/submission_file_blobs_controller.rb
+++ b/app/controllers/v1/submission_file_blobs_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class V1::SubmissionFileBlobsController < ApplicationController
+  deserializable_resource :file_blob
+
+  def create
+    submission_file = SubmissionFile.find(params[:file_id])
+    submission_file.file_blob = ActiveStorage::Blob.new(file_blob_params)
+
+    render jsonapi: submission_file, status: :created
+  end
+
+  private
+
+  def file_blob_params
+    params.require(:file_blob).permit(:key, :filename, :content_type, :byte_size, :checksum)
+  end
+end

--- a/app/deserializable/deserializable_submission_file_blob.rb
+++ b/app/deserializable/deserializable_submission_file_blob.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DeserializableSubmissionFileBlob < JSONAPI::Deserializable::Resource
+  attributes :key, :filename, :content_type, :byte_size, :checksum
+end

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -1,4 +1,6 @@
 class SubmissionFile < ApplicationRecord
   belongs_to :submission
   has_many :entries, dependent: :nullify, class_name: 'SubmissionEntry'
+
+  has_one_attached :file
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,7 @@ require 'rails'
 require 'active_model/railtie'
 require 'active_job/railtie'
 require 'active_record/railtie'
-# require 'active_storage/engine'
+require 'active_storage/engine'
 require 'action_controller/railtie'
 # require "action_mailer/railtie"
 require 'action_view/railtie'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Store uploaded files on Amazon S3
+  config.active_storage.service = :amazon
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,6 +29,9 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
+  # Store uploaded files on Amazon S3
+  config.active_storage.service = :amazon
+
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,7 +19,11 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
+
+  # Store attachment files on the local file system
+  config.active_storage.service = :test
+
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
 
     resources :files, only: [] do
       resources :entries, only: %i[show create update], controller: 'submission_entries'
+      resources :blobs, only: :create, controller: 'submission_file_blobs'
     end
 
     namespace :events do

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,29 +6,9 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket
-
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket
-
-# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name
-
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]
+amazon:
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: <%= ENV['AWS_S3_REGION'] %>
+  bucket: <%= ENV['AWS_S3_BUCKET'] %>

--- a/db/migrate/20180816120814_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20180816120814_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,26 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs, id: :uuid do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: :uuid do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, type: :uuid, polymorphic: true, index: false
+      t.references :blob,     null: false, type: :uuid
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_07_093650) do
+ActiveRecord::Schema.define(version: 2018_08_16_120814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.uuid "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "agreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "framework_id", null: false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.include JSONAPI::RSpec
+  config.include StorageHelpers
   config.include RequestHelpers, type: :request
   config.include ActiveSupport::Testing::TimeHelpers
   Aws.config[:stub_responses] = true

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -20,12 +20,7 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      post "/v1/files/#{file.id}/entries", params: params.to_json, headers: headers
+      post "/v1/files/#{file.id}/entries", params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(:created)
 
@@ -56,12 +51,7 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      post "/v1/files/#{file.id}/entries", params: params.to_json, headers: headers
+      post "/v1/files/#{file.id}/entries", params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(:bad_request)
     end
@@ -108,14 +98,9 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
       expect_submission_status_update_to_be_performed(file.submission)
 
-      patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
+      patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(:no_content)
       expect(entry.reload).to be_validated
@@ -141,14 +126,9 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
       expect_submission_status_update_to_be_performed(file.submission)
 
-      patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
+      patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(:no_content)
       expect(entry.reload).to be_pending
@@ -177,14 +157,9 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
       expect_submission_status_update_to_be_performed(file.submission)
 
-      patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
+      patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(:no_content)
       expect(entry.reload).to be_errored

--- a/spec/requests/v1/memberships_spec.rb
+++ b/spec/requests/v1/memberships_spec.rb
@@ -83,12 +83,7 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      post '/v1/memberships', params: params.to_json, headers: headers
+      post '/v1/memberships', params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(:created)
 
@@ -104,13 +99,8 @@ RSpec.describe '/v1' do
     it 'deletes a membership, disassociating a user from a supplier' do
       membership = FactoryBot.create(:membership)
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
       expect do
-        delete "/v1/memberships/#{membership.id}", params: {}, headers: headers
+        delete "/v1/memberships/#{membership.id}", params: {}, headers: json_headers
       end.to change { Membership.count }.from(1).to(0)
     end
   end

--- a/spec/requests/v1/submission_file_blobs_spec.rb
+++ b/spec/requests/v1/submission_file_blobs_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/v1' do
+  describe 'POST /files/:file_id/blobs' do
+    let(:submission_file) { FactoryBot.create(:submission_file) }
+    let(:params) do
+      {
+        data: {
+          type: 'file_blobs',
+          attributes: {
+            key: stubbed_blob_key,
+            filename: 'filename.xlsx',
+            content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            byte_size: 234936,
+            checksum: 'r1gZERPTNkeuHwKyI9qUPQ=='
+          }
+        }
+      }
+    end
+
+    it 'creates the file attachment against the submission file' do
+      post v1_file_blobs_path(submission_file.id), params: params.to_json, headers: json_headers
+
+      expect(response).to have_http_status(:created)
+      expect(json['data']).to have_id(submission_file.id)
+
+      file_attachment = submission_file.file
+
+      expect(file_attachment).to be_attached
+      expect(file_attachment.key).to eq(stubbed_blob_key)
+      expect(file_attachment.filename).to eq('filename.xlsx')
+      expect(file_attachment.content_type).to eq('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+      expect(file_attachment.byte_size).to eq(234936)
+      expect(file_attachment.checksum).to eq('r1gZERPTNkeuHwKyI9qUPQ==')
+    end
+  end
+end

--- a/spec/requests/v1/submission_files_spec.rb
+++ b/spec/requests/v1/submission_files_spec.rb
@@ -5,12 +5,7 @@ RSpec.describe '/v1' do
     it 'creates a new submission file and returns its id' do
       submission = FactoryBot.create(:submission)
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      post "/v1/submissions/#{submission.id}/files", params: {}, headers: headers
+      post "/v1/submissions/#{submission.id}/files", params: {}, headers: json_headers
 
       expect(response).to have_http_status(:created)
 
@@ -26,11 +21,6 @@ RSpec.describe '/v1' do
       submission = FactoryBot.create(:submission)
       file = FactoryBot.create(:submission_file, submission: submission)
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
       params = {
         data: {
           type: 'submission_files',
@@ -40,7 +30,7 @@ RSpec.describe '/v1' do
         }
       }
 
-      patch "/v1/submissions/#{submission.id}/files/#{file.id}", params: params.to_json, headers: headers
+      patch "/v1/submissions/#{submission.id}/files/#{file.id}", params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(204)
       expect(file.reload.rows).to eql 1000

--- a/spec/requests/v1/submission_files_spec.rb
+++ b/spec/requests/v1/submission_files_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe '/v1' do
+  describe 'POST /submissions/:submission_id/files' do
+    it 'creates a new submission file and returns its id' do
+      submission = FactoryBot.create(:submission)
+
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      post "/v1/submissions/#{submission.id}/files", params: {}, headers: headers
+
+      expect(response).to have_http_status(:created)
+
+      file = SubmissionFile.first
+
+      expect(json['data']).to have_id(file.id)
+      expect(json['data']).to have_attribute(:submission_id).with_value(submission.id)
+    end
+  end
+
+  describe 'PATCH /submission/:submission_id/files/:file_id' do
+    it 'updates a submission file' do
+      submission = FactoryBot.create(:submission)
+      file = FactoryBot.create(:submission_file, submission: submission)
+
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      params = {
+        data: {
+          type: 'submission_files',
+          attributes: {
+            rows: 1000
+          }
+        }
+      }
+
+      patch "/v1/submissions/#{submission.id}/files/#{file.id}", params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(204)
+      expect(file.reload.rows).to eql 1000
+    end
+  end
+
+  describe 'GET /submissions/:submission_id/files/:id' do
+    it 'retrieves a submission file data associated with a submission' do
+      submission = FactoryBot.create(:submission)
+      file = FactoryBot.create(:submission_file, submission_id: submission.id, rows: 40)
+
+      get "/v1/submissions/#{submission.id}/files/#{file.id}"
+
+      expect(response).to have_http_status(:ok)
+
+      expect(json['data']).to have_id(file.id)
+
+      expect(json['data']).to have_attribute(:rows).with_value(file.rows)
+    end
+  end
+end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -125,67 +125,6 @@ RSpec.describe '/v1' do
     end
   end
 
-  describe 'POST /submissions/:submission_id/files' do
-    it 'creates a new submission file and returns its id' do
-      submission = FactoryBot.create(:submission)
-
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      post "/v1/submissions/#{submission.id}/files", params: {}, headers: headers
-
-      expect(response).to have_http_status(:created)
-
-      file = SubmissionFile.first
-
-      expect(json['data']).to have_id(file.id)
-      expect(json['data']).to have_attribute(:submission_id).with_value(submission.id)
-    end
-  end
-
-  describe 'PATCH /submission/:submission_id/files/:file_id' do
-    it 'updates a submission file' do
-      submission = FactoryBot.create(:submission)
-      file = FactoryBot.create(:submission_file, submission: submission)
-
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      params = {
-        data: {
-          type: 'submission_files',
-          attributes: {
-            rows: 1000
-          }
-        }
-      }
-
-      patch "/v1/submissions/#{submission.id}/files/#{file.id}", params: params.to_json, headers: headers
-
-      expect(response).to have_http_status(204)
-      expect(file.reload.rows).to eql 1000
-    end
-  end
-
-  describe 'GET /submissions/:submission_id/files/:id' do
-    it 'retrieves a submission file data associated with a submission' do
-      submission = FactoryBot.create(:submission)
-      file = FactoryBot.create(:submission_file, submission_id: submission.id, rows: 40)
-
-      get "/v1/submissions/#{submission.id}/files/#{file.id}"
-
-      expect(response).to have_http_status(:ok)
-
-      expect(json['data']).to have_id(file.id)
-
-      expect(json['data']).to have_attribute(:rows).with_value(file.rows)
-    end
-  end
-
   describe 'POST /submissions/:submission_id/entries' do
     it 'stores a submission entry, not associated with a file' do
       submission = FactoryBot.create(:submission)

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -78,12 +78,7 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      post "/v1/submissions?task_id=#{task.id}", params: params.to_json, headers: headers
+      post "/v1/submissions?task_id=#{task.id}", params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(:created)
 
@@ -109,12 +104,7 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      patch "/v1/submissions/#{submission.id}", params: params.to_json, headers: headers
+      patch "/v1/submissions/#{submission.id}", params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(:no_content)
 
@@ -144,12 +134,7 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      post "/v1/submissions/#{submission.id}/entries", params: params.to_json, headers: headers
+      post "/v1/submissions/#{submission.id}/entries", params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(:created)
 
@@ -170,12 +155,7 @@ RSpec.describe '/v1' do
     it 'invokes the calculate lambda function successfully' do
       submission = FactoryBot.create(:submission)
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      post "/v1/submissions/#{submission.id}/calculate", params: {}, headers: headers
+      post "/v1/submissions/#{submission.id}/calculate", params: {}, headers: json_headers
 
       expect(response).to have_http_status(:no_content)
     end

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -20,12 +20,7 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      post '/v1/tasks', params: params.to_json, headers: headers
+      post '/v1/tasks', params: params.to_json, headers: json_headers
 
       expect(response).to have_http_status(:created)
 
@@ -228,12 +223,7 @@ RSpec.describe '/v1' do
         }
       }
 
-      headers = {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json'
-      }
-
-      patch "/v1/tasks/#{task.id}", params: params.to_json, headers: headers
+      patch "/v1/tasks/#{task.id}", params: params.to_json, headers: json_headers
 
       expect(response).to be_successful
 

--- a/spec/support/active_storage.rb
+++ b/spec/support/active_storage.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.after(:each) do
+    FileUtils.rm_rf Rails.root.join('tmp', 'storage')
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -2,4 +2,8 @@ module RequestHelpers
   def json
     JSON.parse(response.body)
   end
+
+  def json_headers
+    { 'Content-Type': 'application/vnd.api+json', 'Accept': 'application/vnd.api+json' }
+  end
 end

--- a/spec/support/storage_helpers.rb
+++ b/spec/support/storage_helpers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module StorageHelpers
+  # Returns the key for a stubbed ActiveStorage::Blob as it would be stored
+  # by the Disk-based storage service.
+  def stubbed_blob_key
+    @stubbed_blob_key ||= begin
+      FileUtils.mkdir_p Rails.root.join('tmp', 'storage', 'te', 'st')
+      FileUtils.touch Rails.root.join('tmp', 'storage', 'te', 'st', 'test-file')
+      'test-file'
+    end
+  end
+end


### PR DESCRIPTION
This endpoint will be used by the supplier-facing application to tell
the backend API where it can find the uploaded submission file.

The supplier-facing application handles the mechanics of uploading
user's files to S3 using ActiveStorage. By sending the details of the
ActiveStorage::Blob to the backend API, the API can create it's own
record of the file and thus make it available for the system to access
and manipulate as required.

This need to sync low-level file storage details using the API in this
way is a bit of a smell, but given the architecture as it has been
defined right now this feels like the most pragmatic way to make it so
that the supplier front-end can handle the file upload whilst still
having the backend API as the authoritative record of the file itself
without the backend having to read the file once it's been uploaded.