### PR TITLE
Release 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [release-8] - 2018-09-13
+
+- Introduce new "validation_failed" state to submissions
+- Added first exporter for data warehouse export: tasks
+- Enhanced submission entries to make identifying their type easier
+
 ## [release-7] - 2018-08-23
 
 - Added script to generate tasks for September 2018


### PR DESCRIPTION
- Introduce new "validation_failed" state to submissions
- Added first exporter for data warehouse export: tasks
- Enhanced submission entries to make identifying their type easier

Note the following data migration will need to be run once the code ships:

```rails runner db/data_migrate/20180822120600_update_submission_statuses.rb```