### PR TITLE
Ignore all dotenv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 
 # Environment variables
 .env
-.env.local
+.env.*
 
 docker-compose.env
 


### PR DESCRIPTION
We use dotenv-rails to configure environment variables locally. The gem
supports per-environment `.env` files, for example `.env.development`.
By ignoring all `.env` files developers have maximum flexibility to
configure environment variables to suite their environment.