### PR TITLE
Update finance report to scope on entry type

### DIFF
--- a/app/models/export/coda_finance_report/row.rb
+++ b/app/models/export/coda_finance_report/row.rb
@@ -53,7 +53,7 @@ module Export
 
       def total_sales
         submission.entries
-                  .sheet('InvoicesRaised')
+                  .invoices
                   .sector(sector)
                   .sum { |entry| numeric_string_to_number(entry.data['Total Cost (ex VAT)']) }
       end

--- a/app/models/submission_entry.rb
+++ b/app/models/submission_entry.rb
@@ -8,6 +8,8 @@ class SubmissionEntry < ApplicationRecord
   validates :entry_type, inclusion: { in: %w[invoice order] }, allow_blank: true
 
   scope :sheet, ->(sheet_name) { where("source->>'sheet' = ?", sheet_name) }
+  scope :invoices, -> { where(entry_type: 'invoice') }
+  scope :orders, -> { where(entry_type: 'order') }
   scope :sector, lambda { |sector|
     joins("INNER JOIN customers ON customers.urn = CAST(submission_entries.data->>'Customer URN' AS INTEGER)")
       .where('customers.sector = ?', sector)

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -3,7 +3,16 @@ FactoryBot.define do
     submission
     submission_file
     data(test_key: 'some data')
-    source(sheet: 'InvoicesReceived', row: 1)
+
+    trait :invoice do
+      entry_type 'invoice'
+      source(sheet: 'InvoicesReceived', row: 1)
+    end
+
+    trait :order do
+      entry_type 'order'
+      source(sheet: 'OrdersRaised', row: 1)
+    end
 
     factory :validated_submission_entry do
       aasm_state :validated
@@ -11,6 +20,14 @@ FactoryBot.define do
 
     factory :errored_submission_entry do
       aasm_state :errored
+    end
+
+    factory :validated_invoice_submission_entry, parent: :validated_submission_entry do
+      invoice
+    end
+
+    factory :validated_order_submission_entry, parent: :validated_submission_entry do
+      order
     end
   end
 end

--- a/spec/models/export/coda_finance_report/row_spec.rb
+++ b/spec/models/export/coda_finance_report/row_spec.rb
@@ -56,41 +56,36 @@ RSpec.describe Export::CodaFinanceReport::Row do
 
     let!(:home_office_invoice_entry) do
       FactoryBot.create(
-        :validated_submission_entry,
+        :validated_invoice_submission_entry,
         submission: submission,
-        source: { sheet: 'InvoicesRaised', row: 1 },
         data: { 'Total Cost (ex VAT)' => '801.50', 'Customer URN' => home_office.urn }
       )
     end
     let!(:health_dept_invoice_entry) do
       FactoryBot.create(
-        :validated_submission_entry,
+        :validated_invoice_submission_entry,
         submission: submission,
-        source: { sheet: 'InvoicesRaised', row: 2 },
         data: { 'Total Cost (ex VAT)' => '428.95', 'Customer URN' => health_dept.urn }
       )
     end
     let!(:bobs_charity_invoice_entry) do
       FactoryBot.create(
-        :validated_submission_entry,
+        :validated_invoice_submission_entry,
         submission: submission,
-        source: { sheet: 'InvoicesRaised', row: 2 },
         data: { 'Total Cost (ex VAT)' => '-428.95', 'Customer URN' => bobs_charity.urn }
       )
     end
     let!(:home_office_order_entry) do
       FactoryBot.create(
-        :validated_submission_entry,
+        :validated_order_submission_entry,
         submission: submission,
-        source: { sheet: 'OrdersReceived', row: 1 },
         data: { 'Total Cost (ex VAT)' => '1000.00', 'Customer URN' => home_office.urn }
       )
     end
     let!(:bobs_charity_order_entry) do
       FactoryBot.create(
-        :validated_submission_entry,
+        :validated_order_submission_entry,
         submission: submission,
-        source: { sheet: 'OrdersReceived', row: 1 },
         data: { 'Total Cost (ex VAT)' => '1200.00', 'Customer URN' => bobs_charity.urn }
       )
     end
@@ -107,9 +102,8 @@ RSpec.describe Export::CodaFinanceReport::Row do
 
     it 'handles sales amounts written as a human-readable number' do
       FactoryBot.create(
-        :validated_submission_entry,
+        :validated_invoice_submission_entry,
         submission: submission,
-        source: { sheet: 'InvoicesRaised', row: 3 },
         data: { 'Total Cost (ex VAT)' => ' 2,428.95 ', 'Customer URN' => health_dept.urn }
       )
       expect(cg_report_row.data['Inf Sales']).to eq '3659.40'

--- a/spec/models/export/coda_finance_report_spec.rb
+++ b/spec/models/export/coda_finance_report_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe Export::CodaFinanceReport do
   end
   let(:submission_entry_1) do
     FactoryBot.build(
-      :validated_submission_entry,
+      :validated_invoice_submission_entry,
       data: { 'Total Cost (ex VAT)' => '678.55', 'Customer URN' => home_office.urn },
       source: { sheet: 'InvoicesRaised', row: 1 }
     )
   end
   let(:submission_entry_2) do
     FactoryBot.build(
-      :validated_submission_entry,
+      :validated_invoice_submission_entry,
       data: { 'Total Cost (ex VAT)' => '123.45', 'Customer URN' => home_office.urn },
       source: { sheet: 'InvoicesRaised', row: 2 }
     )


### PR DESCRIPTION
We have frameworks landing shortly that will use different names for their worksheets (e.g. "Invoices" instead of "InvoicesRaised"). This updates the finance report so it identifies invoice entries via their
type, rather than the sheet name.