### PR TITLE
Add and expose submission_entries#entry_type column

### DIFF
--- a/app/deserializable/deserializable_submission_entry.rb
+++ b/app/deserializable/deserializable_submission_entry.rb
@@ -1,4 +1,5 @@
 class DeserializableSubmissionEntry < JSONAPI::Deserializable::Resource
+  attribute :entry_type
   attribute :source
   attribute :data
   attribute :status

--- a/app/models/submission_entry.rb
+++ b/app/models/submission_entry.rb
@@ -5,6 +5,7 @@ class SubmissionEntry < ApplicationRecord
   belongs_to :submission_file, optional: true
 
   validates :data, presence: true
+  validates :entry_type, inclusion: { in: %w[invoice order] }, allow_blank: true
 
   scope :sheet, ->(sheet_name) { where("source->>'sheet' = ?", sheet_name) }
   scope :sector, lambda { |sector|

--- a/db/migrate/20180911160120_add_entry_type_to_submission_entries.rb
+++ b/db/migrate/20180911160120_add_entry_type_to_submission_entries.rb
@@ -1,0 +1,6 @@
+class AddEntryTypeToSubmissionEntries < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submission_entries, :entry_type, :string
+    add_index :submission_entries, :entry_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_16_120814) do
+ActiveRecord::Schema.define(version: 2018_09_11_160120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -107,7 +107,9 @@ ActiveRecord::Schema.define(version: 2018_08_16_120814) do
     t.datetime "updated_at", null: false
     t.string "aasm_state"
     t.jsonb "validation_errors"
+    t.string "entry_type"
     t.index ["aasm_state"], name: "index_submission_entries_on_aasm_state"
+    t.index ["entry_type"], name: "index_submission_entries_on_entry_type"
     t.index ["submission_file_id"], name: "index_submission_entries_on_submission_file_id"
     t.index ["submission_id"], name: "index_submission_entries_on_submission_id"
   end


### PR DESCRIPTION
This will be used to identify the type of entry, i.e. whether it's an "invoice" or an "order" row. We want this to be a first-class attribute of the model as we will often need to scope by the type of entry, specifically in things like the finance report and data exports. By normalising it as an enumerated type, it becomes easier to scope entries that may have been imported against templates that have different names for the actual worksheets (for example some call the worksheet "Invoices" whilst others call it "InvoicesRaised")

Note that we'll soon start importing other types of entry (e.g. bids) and so the list of valid entry types will need to be updated, but a decision on that should be made later when we know which additional types of entry we will be importing and whether they need to be individually identifiable or not (i.e. do we add "bids" to the list or a catch-all "other").

Note that this is adding the column so that the ingest process can start to set it. Separate PRs will follow to:

- update ingest to set this field
- add a data migration to back-fill this column for existing entries
- update the finance report to utilise this new field