### PR TITLE
(314) Add `validation_failed` state to the `Submission` model

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -11,11 +11,13 @@ class Submission < ApplicationRecord
   aasm do
     state :pending, initial: true
     state :processing
+    state :validation_failed
     state :in_review
     state :completed
 
     event :ready_for_review do
-      transitions from: %i[pending processing], to: :in_review
+      transitions from: %i[pending processing], to: :in_review, guard: :all_entries_valid?
+      transitions from: %i[pending processing], to: :validation_failed
     end
 
     event :reviewed_and_accepted do

--- a/db/data_migrate/20180822120600_update_submission_statuses.rb
+++ b/db/data_migrate/20180822120600_update_submission_statuses.rb
@@ -1,0 +1,4 @@
+Submission
+  .where(aasm_state: :in_review)
+  .select { |s| s.entries.errored.any? }
+  .update_all!(aasm_state: :validation_failed)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,9 +72,9 @@ task_in_review_with_errors = Task.find_or_create_by!(
   supplier: supplier,
   period_month: Date.today.month,
   period_year: Date.today.year,
-  description: 'In review task (invalid submission)'
+  description: 'Validation failed task (invalid submission)'
 )
-invalid_submission = supplier.submissions.find_or_create_by!(framework: framework_invalid, task: task_in_review_with_errors, aasm_state: "in_review")
+invalid_submission = supplier.submissions.find_or_create_by!(framework: framework_invalid, task: task_in_review_with_errors, aasm_state: "validation_failed")
 submission_file = invalid_submission.files.find_or_create_by!(rows: 2)
 invalid_submission.entries.find_or_create_by!(submission_file: submission_file, aasm_state: "validated", data: { key: "value" }, source: { sheet: "InvoicesReceived", row: 1 })
 invalid_submission.entries.find_or_create_by!(

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     end
 
     factory :submission_with_invalid_entries do
-      aasm_state :in_review
+      aasm_state :validation_failed
 
       after(:create) do |submission, _evaluator|
         create_list(:validated_submission_entry, 2, submission: submission)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -7,4 +7,20 @@ RSpec.describe Submission do
 
   it { is_expected.to have_many(:files) }
   it { is_expected.to have_many(:entries) }
+
+  describe 'state machine' do
+    it 'transitions from processing to in_review, with a valid submission' do
+      submission = FactoryBot.create(:submission_with_validated_entries, aasm_state: :processing)
+      submission.ready_for_review
+
+      expect(submission).to be_in_review
+    end
+
+    it 'transitions from processing to validation_failed, when there are errors' do
+      submission = FactoryBot.create(:submission_with_invalid_entries, aasm_state: :processing)
+      submission.ready_for_review
+
+      expect(submission).to be_validation_failed
+    end
+  end
 end

--- a/spec/models/submission_status_update_spec.rb
+++ b/spec/models/submission_status_update_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe SubmissionStatusUpdate do
       context 'with no "pending" entries remaining, but some having failed validation' do
         let(:submission) { FactoryBot.create(:submission_with_invalid_entries, aasm_state: :processing) }
 
-        it 'transitions the submission to "in_review"' do
+        it 'transitions the submission to "validation_failed"' do
           submission_status_check.perform!
 
-          expect(submission).to be_in_review
+          expect(submission).to be_validation_failed
         end
 
         it 'does not trigger a levy calculation' do


### PR DESCRIPTION
Add the new `validation_failed` state (see [ADR#18](https://github.com/Crown-Commercial-Service/DataSubmissionService-ADRs/blob/master/doc/adr/0018-submission-state-machine.md)). 

When a submission's entries have all passed through the validation process, and some of the entries are invalid, we now transition it to the `validation_failed` state. Submissions with all valid entries continue to be transitioned to the `in_review` state as before.