### PR TITLE
Rename levy column to management_charge

### DIFF
--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -25,7 +25,7 @@ class V1::SubmissionsController < ApplicationController
 
   def update
     submission = Submission.find(params[:id])
-    submission.levy = update_submission_params[:levy] * 100
+    submission.management_charge = params.dig(:submission, :management_charge) * 100
     submission.ready_for_review!
 
     if submission.save
@@ -50,9 +50,5 @@ class V1::SubmissionsController < ApplicationController
 
   def complete_submission!(submission)
     SubmissionCompletion.new(submission).perform!
-  end
-
-  def update_submission_params
-    params.require(:submission).permit(:levy)
   end
 end

--- a/app/models/submission_status_update.rb
+++ b/app/models/submission_status_update.rb
@@ -8,7 +8,7 @@ class SubmissionStatusUpdate
   def perform!
     return unless submission.entries.any?
 
-    trigger_levy_calculation if all_entries_valid?
+    trigger_management_charge_calculation if all_entries_valid?
     transition_to_in_review if no_entries_pending? && some_entries_errored?
   end
 
@@ -30,7 +30,7 @@ class SubmissionStatusUpdate
     submission.entries.errored.any?
   end
 
-  def trigger_levy_calculation
+  def trigger_management_charge_calculation
     AWSLambdaService.new(submission_id: submission.id).trigger
   end
 end

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -7,7 +7,7 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
   has_many :files
 
   attributes :framework_id, :supplier_id, :task_id
-  attribute :levy
+  attribute :management_charge
   attribute :purchase_order_number
 
   attribute :status do

--- a/db/migrate/20180917160328_rename_levy_to_management_charge.rb
+++ b/db/migrate/20180917160328_rename_levy_to_management_charge.rb
@@ -1,0 +1,5 @@
+class RenameLevyToManagementCharge < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :submissions, :levy, :management_charge
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_12_152515) do
+ActiveRecord::Schema.define(version: 2018_09_17_160328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 2018_09_12_152515) do
   create_table "submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "framework_id", null: false
     t.uuid "supplier_id", null: false
-    t.integer "levy"
+    t.integer "management_charge"
     t.string "aasm_state"
     t.uuid "task_id"
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,7 +57,7 @@ task_in_review = Task.find_or_create_by!(
   period_year: Date.today.year,
   description: 'In review task (validated submission)'
 )
-valid_submission = supplier.submissions.find_or_create_by!(framework: framework_valid, task: task_in_review, aasm_state: "in_review", levy: 3000)
+valid_submission = supplier.submissions.find_or_create_by!(framework: framework_valid, task: task_in_review, aasm_state: "in_review", management_charge: 3000)
 submission_file = valid_submission.files.find_or_create_by!(rows: 2)
 valid_submission.entries.find_or_create_by!(submission_file: submission_file, aasm_state: "validated", data: { key: "value" }, entry_type: 'invoice', source: { sheet: "InvoicesRaised", row: 1 })
 valid_submission.entries.find_or_create_by!(submission_file: submission_file, aasm_state: "validated", data: { key: "another value" }, entry_type: 'invoice', source: { sheet: "InvoicesRaised", row: 2 })

--- a/spec/models/submission_status_update_spec.rb
+++ b/spec/models/submission_status_update_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SubmissionStatusUpdate do
           expect(submission).to be_processing
         end
 
-        it 'does not trigger a levy calculation' do
+        it 'does not trigger a management charge calculation' do
           expect(aws_lambda_service_double).not_to receive(:trigger)
 
           submission_status_check.perform!
@@ -35,7 +35,7 @@ RSpec.describe SubmissionStatusUpdate do
           expect(submission).to be_processing
         end
 
-        it 'triggers a levy calculation' do
+        it 'triggers a management charge calculation' do
           expect(aws_lambda_service_double).to receive(:trigger)
 
           submission_status_check.perform!
@@ -55,7 +55,7 @@ RSpec.describe SubmissionStatusUpdate do
           expect(submission).to be_processing
         end
 
-        it 'does not trigger a levy calculation' do
+        it 'does not trigger a management charge calculation' do
           expect(aws_lambda_service_double).not_to receive(:trigger)
 
           submission_status_check.perform!
@@ -71,7 +71,7 @@ RSpec.describe SubmissionStatusUpdate do
           expect(submission).to be_validation_failed
         end
 
-        it 'does not trigger a levy calculation' do
+        it 'does not trigger a management charge calculation' do
           expect(aws_lambda_service_double).not_to receive(:trigger)
 
           submission_status_check.perform!

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe '/v1' do
         data: {
           type: 'submissions',
           attributes: {
-            levy: 42.50
+            management_charge: 42.50
           }
         }
       }
@@ -112,7 +112,7 @@ RSpec.describe '/v1' do
 
       submission.reload
 
-      expect(submission.levy).to eql 4250
+      expect(submission.management_charge).to eql 4250
       expect(submission).to be_in_review
     end
   end


### PR DESCRIPTION
The "levy" term is deprecated, with "management charge" being the
correct term to describe the charge.

Note that because we are between submission periods and are not expecting any submissions until next month, we can roll this out as a single release and update the calculate lambda in our own good time without having to worry about requests being made against the API using the wrong parameter names.

Corresponding change to calculation lambda: https://github.com/dxw/DataSubmissionServiceTerraform/pull/78