### PR TITLE
Expose submission entry summaries to frontend

### DIFF
--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -13,4 +13,12 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
   attribute :status do
     @object.aasm.current_state
   end
+
+  attribute :invoice_count do
+    @object.entries.invoices.count
+  end
+
+  attribute :order_count do
+    @object.entries.orders.count
+  end
 end

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -9,6 +9,16 @@ FactoryBot.define do
       association :task, status: 'completed'
     end
 
+    transient do
+      invoice_entries { 0 }
+      order_entries { 0 }
+    end
+
+    after(:create) do |submission, evaluator|
+      create_list(:invoice_entry, evaluator.invoice_entries, submission: submission)
+      create_list(:order_entry, evaluator.order_entries, submission: submission)
+    end
+
     factory :submission_with_pending_entries do
       after(:create) do |submission, _evaluator|
         create_list(:invoice_entry, 2, submission: submission)

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -11,13 +11,15 @@ FactoryBot.define do
 
     factory :submission_with_pending_entries do
       after(:create) do |submission, _evaluator|
-        create_list(:submission_entry, 3, submission: submission)
+        create_list(:invoice_entry, 2, submission: submission)
+        create_list(:order_entry, 1, submission: submission)
       end
     end
 
     factory :submission_with_validated_entries do
       after(:create) do |submission, _evaluator|
-        create_list(:validated_submission_entry, 3, submission: submission)
+        create_list(:invoice_entry, 2, :valid, submission: submission)
+        create_list(:order_entry, 1, :valid, submission: submission)
       end
     end
 
@@ -25,8 +27,8 @@ FactoryBot.define do
       aasm_state :validation_failed
 
       after(:create) do |submission, _evaluator|
-        create_list(:validated_submission_entry, 2, submission: submission)
-        create_list(:errored_submission_entry, 1, submission: submission)
+        create_list(:invoice_entry, 2, :valid, submission: submission)
+        create_list(:invoice_entry, 1, :errored, submission: submission)
       end
     end
 
@@ -34,8 +36,8 @@ FactoryBot.define do
       aasm_state :processing
 
       after(:create) do |submission, _evaluator|
-        create_list(:validated_submission_entry, 2, submission: submission)
-        create_list(:submission_entry, 1, submission: submission)
+        create_list(:invoice_entry, 2, :valid, submission: submission)
+        create_list(:invoice_entry, 1, submission: submission)
       end
     end
   end

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :submission_entry do
     submission
-    submission_file
     data(test_key: 'some data')
 
     trait :invoice do

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -3,30 +3,22 @@ FactoryBot.define do
     submission
     data(test_key: 'some data')
 
-    trait :invoice do
+    factory :invoice_entry do
       entry_type 'invoice'
       source(sheet: 'InvoicesRaised', row: 1)
     end
 
-    trait :order do
+    factory :order_entry do
       entry_type 'order'
       source(sheet: 'OrdersReceived', row: 1)
     end
 
-    factory :validated_submission_entry do
+    trait :valid do
       aasm_state :validated
     end
 
-    factory :errored_submission_entry do
+    trait :errored do
       aasm_state :errored
-    end
-
-    factory :validated_invoice_submission_entry, parent: :validated_submission_entry do
-      invoice
-    end
-
-    factory :validated_order_submission_entry, parent: :validated_submission_entry do
-      order
     end
   end
 end

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -5,12 +5,12 @@ FactoryBot.define do
 
     trait :invoice do
       entry_type 'invoice'
-      source(sheet: 'InvoicesReceived', row: 1)
+      source(sheet: 'InvoicesRaised', row: 1)
     end
 
     trait :order do
       entry_type 'order'
-      source(sheet: 'OrdersRaised', row: 1)
+      source(sheet: 'OrdersReceived', row: 1)
     end
 
     factory :validated_submission_entry do

--- a/spec/models/export/coda_finance_report/row_spec.rb
+++ b/spec/models/export/coda_finance_report/row_spec.rb
@@ -56,35 +56,40 @@ RSpec.describe Export::CodaFinanceReport::Row do
 
     let!(:home_office_invoice_entry) do
       FactoryBot.create(
-        :validated_invoice_submission_entry,
+        :invoice_entry,
+        :valid,
         submission: submission,
         data: { 'Total Cost (ex VAT)' => '801.50', 'Customer URN' => home_office.urn }
       )
     end
     let!(:health_dept_invoice_entry) do
       FactoryBot.create(
-        :validated_invoice_submission_entry,
+        :invoice_entry,
+        :valid,
         submission: submission,
         data: { 'Total Cost (ex VAT)' => '428.95', 'Customer URN' => health_dept.urn }
       )
     end
     let!(:bobs_charity_invoice_entry) do
       FactoryBot.create(
-        :validated_invoice_submission_entry,
+        :invoice_entry,
+        :valid,
         submission: submission,
         data: { 'Total Cost (ex VAT)' => '-428.95', 'Customer URN' => bobs_charity.urn }
       )
     end
     let!(:home_office_order_entry) do
       FactoryBot.create(
-        :validated_order_submission_entry,
+        :order_entry,
+        :valid,
         submission: submission,
         data: { 'Total Cost (ex VAT)' => '1000.00', 'Customer URN' => home_office.urn }
       )
     end
     let!(:bobs_charity_order_entry) do
       FactoryBot.create(
-        :validated_order_submission_entry,
+        :order_entry,
+        :valid,
         submission: submission,
         data: { 'Total Cost (ex VAT)' => '1200.00', 'Customer URN' => bobs_charity.urn }
       )
@@ -102,7 +107,8 @@ RSpec.describe Export::CodaFinanceReport::Row do
 
     it 'handles sales amounts written as a human-readable number' do
       FactoryBot.create(
-        :validated_invoice_submission_entry,
+        :invoice_entry,
+        :valid,
         submission: submission,
         data: { 'Total Cost (ex VAT)' => ' 2,428.95 ', 'Customer URN' => health_dept.urn }
       )

--- a/spec/models/export/coda_finance_report_spec.rb
+++ b/spec/models/export/coda_finance_report_spec.rb
@@ -26,16 +26,12 @@ RSpec.describe Export::CodaFinanceReport do
   end
   let(:submission_entry_1) do
     FactoryBot.build(
-      :validated_invoice_submission_entry,
-      data: { 'Total Cost (ex VAT)' => '678.55', 'Customer URN' => home_office.urn },
-      source: { sheet: 'InvoicesRaised', row: 1 }
+      :invoice_entry, :valid, data: { 'Total Cost (ex VAT)' => '678.55', 'Customer URN' => home_office.urn }
     )
   end
   let(:submission_entry_2) do
     FactoryBot.build(
-      :validated_invoice_submission_entry,
-      data: { 'Total Cost (ex VAT)' => '123.45', 'Customer URN' => home_office.urn },
-      source: { sheet: 'InvoicesRaised', row: 2 }
+      :invoice_entry, :valid, data: { 'Total Cost (ex VAT)' => '123.45', 'Customer URN' => home_office.urn },
     )
   end
 

--- a/spec/models/submission_status_update_spec.rb
+++ b/spec/models/submission_status_update_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SubmissionStatusUpdate do
       context 'with some "pending" entries and some "errored" entries' do
         let(:submission) do
           FactoryBot.create(:submission_with_pending_entries, aasm_state: :processing).tap do |submission|
-            create(:errored_submission_entry, submission: submission)
+            create(:invoice_entry, :errored, submission: submission)
           end
         end
 

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe '/v1' do
           attributes: {
             entry_type: 'invoice',
             source: {
-              sheet: 'InvoicesReceived',
+              sheet: 'InvoicesRaised',
               row: 42
             },
             data: {
@@ -33,7 +33,7 @@ RSpec.describe '/v1' do
       expect(json['data']).to have_attribute(:submission_file_id).with_value(file.id)
       expect(json['data']).to have_attribute(:submission_id).with_value(file.submission.id)
 
-      expect(json.dig('data', 'attributes', 'source', 'sheet')).to eql 'InvoicesReceived'
+      expect(json.dig('data', 'attributes', 'source', 'sheet')).to eql 'InvoicesRaised'
       expect(json.dig('data', 'attributes', 'source', 'row')).to eql 42
       expect(json.dig('data', 'attributes', 'data', 'test')).to eql 'test'
     end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe '/v1' do
           type: 'submission_entries',
           attributes: {
             source: {
-              sheet: 'InvoicesReceived',
+              sheet: 'InvoicesRaised',
               row: 42
             },
             data: {
@@ -147,7 +147,7 @@ RSpec.describe '/v1' do
       expect(json['data']).to have_attribute(:submission_id).with_value(submission.id)
       expect(json['data']).to have_attribute(:submission_file_id).with_value(nil)
 
-      expect(json.dig('data', 'attributes', 'source', 'sheet')).to eql 'InvoicesReceived'
+      expect(json.dig('data', 'attributes', 'source', 'sheet')).to eql 'InvoicesRaised'
       expect(json.dig('data', 'attributes', 'source', 'row')).to eql 42
       expect(json.dig('data', 'attributes', 'data', 'test')).to eql 'test'
     end

--- a/spec/serializable/serializable_submission_spec.rb
+++ b/spec/serializable/serializable_submission_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe SerializableSubmission do
+  context 'given a submission with invoices and orders' do
+    let(:submission) { FactoryBot.create(:submission, invoice_entries: 2, order_entries: 3) }
+    let(:serialized_submission) { SerializableSubmission.new(object: submission) }
+
+    it 'exposes a count of the number of invoice entries' do
+      expect(serialized_submission.as_jsonapi[:attributes][:invoice_count]).to eq(2)
+    end
+
+    it 'exposes a count of the number of order entries' do
+      expect(serialized_submission.as_jsonapi[:attributes][:order_count]).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
So that the frontend can display a summary of the submission entries without having to load all the entries so it can count them, we are exposing counts of invoices and orders.

This PR starts with some commits that refactor the factories to more closely model our understanding of the domain as it stands today.

Related PR for the frontend: https://github.com/dxw/DataSubmissionService/pull/83