### PR TITLE
Fix submission status data migration

### DIFF
--- a/db/data_migrate/20180822120600_update_submission_statuses.rb
+++ b/db/data_migrate/20180822120600_update_submission_statuses.rb
@@ -1,4 +1,14 @@
+submission_ids = Submission
+                 .where(aasm_state: :in_review)
+                 .select { |s| s.entries.errored.any? }
+                 .pluck(:id)
+
+# rubocop:disable Rails/SkipsModelValidations
+# Using `update_all` specifically, so not to touch
+# `updated_at` value
+
 Submission
-  .where(aasm_state: :in_review)
-  .select { |s| s.entries.errored.any? }
-  .update_all!(aasm_state: :validation_failed)
+  .where(id: submission_ids)
+  .update_all(aasm_state: :validation_failed)
+
+# rubocop:enable Rails/SkipsModelValidations


### PR DESCRIPTION
Previous version didn't work, as `select` returns an Array, which is not a valid input for `update_all`.