### PR TITLE
Add an auth0_throttle_sleep param to UserImport

### DIFF
--- a/lib/user_import.rb
+++ b/lib/user_import.rb
@@ -3,9 +3,10 @@ require 'auth0'
 require 'user_import_row'
 
 class UserImport
-  def initialize(csv_data, auth0_client)
+  def initialize(csv_data, auth0_client, auth0_throttle_sleep: 1)
     @rows = CSV.parse(csv_data, headers: true, header_converters: :symbol)
     @auth0_client = auth0_client
+    @auth0_throttle_sleep = auth0_throttle_sleep
   end
 
   def run!
@@ -13,7 +14,7 @@ class UserImport
       UserImportRow.new(row.to_h, @auth0_client).import!
 
       # Needed to stop the Auth0 Management API throttling us
-      sleep 1
+      sleep(@auth0_throttle_sleep)
     end
   end
 end

--- a/spec/lib/user_import_spec.rb
+++ b/spec/lib/user_import_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe UserImport do
       csv += "Vaughan Legal,email2@example.com,Francis Bloggs\n"
       csv += "Vaughan Legal,email3@example.com,Alex Bloggs\n"
 
-      UserImport.new(csv, client).run!
+      UserImport.new(csv, client, auth0_throttle_sleep: 0).run!
 
       expect(client).to have_received(:create_user).exactly(3).times
     end


### PR DESCRIPTION
Default it to 1 second. This was being called three times from the spec,
meaning the specs would appear to hang for 3 seconds if
`user_import_spec` was run.