### PR TITLE
Add and expose Submission#purchase_order_number

### DIFF
--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -8,14 +8,12 @@ class V1::SubmissionsController < ApplicationController
   end
 
   def create
-    task = Task.find(create_submission_params[:task_id])
-    framework = task.framework
-    supplier = task.supplier
+    task = Task.find(params.dig(:submission, :task_id))
 
-    submission = Submission.new(
-      task: task,
-      framework: framework,
-      supplier: supplier
+    submission = task.submissions.new(
+      framework: task.framework,
+      supplier: task.supplier,
+      purchase_order_number: params.dig(:submission, :purchase_order_number)
     )
 
     if submission.save
@@ -52,10 +50,6 @@ class V1::SubmissionsController < ApplicationController
 
   def complete_submission!(submission)
     SubmissionCompletion.new(submission).perform!
-  end
-
-  def create_submission_params
-    params.require(:submission).permit(:task_id)
   end
 
   def update_submission_params

--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -37,14 +37,6 @@ class V1::SubmissionsController < ApplicationController
     end
   end
 
-  def calculate
-    submission = Submission.find(params[:id])
-    # Trigger lambda invocation
-    AWSLambdaService.new(submission_id: submission.id).trigger
-
-    head :no_content
-  end
-
   def complete
     submission = Submission.find(params[:id])
     complete_submission!(submission)

--- a/app/deserializable/deserializable_submission.rb
+++ b/app/deserializable/deserializable_submission.rb
@@ -1,3 +1,4 @@
 class DeserializableSubmission < JSONAPI::Deserializable::Resource
   attribute :task_id
+  attribute :purchase_order_number
 end

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -7,8 +7,8 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
   has_many :files
 
   attributes :framework_id, :supplier_id, :task_id
-
   attribute :levy
+  attribute :purchase_order_number
 
   attribute :status do
     @object.aasm.current_state

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
     resources :agreements, only: %i[create]
     resources :submissions, only: %i[show create update] do
       member do
-        post 'calculate', to: 'submissions#calculate'
         post 'complete', to: 'submissions#complete'
       end
 

--- a/db/migrate/20180912152515_add_purchase_order_number_to_submissions.rb
+++ b/db/migrate/20180912152515_add_purchase_order_number_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddPurchaseOrderNumberToSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submissions, :purchase_order_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_11_160120) do
+ActiveRecord::Schema.define(version: 2018_09_12_152515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(version: 2018_09_11_160120) do
     t.uuid "task_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "purchase_order_number"
     t.index ["aasm_state"], name: "index_submissions_on_aasm_state"
     t.index ["framework_id"], name: "index_submissions_on_framework_id"
     t.index ["supplier_id"], name: "index_submissions_on_supplier_id"

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe '/v1' do
         data: {
           type: 'submissions',
           attributes: {
-            task_id: task.id
+            task_id: task.id,
+            purchase_order_number: 'INV-123'
           }
         }
       }
@@ -88,6 +89,7 @@ RSpec.describe '/v1' do
       expect(json['data']).to have_attribute(:framework_id).with_value(framework.id)
       expect(json['data']).to have_attribute(:supplier_id).with_value(supplier.id)
       expect(json['data']).to have_attribute(:task_id).with_value(task.id)
+      expect(json['data']).to have_attribute(:purchase_order_number).with_value('INV-123')
     end
   end
 

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -151,16 +151,6 @@ RSpec.describe '/v1' do
     end
   end
 
-  describe 'GET /submissions/:submission_id/calculate' do
-    it 'invokes the calculate lambda function successfully' do
-      submission = FactoryBot.create(:submission)
-
-      post "/v1/submissions/#{submission.id}/calculate", params: {}, headers: json_headers
-
-      expect(response).to have_http_status(:no_content)
-    end
-  end
-
   describe 'POST /submissions/:submission_id/complete' do
     context 'given a valid submission' do
       it 'marks the submission as complete' do


### PR DESCRIPTION
Suppliers will often need their invoices to include a purchase order number befoer they can process them. This will be set at the point submissions are created.