### PR TITLE
Feature/385 export the invoices

### DIFF
--- a/app/models/export/coda_finance_report.rb
+++ b/app/models/export/coda_finance_report.rb
@@ -3,10 +3,8 @@ require 'csv'
 module Export
   # Used to generate reports summarising submissions in the format needed for
   # feeding into Coda, the CCS finance system.
-  class CodaFinanceReport
-    attr_reader :submissions, :output
-
-    HEADERS = [
+  class CodaFinanceReport < ToIO
+    HEADER = [
       'RunID',
       'Nominal',
       'Customer Code',
@@ -23,48 +21,9 @@ module Export
       'M_Q'
     ].freeze
 
-    def initialize(submissions, output)
-      @submissions = submissions
-      @output = output
-    end
-
-    def run
-      output.puts CSV.generate_line(HEADERS)
-      submissions.each do |submission|
-        output.puts(CSV.generate_line(row_for_submission(submission, Customer.sectors[:central_government])))
-        output.puts(CSV.generate_line(row_for_submission(submission, Customer.sectors[:wider_public_sector])))
-      end
-    end
-
-    private
-
-    def row_for_submission(submission, sector)
-      data = Row.new(submission, sector).data
-
-      [
-        data['RunID'],
-        data['Nominal'],
-        data['Customer Code'],
-        data['Customer Name'],
-        data['Contract ID'],
-        data['Order Number'],
-        data['Lot Description'],
-        data['Inf Sales'],
-        data['Commission'],
-        data['Commission %'],
-        data['End User'],
-        data['Submitter'],
-        data['Month'],
-        monthly_or_quarterly
-      ]
-    end
-
-    # Used to indicate if the data in the report is for monthly or quarterly
-    # submissions. In reality, only monthly submissions are supported by both
-    # the legacy and the new system and quarterly frameworks (of which there is
-    # one?) is handled manually by CCS.
-    def monthly_or_quarterly
-      'M'
+    def output_row(submission)
+      output.puts(Row.new(submission, Customer.sectors[:central_government]).to_csv_line)
+      output.puts(Row.new(submission, Customer.sectors[:wider_public_sector]).to_csv_line)
     end
   end
 end

--- a/app/models/export/coda_finance_report/row.rb
+++ b/app/models/export/coda_finance_report/row.rb
@@ -1,47 +1,91 @@
 module Export
   class CodaFinanceReport
-    class Row
-      attr_reader :sector, :submission
+    class Row < Export::CsvRow
+      alias_method :submission, :model
+
+      attr_reader :sector
 
       def initialize(submission, sector)
-        @submission = submission
+        super(submission)
         @sector = sector
       end
 
-      delegate :id, to: :submission, prefix: true
-      delegate :coda_reference, :name, to: :supplier, prefix: true
-      delegate :coda_reference, :name, :short_name, to: :framework, prefix: true
+      def row_values
+        [
+          run_id,
+          nominal,
+          customer_code,
+          customer_name,
+          contract_id,
+          order_number,
+          lot_description,
+          inf_sales,
+          commission,
+          commission_percent,
+          end_user,
+          submitter,
+          month,
+          m_q
+        ]
+      end
 
-      def data
-        @data ||= {
-          'RunID' => submission_id,
-          'Nominal' => framework_coda_reference,
-          'Contract ID' => framework_short_name,
-          'Lot Description' => framework_name,
-          'Customer Code' => supplier_coda_reference,
-          'Customer Name' => supplier_name,
-          'Submitter' => supplier_name,
-          'Month' => task_period,
-          'End User' => sector_identifier,
-          'Inf Sales' => format_money(total_sales),
-          'Commission' => format_money(management_charge),
-          'Commission %' => format_percentage(management_charge_rate)
-        }
+      def run_id
+        submission.id
+      end
+
+      def nominal
+        framework.coda_reference
+      end
+
+      def customer_code
+        supplier.coda_reference
+      end
+
+      def customer_name
+        supplier.name
+      end
+
+      def contract_id
+        framework.short_name
+      end
+
+      def order_number
+        BLANK_FOR_NOW
+      end
+
+      def lot_description
+        framework.name
+      end
+
+      def inf_sales
+        format_money(total_sales)
+      end
+
+      def commission
+        format_money(management_charge)
+      end
+
+      def commission_percent
+        format_percentage(management_charge_rate)
+      end
+
+      def end_user
+        sector_identifier
+      end
+
+      def submitter
+        supplier.name
+      end
+
+      def month
+        task_period
+      end
+
+      def m_q
+        monthly_or_quarterly
       end
 
       private
-
-      def framework
-        @framework ||= submission.framework
-      end
-
-      def supplier
-        @supplier ||= submission.supplier
-      end
-
-      def task
-        @task ||= submission.task
-      end
 
       def task_period
         Date.new(task.period_year, task.period_month).strftime('%B %Y')
@@ -76,6 +120,26 @@ module Export
 
       def format_percentage(percentage)
         (percentage / 100).to_s
+      end
+
+      # Used to indicate if the data in the report is for monthly or quarterly
+      # submissions. In reality, only monthly submissions are supported by both
+      # the legacy and the new system and quarterly frameworks (of which there is
+      # one?) is handled manually by CCS.
+      def monthly_or_quarterly
+        'M'
+      end
+
+      def framework
+        @framework ||= submission.framework
+      end
+
+      def supplier
+        @supplier ||= submission.supplier
+      end
+
+      def task
+        @task ||= submission.task
       end
     end
   end

--- a/app/models/export/csv_row.rb
+++ b/app/models/export/csv_row.rb
@@ -1,7 +1,8 @@
 module Export
   class CsvRow
-    MISSING = '#MISSING'.freeze # fields that are needed for MVP that we don't have yet
-    BLANK_FOR_NOW = nil         # things that can be blank for MVP
+    MISSING = '#MISSING'.freeze       # fields that are needed for MVP that we don't have yet
+    NOT_IN_DATA = '#NOTINDATA'.freeze # fields that we looked for in the JSONB data and could not find
+    BLANK_FOR_NOW = nil               # things that can be blank for MVP
 
     attr_reader :model
 

--- a/app/models/export/csv_row.rb
+++ b/app/models/export/csv_row.rb
@@ -1,6 +1,7 @@
 module Export
   class CsvRow
     MISSING = '#MISSING'.freeze # fields that are needed for MVP that we don't have yet
+    BLANK_FOR_NOW = nil         # things that can be blank for MVP
 
     attr_reader :model
 

--- a/app/models/export/csv_row.rb
+++ b/app/models/export/csv_row.rb
@@ -1,0 +1,15 @@
+module Export
+  class CsvRow
+    MISSING = '#MISSING'.freeze # fields that are needed for MVP that we don't have yet
+
+    attr_reader :model
+
+    def initialize(model)
+      @model = model
+    end
+
+    def to_csv_line
+      CSV.generate_line(row_values)
+    end
+  end
+end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -20,6 +20,7 @@ module Export
       UnitType
       UnitPrice
       UnitQuantity
+      InvoiceValue
     ].freeze
   end
 end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -7,6 +7,8 @@ module Export
       CustomerURN
       CustomerName
       CustomerPostcode
+      InvoiceDate
+      InvoiceNumber
     ].freeze
 
     attr_reader :invoices, :output

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -4,6 +4,9 @@ module Export
   class Invoices
     HEADER = %w[
       SubmissionID
+      CustomerURN
+      CustomerName
+      CustomerPostcode
     ].freeze
 
     attr_reader :invoices, :output

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -3,7 +3,7 @@ require 'csv'
 module Export
   class Invoices
     HEADER = %w[
-      Foo
+      SubmissionID
     ].freeze
 
     attr_reader :invoices, :output

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -23,6 +23,7 @@ module Export
       InvoiceValue
       Expenses
       VATCharged
+      PromotionCode
     ].freeze
   end
 end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -9,6 +9,8 @@ module Export
       CustomerPostcode
       InvoiceDate
       InvoiceNumber
+      SupplierReferenceNumber
+      CustomerReferenceNumber
     ].freeze
   end
 end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -17,6 +17,9 @@ module Export
       ProductClass
       ProductSubClass
       ProductCode
+      UnitType
+      UnitPrice
+      UnitQuantity
     ].freeze
   end
 end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -24,6 +24,14 @@ module Export
       Expenses
       VATCharged
       PromotionCode
+      Additional1
+      Additional2
+      Additional3
+      Additional4
+      Additional5
+      Additional6
+      Additional7
+      Additional8
     ].freeze
   end
 end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -1,0 +1,23 @@
+require 'csv'
+
+module Export
+  class Invoices
+    HEADER = %w[
+      Foo
+    ].freeze
+
+    attr_reader :invoices, :output
+
+    def initialize(invoices, output)
+      @invoices = invoices
+      @output = output
+    end
+
+    def run
+      output.puts(CSV.generate_line(HEADER))
+      invoices.each do |invoice|
+        output.puts(Row.new(invoice).to_csv_line)
+      end
+    end
+  end
+end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -21,6 +21,7 @@ module Export
       UnitPrice
       UnitQuantity
       InvoiceValue
+      Expenses
     ].freeze
   end
 end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -22,6 +22,7 @@ module Export
       UnitQuantity
       InvoiceValue
       Expenses
+      VATCharged
     ].freeze
   end
 end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -11,6 +11,7 @@ module Export
       InvoiceNumber
       SupplierReferenceNumber
       CustomerReferenceNumber
+      LotNumber
     ].freeze
   end
 end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -1,7 +1,7 @@
 require 'csv'
 
 module Export
-  class Invoices
+  class Invoices < ToIO
     HEADER = %w[
       SubmissionID
       CustomerURN
@@ -10,19 +10,5 @@ module Export
       InvoiceDate
       InvoiceNumber
     ].freeze
-
-    attr_reader :invoices, :output
-
-    def initialize(invoices, output)
-      @invoices = invoices
-      @output = output
-    end
-
-    def run
-      output.puts(CSV.generate_line(HEADER))
-      invoices.each do |invoice|
-        output.puts(Row.new(invoice).to_csv_line)
-      end
-    end
   end
 end

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -12,6 +12,11 @@ module Export
       SupplierReferenceNumber
       CustomerReferenceNumber
       LotNumber
+      ProductDescription
+      ProductGroup
+      ProductClass
+      ProductSubClass
+      ProductCode
     ].freeze
   end
 end

--- a/app/models/export/invoices/extract.rb
+++ b/app/models/export/invoices/extract.rb
@@ -1,0 +1,9 @@
+module Export
+  class Invoices
+    module Extract
+      def self.all_relevant
+        Invoice.all
+      end
+    end
+  end
+end

--- a/app/models/export/invoices/extract.rb
+++ b/app/models/export/invoices/extract.rb
@@ -11,4 +11,3 @@ module Export
     end
   end
 end
-

--- a/app/models/export/invoices/extract.rb
+++ b/app/models/export/invoices/extract.rb
@@ -2,8 +2,13 @@ module Export
   class Invoices
     module Extract
       def self.all_relevant
-        Invoice.all
+        SubmissionEntry.invoices
+                       .select('submission_entries.*, frameworks.short_name AS _framework_short_name')
+                       .joins(submission: :framework)
+                       .merge(Submission.completed)
+                       .order(:created_at)
       end
     end
   end
 end
+

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -1,6 +1,8 @@
 module Export
   class Invoices
     class Row
+      MISSING = '#MISSING'.freeze
+
       attr_reader :invoice
 
       def initialize(invoice)
@@ -10,7 +12,22 @@ module Export
       def row_values
         [
           invoice.submission_id,
+          customer_urn,
+          customer_name,
+          customer_postcode
         ]
+      end
+
+      def customer_urn
+        MISSING
+      end
+
+      def customer_name
+        MISSING
+      end
+
+      def customer_postcode
+        MISSING
       end
 
       def to_csv_line

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -22,6 +22,7 @@ module Export
           unit_type,
           unit_price,
           unit_quantity,
+          invoice_value
         ]
       end
 
@@ -87,6 +88,10 @@ module Export
 
       def unit_quantity
         value_for('UnitQuantity')
+      end
+
+      def invoice_value
+        value_for('InvoiceValue')
       end
 
       private

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -108,7 +108,7 @@ module Export
       end
 
       def expenses
-        MISSING
+        value_for('Expenses', default: nil)
       end
 
       def vat_charged

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -23,7 +23,8 @@ module Export
           unit_price,
           unit_quantity,
           invoice_value,
-          expenses
+          expenses,
+          vat_charged
         ]
       end
 
@@ -97,6 +98,10 @@ module Export
 
       def expenses
         MISSING
+      end
+
+      def vat_charged
+        value_for('VATCharged')
       end
 
       private

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -3,6 +3,7 @@ module Export
     class Row < Export::CsvRow
       alias_method :invoice, :model
 
+      # rubocop:disable Metrics/AbcSize
       def row_values
         [
           invoice.submission_id,
@@ -25,9 +26,18 @@ module Export
           invoice_value,
           expenses,
           vat_charged,
-          promotion_code
+          promotion_code,
+          additional1,
+          additional2,
+          additional3,
+          additional4,
+          additional5,
+          additional6,
+          additional7,
+          additional8,
         ]
       end
+      # rubocop:enable Metrics/AbcSize
 
       def customer_urn
         value_for('CustomerURN')
@@ -107,6 +117,12 @@ module Export
 
       def promotion_code
         value_for('PromotionCode', default: nil)
+      end
+
+      (1..8).each do |n|
+        define_method "additional#{n}" do
+          value_for("Additional#{n}", default: nil)
+        end
       end
 
       private

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -24,7 +24,8 @@ module Export
           unit_quantity,
           invoice_value,
           expenses,
-          vat_charged
+          vat_charged,
+          promotion_code
         ]
       end
 
@@ -102,6 +103,10 @@ module Export
 
       def vat_charged
         value_for('VATCharged')
+      end
+
+      def promotion_code
+        value_for('PromotionCode', default: nil)
       end
 
       private

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -1,13 +1,7 @@
 module Export
   class Invoices
-    class Row
-      MISSING = '#MISSING'.freeze
-
-      attr_reader :invoice
-
-      def initialize(invoice)
-        @invoice = invoice
-      end
+    class Row < Export::CsvRow
+      alias_method :invoice, :model
 
       def row_values
         [
@@ -38,10 +32,6 @@ module Export
 
       def invoice_number
         MISSING
-      end
-
-      def to_csv_line
-        CSV.generate_line(row_values)
       end
     end
   end

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -14,7 +14,9 @@ module Export
           invoice.submission_id,
           customer_urn,
           customer_name,
-          customer_postcode
+          customer_postcode,
+          invoice_date,
+          invoice_number
         ]
       end
 
@@ -27,6 +29,14 @@ module Export
       end
 
       def customer_postcode
+        MISSING
+      end
+
+      def invoice_date
+        MISSING
+      end
+
+      def invoice_number
         MISSING
       end
 

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -15,23 +15,33 @@ module Export
       end
 
       def customer_urn
-        invoice.data['Customer URN'] || NOT_IN_DATA
+        value_for('CustomerURN')
       end
 
       def customer_name
-        invoice.data['Customer Organisation Name'] || NOT_IN_DATA
+        value_for('CustomerName')
       end
 
       def customer_postcode
-        invoice.data['Customer Post Code'] || NOT_IN_DATA
+        value_for('CustomerPostCode')
       end
 
       def invoice_date
-        invoice.data['Customer Invoice Date'] || NOT_IN_DATA
+        value_for('InvoiceDate')
       end
 
       def invoice_number
-        invoice.data['Customer Invoice Number'] || NOT_IN_DATA
+        value_for('InvoiceNumber')
+      end
+
+      private
+
+      def value_for(destination_field, default: NOT_IN_DATA)
+        source_field = Export::Template.source_field_for(
+          destination_field,
+          invoice._framework_short_name
+        )
+        invoice.data.fetch(source_field, default)
       end
     end
   end

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -12,7 +12,8 @@ module Export
           invoice_date,
           invoice_number,
           supplier_reference_number,
-          customer_reference_number
+          customer_reference_number,
+          lot_number
         ]
       end
 
@@ -42,6 +43,10 @@ module Export
 
       def customer_reference_number
         nil
+      end
+
+      def lot_number
+        value_for('LotNumber')
       end
 
       private

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -10,7 +10,9 @@ module Export
           customer_name,
           customer_postcode,
           invoice_date,
-          invoice_number
+          invoice_number,
+          supplier_reference_number,
+          customer_reference_number
         ]
       end
 
@@ -32,6 +34,14 @@ module Export
 
       def invoice_number
         value_for('InvoiceNumber')
+      end
+
+      def supplier_reference_number
+        value_for('SupplierReferenceNumber')
+      end
+
+      def customer_reference_number
+        nil
       end
 
       private

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -1,0 +1,21 @@
+module Export
+  class Invoices
+    class Row
+      attr_reader :invoice
+
+      def initialize(invoice)
+        @invoice = invoice
+      end
+
+      def row_values
+        [
+          invoice.submission_id,
+        ]
+      end
+
+      def to_csv_line
+        CSV.generate_line(row_values)
+      end
+    end
+  end
+end

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -19,6 +19,9 @@ module Export
           product_class,
           product_subclass,
           product_code,
+          unit_type,
+          unit_price,
+          unit_quantity,
         ]
       end
 
@@ -72,6 +75,18 @@ module Export
 
       def product_code
         MISSING
+      end
+
+      def unit_type
+        value_for('UnitType')
+      end
+
+      def unit_price
+        value_for('UnitPrice')
+      end
+
+      def unit_quantity
+        value_for('UnitQuantity')
       end
 
       private

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -22,7 +22,8 @@ module Export
           unit_type,
           unit_price,
           unit_quantity,
-          invoice_value
+          invoice_value,
+          expenses
         ]
       end
 
@@ -92,6 +93,10 @@ module Export
 
       def invoice_value
         value_for('InvoiceValue')
+      end
+
+      def expenses
+        MISSING
       end
 
       private

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -13,7 +13,12 @@ module Export
           invoice_number,
           supplier_reference_number,
           customer_reference_number,
-          lot_number
+          lot_number,
+          product_description,
+          product_group,
+          product_class,
+          product_subclass,
+          product_code,
         ]
       end
 
@@ -47,6 +52,26 @@ module Export
 
       def lot_number
         value_for('LotNumber')
+      end
+
+      def product_description
+        MISSING
+      end
+
+      def product_group
+        MISSING
+      end
+
+      def product_class
+        MISSING
+      end
+
+      def product_subclass
+        MISSING
+      end
+
+      def product_code
+        MISSING
       end
 
       private

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -72,23 +72,23 @@ module Export
       end
 
       def product_description
-        MISSING
+        value_for('ProductDescription', default: nil)
       end
 
       def product_group
-        MISSING
+        value_for('ProductGroup', default: nil)
       end
 
       def product_class
-        MISSING
+        value_for('ProductClass', default: nil)
       end
 
       def product_subclass
-        MISSING
+        value_for('ProductSubClass', default: nil)
       end
 
       def product_code
-        MISSING
+        value_for('ProductCode', default: nil)
       end
 
       def unit_type

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -15,23 +15,23 @@ module Export
       end
 
       def customer_urn
-        MISSING
+        invoice.data['Customer URN'] || NOT_IN_DATA
       end
 
       def customer_name
-        MISSING
+        invoice.data['Customer Organisation Name'] || NOT_IN_DATA
       end
 
       def customer_postcode
-        MISSING
+        invoice.data['Customer Post Code'] || NOT_IN_DATA
       end
 
       def invoice_date
-        MISSING
+        invoice.data['Customer Invoice Date'] || NOT_IN_DATA
       end
 
       def invoice_number
-        MISSING
+        invoice.data['Customer Invoice Number'] || NOT_IN_DATA
       end
     end
   end

--- a/app/models/export/submissions.rb
+++ b/app/models/export/submissions.rb
@@ -1,7 +1,7 @@
 require 'csv'
 
 module Export
-  class Submissions
+  class Submissions < ToIO
     HEADER = %w[
       TaskID
       SubmissionID
@@ -21,19 +21,5 @@ module Export
       FinanceExportDate
       PONumber
     ].freeze
-
-    attr_reader :submissions, :output
-
-    def initialize(submissions, output)
-      @submissions = submissions
-      @output = output
-    end
-
-    def run
-      output.puts(CSV.generate_line(HEADER))
-      submissions.each do |submission|
-        output.puts(Row.new(submission).to_csv_line)
-      end
-    end
   end
 end

--- a/app/models/export/submissions/row.rb
+++ b/app/models/export/submissions/row.rb
@@ -1,13 +1,7 @@
 module Export
   class Submissions
-    class Row
-      MISSING = '#MISSING'.freeze # fields that are needed for MVP that we don't have yet
-
-      attr_reader :submission
-
-      def initialize(submission)
-        @submission = submission
-      end
+    class Row < Export::CsvRow
+      alias_method :submission, :model
 
       def row_values
         [
@@ -70,10 +64,6 @@ module Export
       def supplier_approved_by; end
 
       def finance_export_date; end
-
-      def to_csv_line
-        CSV.generate_line(row_values)
-      end
 
       def invoice_value
         MISSING

--- a/app/models/export/tasks.rb
+++ b/app/models/export/tasks.rb
@@ -1,7 +1,7 @@
 require 'csv'
 
 module Export
-  class Tasks
+  class Tasks < ToIO
     HEADER = %w[
       TaskID
       Month
@@ -12,19 +12,5 @@ module Export
       StartedDate
       CompletedDate
     ].freeze
-
-    attr_reader :tasks, :output
-
-    def initialize(tasks, output)
-      @tasks = tasks
-      @output = output
-    end
-
-    def run
-      output.puts(CSV.generate_line(HEADER))
-      tasks.each do |task|
-        output.puts(Row.new(task).to_csv_line)
-      end
-    end
   end
 end

--- a/app/models/export/tasks/row.rb
+++ b/app/models/export/tasks/row.rb
@@ -1,15 +1,11 @@
 module Export
   class Tasks
-    class Row
+    class Row < Export::CsvRow
       # Always 1 for now. May be used to indicate different task types in future.
       FIXED_TASK_TYPE = 1
       EMPTY_FOR_NOW = nil
 
-      attr_reader :task
-
-      def initialize(task)
-        @task = task
-      end
+      alias_method :task, :model
 
       def year_and_month
         "#{task.period_year}-#{format('%02d', task.period_month)}"
@@ -26,10 +22,6 @@ module Export
           EMPTY_FOR_NOW,
           EMPTY_FOR_NOW
         ]
-      end
-
-      def to_csv_line
-        CSV.generate_line(row_values)
       end
     end
   end

--- a/app/models/export/template.rb
+++ b/app/models/export/template.rb
@@ -8,7 +8,11 @@ module Export
       'InvoiceDate'             => 'Customer Invoice Date',
       'InvoiceNumber'           => 'Customer Invoice Number',
       'SupplierReferenceNumber' => 'Supplier Reference Number',
-      'LotNumber'               => 'Tier Number'
+      'LotNumber'               => 'Tier Number',
+      # Missing product codes
+      'UnitType'                => 'Unit of Purchase',
+      'UnitPrice'               => 'Price per Unit',
+      'UnitQuantity'            => 'Quantity',
     }.freeze
 
     BY_FRAMEWORK = {

--- a/app/models/export/template.rb
+++ b/app/models/export/template.rb
@@ -1,0 +1,23 @@
+module Export
+  module Template
+    # Mapping direction: destination_field in export => source_field from submission_entries.data
+    LEGAL_FRAMEWORK = {
+      'CustomerURN'      => 'Customer URN',
+      'CustomerName'     => 'Customer Organisation Name',
+      'CustomerPostCode' => 'Customer Post Code',
+      'InvoiceDate'      => 'Customer Invoice Date',
+      'InvoiceNumber'    => 'Customer Invoice Number',
+    }.freeze
+
+    BY_FRAMEWORK = {
+      'RM3786' => LEGAL_FRAMEWORK,
+      'RM3756' => LEGAL_FRAMEWORK,
+      'RM3787' => LEGAL_FRAMEWORK,
+    }.freeze
+
+    def self.source_field_for(dest_field_name, framework_short_name)
+      template_fields = BY_FRAMEWORK.fetch(framework_short_name)
+      template_fields[dest_field_name]
+    end
+  end
+end

--- a/app/models/export/template.rb
+++ b/app/models/export/template.rb
@@ -7,7 +7,8 @@ module Export
       'CustomerPostCode'        => 'Customer Post Code',
       'InvoiceDate'             => 'Customer Invoice Date',
       'InvoiceNumber'           => 'Customer Invoice Number',
-      'SupplierReferenceNumber' => 'Supplier Reference Number'
+      'SupplierReferenceNumber' => 'Supplier Reference Number',
+      'LotNumber'               => 'Tier Number'
     }.freeze
 
     BY_FRAMEWORK = {

--- a/app/models/export/template.rb
+++ b/app/models/export/template.rb
@@ -15,6 +15,12 @@ module Export
       'UnitQuantity'            => 'Quantity',
       'InvoiceValue'            => 'Total Cost (ex VAT)',
       'VATCharged'              => 'VAT Amount Charged',
+      'Additional1'             => 'Matter Name',
+      'Additional2'             => 'Pro-Bono Price per Unit',
+      'Additional3'             => 'Pro-Bono Quantity',
+      'Additional4'             => 'Pro-Bono Total Value',
+      'Additional5'             => 'Sub-Contractor Name (If Applicable)',
+      'Additional6'             => 'Pricing Mechanism',
     }.freeze
 
     BY_FRAMEWORK = {

--- a/app/models/export/template.rb
+++ b/app/models/export/template.rb
@@ -13,7 +13,8 @@ module Export
       'UnitType'                => 'Unit of Purchase',
       'UnitPrice'               => 'Price per Unit',
       'UnitQuantity'            => 'Quantity',
-      'InvoiceValue'            => 'Total Cost (ex VAT)'
+      'InvoiceValue'            => 'Total Cost (ex VAT)',
+      'VATCharged'              => 'VAT Amount Charged',
     }.freeze
 
     BY_FRAMEWORK = {

--- a/app/models/export/template.rb
+++ b/app/models/export/template.rb
@@ -2,11 +2,12 @@ module Export
   module Template
     # Mapping direction: destination_field in export => source_field from submission_entries.data
     LEGAL_FRAMEWORK = {
-      'CustomerURN'      => 'Customer URN',
-      'CustomerName'     => 'Customer Organisation Name',
-      'CustomerPostCode' => 'Customer Post Code',
-      'InvoiceDate'      => 'Customer Invoice Date',
-      'InvoiceNumber'    => 'Customer Invoice Number',
+      'CustomerURN'             => 'Customer URN',
+      'CustomerName'            => 'Customer Organisation Name',
+      'CustomerPostCode'        => 'Customer Post Code',
+      'InvoiceDate'             => 'Customer Invoice Date',
+      'InvoiceNumber'           => 'Customer Invoice Number',
+      'SupplierReferenceNumber' => 'Supplier Reference Number'
     }.freeze
 
     BY_FRAMEWORK = {

--- a/app/models/export/template.rb
+++ b/app/models/export/template.rb
@@ -13,6 +13,7 @@ module Export
       'UnitType'                => 'Unit of Purchase',
       'UnitPrice'               => 'Price per Unit',
       'UnitQuantity'            => 'Quantity',
+      'InvoiceValue'            => 'Total Cost (ex VAT)'
     }.freeze
 
     BY_FRAMEWORK = {

--- a/app/models/export/to_io.rb
+++ b/app/models/export/to_io.rb
@@ -10,8 +10,12 @@ module Export
     def run
       output.puts(CSV.generate_line(self.class::HEADER))
       relation.each do |model|
-        output.puts(self.class::Row.new(model).to_csv_line)
+        output_row(model)
       end
+    end
+
+    def output_row(model)
+      output.puts(self.class::Row.new(model).to_csv_line)
     end
   end
 end

--- a/app/models/export/to_io.rb
+++ b/app/models/export/to_io.rb
@@ -1,0 +1,17 @@
+module Export
+  class ToIO
+    attr_reader :relation, :output
+
+    def initialize(relation, output)
+      @relation = relation
+      @output = output
+    end
+
+    def run
+      output.puts(CSV.generate_line(self.class::HEADER))
+      relation.each do |model|
+        output.puts(self.class::Row.new(model).to_csv_line)
+      end
+    end
+  end
+end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -17,4 +17,13 @@ namespace :export do
       Export::Submissions.new(Export::Submissions::Extract.all_relevant, file).run
     end
   end
+
+  desc 'Export invoice entities to CSV'
+  task invoices: :environment do
+    filename = "/tmp/invoices_#{Time.zone.today}.csv"
+    warn("Exporting invoices to #{filename}")
+    File.open(filename, 'w+') do |file|
+      Export::Invoices.new(Export::Invoices::Extract.all_relevant, file).run
+    end
+  end
 end

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -30,5 +30,34 @@ FactoryBot.define do
       aasm_state :errored
       validation_errors { [{ 'message' => error_message, 'location' => { 'row' => row, 'column' => column } }] }
     end
+
+    trait :legal_framework_data do
+      data do
+        {
+          'UNSPSC' => '80120000',
+          'Quantity' => '-0.9',
+          'Matter Name' => 'GITIS Terms and Conditions',
+          'Tier Number' => '1',
+          'Customer URN' => '10012345',
+          'Service Type' => 'Core',
+          'Price per Unit' => '151.09',
+          'Unit of Purchase' => 'Hourly',
+          'Pricing Mechanism' => 'Time and Material',
+          'Pro-Bono Quantity' => '0.00',
+          'Customer Post Code' => 'SW1P 3ZZ',
+          'Practitioner Grade' => 'Legal Director/Senior Solicitor',
+          'Primary Specialism' => 'Contracts',
+          'VAT Amount Charged' => '-27.20',
+          'Total Cost (ex VAT)' => '-135.98',
+          'Pro-Bono Total Value' => '0.00',
+          'Customer Invoice Date' => '5/31/18',
+          'Customer Invoice Number' => '3307957',
+          'Pro-Bono Price per Unit' => '0.00',
+          'Supplier Reference Number' => 'DEP/0008.00032',
+          'Customer Organisation Name' => 'Department for Education',
+          'Sub-Contractor Name (If Applicable)' => 'N/A'
+        }
+      end
+    end
   end
 end

--- a/spec/lib/tasks/export/invoices_spec.rb
+++ b/spec/lib/tasks/export/invoices_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'rake export:invoices', type: :task do
+  it 'preloads the Rails environment' do
+    expect(task.prerequisites).to include 'environment'
+  end
+
+  context 'no date is given' do
+    let(:invoice_exporter)   { spy('Export::Invoices') }
+    let(:invoices_to_export) { [double('Invoice'), double('Invoice')] }
+    let(:todays_filename)    { "/tmp/invoices_#{Time.zone.today}.csv" }
+
+    after { File.delete(todays_filename) }
+
+    before do
+      allow(Export::Invoices::Extract).to receive(:all_relevant).and_return(invoices_to_export)
+      allow(Export::Invoices).to receive(:new).with(
+        invoices_to_export, duck_type(:puts)
+      ).and_return(
+        invoice_exporter
+      )
+
+      task.execute
+    end
+
+    it 'forwards the request to Export::Invoices#run' do
+      expect(invoice_exporter).to have_received(:run)
+    end
+
+    it 'creates that file' do
+      expect(File).to exist(todays_filename)
+    end
+
+    it 'tells us what file it’s creating on STDERR' do
+      expect { task.execute }.to output(
+        "Exporting invoices to #{todays_filename}\n"
+      ).to_stderr
+    end
+  end
+end

--- a/spec/models/export/coda_finance_report/row_spec.rb
+++ b/spec/models/export/coda_finance_report/row_spec.rb
@@ -9,44 +9,44 @@ RSpec.describe Export::CodaFinanceReport::Row do
   subject(:wps_report_row) { Export::CodaFinanceReport::Row.new(submission, Customer.sectors[:wider_public_sector]) }
 
   it 'reports the submission ID as ‘RunID’' do
-    expect(cg_report_row.data['RunID']).to eq submission.id
+    expect(cg_report_row.run_id).to eq submission.id
   end
 
   it 'reports the framework’s coda_reference as ‘Nominal’' do
-    expect(cg_report_row.data['Nominal']).to eq framework.coda_reference
+    expect(cg_report_row.nominal).to eq framework.coda_reference
   end
 
   it 'reports the framework’ short_name as ‘Contract ID' do
-    expect(cg_report_row.data['Contract ID']).to eq framework.short_name
+    expect(cg_report_row.contract_id).to eq framework.short_name
   end
 
   it 'reports the framework’ name as ‘Lot Description’' do
-    expect(cg_report_row.data['Lot Description']).to eq framework.name
+    expect(cg_report_row.lot_description).to eq framework.name
   end
 
   it 'reports the supplier’s coda_reference as ‘Customer Code’' do
-    expect(cg_report_row.data['Customer Code']).to eq supplier.coda_reference
+    expect(cg_report_row.customer_code).to eq supplier.coda_reference
   end
 
   it 'reports the supplier’s name as ‘Customer Name’' do
-    expect(cg_report_row.data['Customer Name']).to eq supplier.name
+    expect(cg_report_row.customer_name).to eq supplier.name
   end
 
   it 'also reports the supplier’s name as ‘Submitter’ for now as we don’t record the submitting user' do
-    expect(cg_report_row.data['Submitter']).to eq supplier.name
+    expect(cg_report_row.submitter).to eq supplier.name
   end
 
   it 'reports the task’s period in the format "Month YEAR" as ‘Month’' do
-    expect(cg_report_row.data['Month']).to eq 'August 2018'
+    expect(cg_report_row.month).to eq 'August 2018'
   end
 
   it 'reports the management charge rate as ‘Commission %’' do
-    expect(cg_report_row.data['Commission %']).to eq '0.015'
+    expect(cg_report_row.commission_percent).to eq '0.015'
   end
 
   it 'reports the sector as ‘End User’' do
-    expect(cg_report_row.data['End User']).to eq 'UCGV'
-    expect(wps_report_row.data['End User']).to eq 'UWPS'
+    expect(cg_report_row.end_user).to eq 'UCGV'
+    expect(wps_report_row.end_user).to eq 'UWPS'
   end
 
   describe 'the calculations' do
@@ -96,13 +96,13 @@ RSpec.describe Export::CodaFinanceReport::Row do
     end
 
     it 'reports the total invoiced sales, scoped to the sector, as ‘Inf Sales’' do
-      expect(cg_report_row.data['Inf Sales']).to eq '1230.45'
-      expect(wps_report_row.data['Inf Sales']).to eq '-428.95'
+      expect(cg_report_row.inf_sales).to eq '1230.45'
+      expect(wps_report_row.inf_sales).to eq '-428.95'
     end
 
     it 'reports the total management charge, scoped to the sector, as ‘Commission’' do
-      expect(cg_report_row.data['Commission']).to eq '18.45'
-      expect(wps_report_row.data['Commission']).to eq '-6.43'
+      expect(cg_report_row.commission).to eq '18.45'
+      expect(wps_report_row.commission).to eq '-6.43'
     end
 
     it 'handles sales amounts written as a human-readable number' do
@@ -112,16 +112,16 @@ RSpec.describe Export::CodaFinanceReport::Row do
         submission: submission,
         data: { 'Total Cost (ex VAT)' => ' 2,428.95 ', 'Customer URN' => health_dept.urn }
       )
-      expect(cg_report_row.data['Inf Sales']).to eq '3659.40'
-      expect(cg_report_row.data['Commission']).to eq '54.89'
+      expect(cg_report_row.inf_sales).to eq '3659.40'
+      expect(cg_report_row.commission).to eq '54.89'
     end
 
     it 'handles no business submissions, reporting them as zero sales and commission' do
       no_business_submission = FactoryBot.create(:no_business_submission)
       row = Export::CodaFinanceReport::Row.new(no_business_submission, Customer.sectors[:central_government])
 
-      expect(row.data['Inf Sales']).to eq '0.00'
-      expect(row.data['Commission']).to eq '0.00'
+      expect(row.inf_sales).to eq '0.00'
+      expect(row.commission).to eq '0.00'
     end
   end
 end

--- a/spec/models/export/invoices/extract_spec.rb
+++ b/spec/models/export/invoices/extract_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Export::Invoices::Extract do
+  describe '.all_relevant' do
+    subject(:all_relevant) { Export::Invoices::Extract.all_relevant }
+
+    context 'there are some complete and incomplete submissions, all with valid entries' do
+      let!(:complete_submission) do
+        create :submission_with_validated_entries, aasm_state: 'completed'
+      end
+      let!(:pending_submission) do
+        create :submission_with_validated_entries
+      end
+
+      it 'contains only invoices from the complete submission' do
+        expect(all_relevant.map(&:entry_type)).to all(eql('invoice'))
+        expect(all_relevant.map(&:submission_id)).to all(eql(complete_submission.id))
+      end
+    end
+  end
+end

--- a/spec/models/export/invoices/extract_spec.rb
+++ b/spec/models/export/invoices/extract_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Export::Invoices::Extract do
         expect(all_relevant.map(&:entry_type)).to all(eql('invoice'))
         expect(all_relevant.map(&:submission_id)).to all(eql(complete_submission.id))
       end
+
+      it 'projects a _framework_short_name field onto every invoice' do
+        expect(all_relevant.map(&:_framework_short_name)).to all(eql(complete_submission.framework.short_name))
+      end
     end
   end
 end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -1,120 +1,149 @@
 require 'rails_helper'
 
 RSpec.describe Export::Invoices::Row do
-  let(:invoice_entry) do
-    double 'SubmissionEntry',
-           _framework_short_name: 'RM3786',
-           data: attributes_for(:submission_entry, :legal_framework_data).fetch(:data)
-  end
-
   subject(:row) { Export::Invoices::Row.new(invoice_entry) }
 
-  describe 'Customer fields' do
-    describe '#customer_urn' do
-      subject { row.customer_urn }
-      it { is_expected.to eql(invoice_entry.data['Customer URN']) }
+  context 'General legal framework RM3786' do
+    let(:invoice_entry) do
+      double 'SubmissionEntry',
+             _framework_short_name: 'RM3786',
+             data: attributes_for(:submission_entry, :legal_framework_data).fetch(:data)
     end
-    describe '#customer_name' do
-      subject { row.customer_name }
-      it { is_expected.to eql('Department for Education') }
-    end
-    describe '#customer_postcode' do
-      subject { row.customer_postcode }
-      it { is_expected.to eql(invoice_entry.data['Customer Post Code']) }
-    end
-    describe '#customer_reference_number' do
-      subject { row.customer_reference_number }
 
-      context 'in legal frameworks' do
-        it { is_expected.to be_nil }
+    describe 'Customer fields' do
+      describe '#customer_urn' do
+        subject { row.customer_urn }
+        it { is_expected.to eql(invoice_entry.data['Customer URN']) }
+      end
+      describe '#customer_name' do
+        subject { row.customer_name }
+        it { is_expected.to eql('Department for Education') }
+      end
+      describe '#customer_postcode' do
+        subject { row.customer_postcode }
+        it { is_expected.to eql(invoice_entry.data['Customer Post Code']) }
+      end
+      describe '#customer_reference_number' do
+        subject { row.customer_reference_number }
+
+        context 'in legal frameworks' do
+          it { is_expected.to be_nil }
+        end
       end
     end
-  end
 
-  describe 'Invoice fields' do
-    describe '#invoice_date' do
-      it 'passes through the date without transformation to ISO8601 (this may/should change)' do
-        expect(row.invoice_date).to eql(invoice_entry.data['Customer Invoice Date'])
+    describe 'Invoice fields' do
+      describe '#invoice_date' do
+        it 'passes through the date without transformation to ISO8601 (this may/should change)' do
+          expect(row.invoice_date).to eql(invoice_entry.data['Customer Invoice Date'])
+        end
+      end
+      describe '#invoice_number' do
+        subject { row.invoice_number }
+        it { is_expected.to eql(invoice_entry.data['Customer Invoice Number']) }
+      end
+      describe '#invoice_value' do
+        subject { row.invoice_value }
+        it { is_expected.to eql(invoice_entry.data['Total Cost (ex VAT)']) }
+      end
+      describe '#supplier_reference_number' do
+        subject { row.supplier_reference_number }
+        it { is_expected.to eql(invoice_entry.data['Supplier Reference Number']) }
+      end
+      describe '#vat_charged' do
+        subject { row.vat_charged }
+        it { is_expected.to eql(invoice_entry.data['VAT Amount Charged']) }
       end
     end
-    describe '#invoice_number' do
-      subject { row.invoice_number }
-      it { is_expected.to eql(invoice_entry.data['Customer Invoice Number']) }
-    end
-    describe '#invoice_value' do
-      subject { row.invoice_value }
-      it { is_expected.to eql(invoice_entry.data['Total Cost (ex VAT)']) }
-    end
-    describe '#supplier_reference_number' do
-      subject { row.supplier_reference_number }
-      it { is_expected.to eql(invoice_entry.data['Supplier Reference Number']) }
-    end
-    describe '#vat_charged' do
-      subject { row.vat_charged }
-      it { is_expected.to eql(invoice_entry.data['VAT Amount Charged']) }
-    end
-  end
 
-  describe 'what happens when a key is missing in the model’s data' do
-    before do
-      invoice_entry.data.delete('Customer Post Code')
+    describe 'what happens when a key is missing in the model’s data' do
+      before do
+        invoice_entry.data.delete('Customer Post Code')
+      end
+
+      it 'substitutes #NOT_IN_DATA' do
+        expect(row.customer_postcode).to eql('#NOTINDATA')
+      end
     end
 
-    it 'substitutes #NOT_IN_DATA' do
-      expect(row.customer_postcode).to eql('#NOTINDATA')
+    describe '#lot_number' do
+      subject { row.lot_number }
+      it { is_expected.to eql(invoice_entry.data['Tier Number']) }
     end
-  end
 
-  describe '#lot_number' do
-    subject { row.lot_number }
-    it { is_expected.to eql(invoice_entry.data['Tier Number']) }
-  end
+    describe 'Product fields' do
+      describe '#product_description' do
+        subject { row.product_description }
+        it { is_expected.to eql(Export::CsvRow::MISSING) }
+      end
+      describe '#product_group' do
+        subject { row.product_group }
+        it { is_expected.to eql(Export::CsvRow::MISSING) }
+      end
+      describe '#product_class' do
+        subject { row.product_class }
+        it { is_expected.to eql(Export::CsvRow::MISSING) }
+      end
+      describe '#product_subclass' do
+        subject { row.product_subclass }
+        it { is_expected.to eql(Export::CsvRow::MISSING) }
+      end
+      describe '#product_code' do
+        subject { row.product_code }
+        it { is_expected.to eql(Export::CsvRow::MISSING) }
+      end
+    end
 
-  describe 'Product fields' do
-    describe '#product_description' do
-      subject { row.product_description }
+    describe 'Unit* fields' do
+      describe '#unit_type' do
+        subject { row.unit_type }
+        it { is_expected.to eql(invoice_entry.data['Unit of Purchase']) }
+      end
+      describe '#unit_price' do
+        subject { row.unit_price }
+        it { is_expected.to eql(invoice_entry.data['Price per Unit']) }
+      end
+      describe '#unit_quantity' do
+        subject { row.unit_quantity }
+        it { is_expected.to eql(invoice_entry.data['Quantity']) }
+      end
+    end
+
+    describe '#expenses' do
+      subject { row.expenses }
       it { is_expected.to eql(Export::CsvRow::MISSING) }
     end
-    describe '#product_group' do
-      subject { row.product_group }
-      it { is_expected.to eql(Export::CsvRow::MISSING) }
-    end
-    describe '#product_class' do
-      subject { row.product_class }
-      it { is_expected.to eql(Export::CsvRow::MISSING) }
-    end
-    describe '#product_subclass' do
-      subject { row.product_subclass }
-      it { is_expected.to eql(Export::CsvRow::MISSING) }
-    end
-    describe '#product_code' do
-      subject { row.product_code }
-      it { is_expected.to eql(Export::CsvRow::MISSING) }
-    end
-  end
 
-  describe 'Unit* fields' do
-    describe '#unit_type' do
-      subject { row.unit_type }
-      it { is_expected.to eql(invoice_entry.data['Unit of Purchase']) }
+    describe '#promotion_code' do
+      subject { row.promotion_code }
+      it { is_expected.to be_nil }
     end
-    describe '#unit_price' do
-      subject { row.unit_price }
-      it { is_expected.to eql(invoice_entry.data['Price per Unit']) }
-    end
-    describe '#unit_quantity' do
-      subject { row.unit_quantity }
-      it { is_expected.to eql(invoice_entry.data['Quantity']) }
-    end
-  end
 
-  describe '#expenses' do
-    subject { row.expenses }
-    it { is_expected.to eql(Export::CsvRow::MISSING) }
-  end
-
-  describe '#promotion_code' do
-    subject { row.promotion_code }
-    it { is_expected.to be_nil }
+    describe 'additional fields' do
+      describe '#additional1' do
+        subject { row.additional1 }
+        it { is_expected.to eql(invoice_entry.data['Matter Name']) }
+      end
+      describe '#additional2' do
+        subject { row.additional2 }
+        it { is_expected.to eql(invoice_entry.data['Pro-Bono Price per Unit']) }
+      end
+      describe '#additional3' do
+        subject { row.additional3 }
+        it { is_expected.to eql(invoice_entry.data['Pro-Bono Quantity']) }
+      end
+      describe '#additional4' do
+        subject { row.additional4 }
+        it { is_expected.to eql(invoice_entry.data['Pro-Bono Total Value']) }
+      end
+      describe '#additional5' do
+        subject { row.additional5 }
+        it { is_expected.to eql(invoice_entry.data['Sub-Contractor Name (If Applicable)']) }
+      end
+      describe '#additional6' do
+        subject { row.additional6 }
+        it { is_expected.to eql(invoice_entry.data['Pricing Mechanism']) }
+      end
+    end
   end
 end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe Export::Invoices::Row do
       subject { row.supplier_reference_number }
       it { is_expected.to eql(invoice_entry.data['Supplier Reference Number']) }
     end
+    describe '#vat_charged' do
+      subject { row.vat_charged }
+      it { is_expected.to eql(invoice_entry.data['VAT Amount Charged']) }
+    end
   end
 
   describe 'what happens when a key is missing in the model’s data' do

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Export::Invoices::Row do
 
     describe '#expenses' do
       subject { row.expenses }
-      it { is_expected.to eql(Export::CsvRow::MISSING) }
+      it { is_expected.to be_nil }
     end
 
     describe '#promotion_code' do

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -19,4 +19,15 @@ RSpec.describe Export::Invoices::Row do
       it { is_expected.to eql('#MISSING') }
     end
   end
+
+  describe 'Invoice fields are currently MISSING' do
+    describe '#invoice_date' do
+      subject { row.invoice_date }
+      it { is_expected.to eql('#MISSING') }
+    end
+    describe '#invoice_number' do
+      subject { row.invoice_number }
+      it { is_expected.to eql('#MISSING') }
+    end
+  end
 end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -1,33 +1,59 @@
 require 'rails_helper'
 
 RSpec.describe Export::Invoices::Row do
-  let(:invoice_entry) { double 'SubmissionEntry' }
+  let(:invoice_entry) do
+    double 'SubmissionEntry', data: {
+      'UNSPSC' => '80120000',
+      'Quantity' => '-0.9',
+      'Matter Name' => 'GITIS Terms and Conditions',
+      'Tier Number' => '1',
+      'Customer URN' => '10012345',
+      'Service Type' => 'Core',
+      'Price per Unit' => '151.09',
+      'Unit of Purchase' => 'Hourly',
+      'Pricing Mechanism' => 'Time and Material',
+      'Pro-Bono Quantity' => '0.00',
+      'Customer Post Code' => 'SW1P 3ZZ',
+      'Practitioner Grade' => 'Legal Director/Senior Solicitor',
+      'Primary Specialism' => 'Contracts',
+      'VAT Amount Charged' => '-27.20',
+      'Total Cost (ex VAT)' => '-135.98',
+      'Pro-Bono Total Value' => '0.00',
+      'Customer Invoice Date' => '5/31/18',
+      'Customer Invoice Number' => '3307957',
+      'Pro-Bono Price per Unit' => '0.00',
+      'Supplier Reference Number' => 'DEP/0008.00032',
+      'Customer Organisation Name' => 'Department for Education',
+      'Sub-Contractor Name (If Applicable)' => 'N/A'
+    }
+  end
 
   subject(:row) { Export::Invoices::Row.new(invoice_entry) }
 
-  describe 'Customer fields are currently MISSING' do
+  describe 'Customer fields' do
     describe '#customer_urn' do
       subject { row.customer_urn }
-      it { is_expected.to eql('#MISSING') }
+      it { is_expected.to eql(invoice_entry.data['Customer URN']) }
     end
     describe '#customer_name' do
       subject { row.customer_name }
-      it { is_expected.to eql('#MISSING') }
+      it { is_expected.to eql('Department for Education') }
     end
     describe '#customer_postcode' do
       subject { row.customer_postcode }
-      it { is_expected.to eql('#MISSING') }
+      it { is_expected.to eql(invoice_entry.data['Customer Post Code']) }
     end
   end
 
-  describe 'Invoice fields are currently MISSING' do
+  describe 'Invoice fields' do
     describe '#invoice_date' do
-      subject { row.invoice_date }
-      it { is_expected.to eql('#MISSING') }
+      it 'passes through the date without transformation to ISO8601 (this may/should change)' do
+        expect(row.invoice_date).to eql(invoice_entry.data['Customer Invoice Date'])
+      end
     end
     describe '#invoice_number' do
       subject { row.invoice_number }
-      it { is_expected.to eql('#MISSING') }
+      it { is_expected.to eql(invoice_entry.data['Customer Invoice Number']) }
     end
   end
 end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Export::Invoices::Row do
+end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -103,4 +103,9 @@ RSpec.describe Export::Invoices::Row do
       it { is_expected.to eql(invoice_entry.data['Quantity']) }
     end
   end
+
+  describe '#expenses' do
+    subject { row.expenses }
+    it { is_expected.to eql(Export::CsvRow::MISSING) }
+  end
 end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -4,30 +4,7 @@ RSpec.describe Export::Invoices::Row do
   let(:invoice_entry) do
     double 'SubmissionEntry',
            _framework_short_name: 'RM3786',
-           data: {
-             'UNSPSC' => '80120000',
-             'Quantity' => '-0.9',
-             'Matter Name' => 'GITIS Terms and Conditions',
-             'Tier Number' => '1',
-             'Customer URN' => '10012345',
-             'Service Type' => 'Core',
-             'Price per Unit' => '151.09',
-             'Unit of Purchase' => 'Hourly',
-             'Pricing Mechanism' => 'Time and Material',
-             'Pro-Bono Quantity' => '0.00',
-             'Customer Post Code' => 'SW1P 3ZZ',
-             'Practitioner Grade' => 'Legal Director/Senior Solicitor',
-             'Primary Specialism' => 'Contracts',
-             'VAT Amount Charged' => '-27.20',
-             'Total Cost (ex VAT)' => '-135.98',
-             'Pro-Bono Total Value' => '0.00',
-             'Customer Invoice Date' => '5/31/18',
-             'Customer Invoice Number' => '3307957',
-             'Pro-Bono Price per Unit' => '0.00',
-             'Supplier Reference Number' => 'DEP/0008.00032',
-             'Customer Organisation Name' => 'Department for Education',
-             'Sub-Contractor Name (If Applicable)' => 'N/A'
-           }
+           data: attributes_for(:submission_entry, :legal_framework_data).fetch(:data)
   end
 
   subject(:row) { Export::Invoices::Row.new(invoice_entry) }
@@ -78,5 +55,10 @@ RSpec.describe Export::Invoices::Row do
     it 'substitutes #NOT_IN_DATA' do
       expect(row.customer_postcode).to eql('#NOTINDATA')
     end
+  end
+
+  describe '#lot_number' do
+    subject { row.lot_number }
+    it { is_expected.to eql(invoice_entry.data['Tier Number']) }
   end
 end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -71,26 +71,26 @@ RSpec.describe Export::Invoices::Row do
       it { is_expected.to eql(invoice_entry.data['Tier Number']) }
     end
 
-    describe 'Product fields' do
+    describe 'Product fields are not captured in legal frameworks' do
       describe '#product_description' do
         subject { row.product_description }
-        it { is_expected.to eql(Export::CsvRow::MISSING) }
+        it { is_expected.to be_nil }
       end
       describe '#product_group' do
         subject { row.product_group }
-        it { is_expected.to eql(Export::CsvRow::MISSING) }
+        it { is_expected.to be_nil }
       end
       describe '#product_class' do
         subject { row.product_class }
-        it { is_expected.to eql(Export::CsvRow::MISSING) }
+        it { is_expected.to be_nil }
       end
       describe '#product_subclass' do
         subject { row.product_subclass }
-        it { is_expected.to eql(Export::CsvRow::MISSING) }
+        it { is_expected.to be_nil }
       end
       describe '#product_code' do
         subject { row.product_code }
-        it { is_expected.to eql(Export::CsvRow::MISSING) }
+        it { is_expected.to be_nil }
       end
     end
 

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -2,30 +2,32 @@ require 'rails_helper'
 
 RSpec.describe Export::Invoices::Row do
   let(:invoice_entry) do
-    double 'SubmissionEntry', data: {
-      'UNSPSC' => '80120000',
-      'Quantity' => '-0.9',
-      'Matter Name' => 'GITIS Terms and Conditions',
-      'Tier Number' => '1',
-      'Customer URN' => '10012345',
-      'Service Type' => 'Core',
-      'Price per Unit' => '151.09',
-      'Unit of Purchase' => 'Hourly',
-      'Pricing Mechanism' => 'Time and Material',
-      'Pro-Bono Quantity' => '0.00',
-      'Customer Post Code' => 'SW1P 3ZZ',
-      'Practitioner Grade' => 'Legal Director/Senior Solicitor',
-      'Primary Specialism' => 'Contracts',
-      'VAT Amount Charged' => '-27.20',
-      'Total Cost (ex VAT)' => '-135.98',
-      'Pro-Bono Total Value' => '0.00',
-      'Customer Invoice Date' => '5/31/18',
-      'Customer Invoice Number' => '3307957',
-      'Pro-Bono Price per Unit' => '0.00',
-      'Supplier Reference Number' => 'DEP/0008.00032',
-      'Customer Organisation Name' => 'Department for Education',
-      'Sub-Contractor Name (If Applicable)' => 'N/A'
-    }
+    double 'SubmissionEntry',
+           _framework_short_name: 'RM3786',
+           data: {
+             'UNSPSC' => '80120000',
+             'Quantity' => '-0.9',
+             'Matter Name' => 'GITIS Terms and Conditions',
+             'Tier Number' => '1',
+             'Customer URN' => '10012345',
+             'Service Type' => 'Core',
+             'Price per Unit' => '151.09',
+             'Unit of Purchase' => 'Hourly',
+             'Pricing Mechanism' => 'Time and Material',
+             'Pro-Bono Quantity' => '0.00',
+             'Customer Post Code' => 'SW1P 3ZZ',
+             'Practitioner Grade' => 'Legal Director/Senior Solicitor',
+             'Primary Specialism' => 'Contracts',
+             'VAT Amount Charged' => '-27.20',
+             'Total Cost (ex VAT)' => '-135.98',
+             'Pro-Bono Total Value' => '0.00',
+             'Customer Invoice Date' => '5/31/18',
+             'Customer Invoice Number' => '3307957',
+             'Pro-Bono Price per Unit' => '0.00',
+             'Supplier Reference Number' => 'DEP/0008.00032',
+             'Customer Organisation Name' => 'Department for Education',
+             'Sub-Contractor Name (If Applicable)' => 'N/A'
+           }
   end
 
   subject(:row) { Export::Invoices::Row.new(invoice_entry) }
@@ -54,6 +56,16 @@ RSpec.describe Export::Invoices::Row do
     describe '#invoice_number' do
       subject { row.invoice_number }
       it { is_expected.to eql(invoice_entry.data['Customer Invoice Number']) }
+    end
+  end
+
+  describe 'what happens when a key is missing in the model’s data' do
+    before do
+      invoice_entry.data.delete('Customer Post Code')
+    end
+
+    it 'substitutes #NOT_IN_DATA' do
+      expect(row.customer_postcode).to eql('#NOTINDATA')
     end
   end
 end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe Export::Invoices::Row do
       subject { row.customer_postcode }
       it { is_expected.to eql(invoice_entry.data['Customer Post Code']) }
     end
+    describe '#customer_reference_number' do
+      subject { row.customer_reference_number }
+
+      context 'in legal frameworks' do
+        it { is_expected.to be_nil }
+      end
+    end
   end
 
   describe 'Invoice fields' do
@@ -56,6 +63,10 @@ RSpec.describe Export::Invoices::Row do
     describe '#invoice_number' do
       subject { row.invoice_number }
       it { is_expected.to eql(invoice_entry.data['Customer Invoice Number']) }
+    end
+    describe '#supplier_reference_number' do
+      subject { row.supplier_reference_number }
+      it { is_expected.to eql(invoice_entry.data['Supplier Reference Number']) }
     end
   end
 

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -84,4 +84,19 @@ RSpec.describe Export::Invoices::Row do
       it { is_expected.to eql(Export::CsvRow::MISSING) }
     end
   end
+
+  describe 'Unit* fields' do
+    describe '#unit_type' do
+      subject { row.unit_type }
+      it { is_expected.to eql(invoice_entry.data['Unit of Purchase']) }
+    end
+    describe '#unit_price' do
+      subject { row.unit_price }
+      it { is_expected.to eql(invoice_entry.data['Price per Unit']) }
+    end
+    describe '#unit_quantity' do
+      subject { row.unit_quantity }
+      it { is_expected.to eql(invoice_entry.data['Quantity']) }
+    end
+  end
 end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -61,4 +61,27 @@ RSpec.describe Export::Invoices::Row do
     subject { row.lot_number }
     it { is_expected.to eql(invoice_entry.data['Tier Number']) }
   end
+
+  describe 'Product fields' do
+    describe '#product_description' do
+      subject { row.product_description }
+      it { is_expected.to eql(Export::CsvRow::MISSING) }
+    end
+    describe '#product_group' do
+      subject { row.product_group }
+      it { is_expected.to eql(Export::CsvRow::MISSING) }
+    end
+    describe '#product_class' do
+      subject { row.product_class }
+      it { is_expected.to eql(Export::CsvRow::MISSING) }
+    end
+    describe '#product_subclass' do
+      subject { row.product_subclass }
+      it { is_expected.to eql(Export::CsvRow::MISSING) }
+    end
+    describe '#product_code' do
+      subject { row.product_code }
+      it { is_expected.to eql(Export::CsvRow::MISSING) }
+    end
+  end
 end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe Export::Invoices::Row do
       subject { row.invoice_number }
       it { is_expected.to eql(invoice_entry.data['Customer Invoice Number']) }
     end
+    describe '#invoice_value' do
+      subject { row.invoice_value }
+      it { is_expected.to eql(invoice_entry.data['Total Cost (ex VAT)']) }
+    end
     describe '#supplier_reference_number' do
       subject { row.supplier_reference_number }
       it { is_expected.to eql(invoice_entry.data['Supplier Reference Number']) }

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -1,4 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Export::Invoices::Row do
+  let(:invoice_entry) { double 'SubmissionEntry' }
+
+  subject(:row) { Export::Invoices::Row.new(invoice_entry) }
+
+  describe 'Customer fields are currently MISSING' do
+    describe '#customer_urn' do
+      subject { row.customer_urn }
+      it { is_expected.to eql('#MISSING') }
+    end
+    describe '#customer_name' do
+      subject { row.customer_name }
+      it { is_expected.to eql('#MISSING') }
+    end
+    describe '#customer_postcode' do
+      subject { row.customer_postcode }
+      it { is_expected.to eql('#MISSING') }
+    end
+  end
 end

--- a/spec/models/export/invoices/row_spec.rb
+++ b/spec/models/export/invoices/row_spec.rb
@@ -112,4 +112,9 @@ RSpec.describe Export::Invoices::Row do
     subject { row.expenses }
     it { is_expected.to eql(Export::CsvRow::MISSING) }
   end
+
+  describe '#promotion_code' do
+    subject { row.promotion_code }
+    it { is_expected.to be_nil }
+  end
 end

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Export::Invoices do
     it 'writes each invoice to that output' do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
-        "#{invoice.submission_id},#MISSING,#MISSING,#MISSING,#MISSING,#MISSING"
+        "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA"
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Export::Invoices do
       expect(output_lines.first).to eql(
         'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber,'\
         'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber,ProductDescription,'\
-        'ProductGroup,ProductClass,ProductSubClass,ProductCode,UnitType,UnitPrice,UnitQuantity'\
+        'ProductGroup,ProductClass,ProductSubClass,ProductCode,UnitType,UnitPrice,UnitQuantity,'\
+        'InvoiceValue'\
       )
     end
 
@@ -36,14 +37,14 @@ RSpec.describe Export::Invoices do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98'
       )
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA'
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -10,17 +10,7 @@ RSpec.describe Export::Invoices do
     end
 
     let!(:invoice) do
-      create :invoice_entry,
-             submission: complete_submission,
-             data: {
-               'Customer URN' => '10012345',
-               'Customer Post Code' => 'SW1P 3ZZ',
-               'Total Cost (ex VAT)' => '-135.98',
-               'Customer Invoice Date' => '5/31/18',
-               'Customer Invoice Number' => '3307957',
-               'Customer Organisation Name' => 'Department for Education',
-               'Supplier Reference Number' => 'DEP/0008.00032',
-             }
+      create :invoice_entry, :legal_framework_data, submission: complete_submission
     end
 
     let!(:invoice2) { create(:invoice_entry, submission: complete_submission) }
@@ -37,20 +27,20 @@ RSpec.describe Export::Invoices do
     it 'writes a header to that output' do
       expect(output_lines.first).to eql(
         'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber,'\
-        'SupplierReferenceNumber,CustomerReferenceNumber'\
+        'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber'\
       )
     end
 
     it 'writes each invoice to that output' do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
-        "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,"
+        "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1"
       )
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
-        "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,"
+        "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA"
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Export::Invoices do
         'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber,'\
         'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber,ProductDescription,'\
         'ProductGroup,ProductClass,ProductSubClass,ProductCode,UnitType,UnitPrice,UnitQuantity,'\
-        'InvoiceValue'\
+        'InvoiceValue,Expenses'\
       )
     end
 
@@ -37,14 +37,14 @@ RSpec.describe Export::Invoices do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98,#MISSING'
       )
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#MISSING'
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Export::Invoices do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98,#MISSING,-27.20,'\
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98,,-27.20,'\
         ',GITIS Terms and Conditions,0.00,0.00,0.00,N/A,Time and Material,,'
       )
     end
@@ -46,7 +46,7 @@ RSpec.describe Export::Invoices do
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#MISSING,#NOTINDATA,'\
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,'\
         ',,,,,,,,'
       )
     end

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Export::Invoices do
       expect(output_lines.first).to eql(
         'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber,'\
         'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber,ProductDescription,'\
-        'ProductGroup,ProductClass,ProductSubClass,ProductCode'\
+        'ProductGroup,ProductClass,ProductSubClass,ProductCode,UnitType,UnitPrice,UnitQuantity'\
       )
     end
 
@@ -36,14 +36,14 @@ RSpec.describe Export::Invoices do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9'
       )
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA'
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -2,15 +2,35 @@ require 'rails_helper'
 require 'stringio'
 
 RSpec.describe Export::Invoices do
-  context 'given valid invoices and an in-memory output' do
-    let(:invoice)  { create(:invoice_entry) }
-    let(:invoices) { [invoice, create(:invoice_entry)] }
+  context 'given some invoices and an in-memory output' do
+    let!(:complete_submission) do
+      create :submission,
+             aasm_state: 'completed',
+             framework: create(:framework, short_name: 'RM3786')
+    end
 
-    let(:output) { StringIO.new }
+    let!(:invoice) do
+      create :invoice_entry,
+             submission: complete_submission,
+             data: {
+               'Customer URN' => '10012345',
+               'Customer Post Code' => 'SW1P 3ZZ',
+               'Total Cost (ex VAT)' => '-135.98',
+               'Customer Invoice Date' => '5/31/18',
+               'Customer Invoice Number' => '3307957',
+               'Customer Organisation Name' => 'Department for Education',
+             }
+    end
+
+    let!(:invoice2) { create(:invoice_entry, submission: complete_submission) }
+
+    let(:output)             { StringIO.new }
+    let(:extracted_invoices) { Export::Invoices::Extract.all_relevant }
+
     subject(:output_lines) { output.string.split("\n") }
 
     before do
-      Export::Invoices.new(invoices, output).run
+      Export::Invoices.new(extracted_invoices, output).run
     end
 
     it 'writes a header to that output' do
@@ -22,13 +42,19 @@ RSpec.describe Export::Invoices do
     it 'writes each invoice to that output' do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
+        "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957"
+      )
+    end
+
+    it 'writes #NOTINDATA for fields it cannot map' do
+      expect(output_lines[2]).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA"
       )
     end
 
     it 'has as many headers as row values' do
       expect(Export::Invoices::HEADER.length).to eql(
-        Export::Invoices::Row.new(invoice).row_values.length
+        Export::Invoices::Row.new(extracted_invoices.first).row_values.length
       )
     end
   end

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require 'stringio'
+
+RSpec.describe Export::Invoices do
+  context 'given valid invoices and an in-memory output' do
+    let(:invoice)  { create(:invoice_entry) }
+    let(:invoices) { [invoice, create(:invoice_entry)] }
+
+    let(:output) { StringIO.new }
+    subject(:output_lines) { output.string.split("\n") }
+
+    before do
+      Export::Invoices.new(invoices, output).run
+    end
+
+    it 'writes a header to that output' do
+      expect(output_lines.first).to eql(
+        'SubmissionID'
+      )
+    end
+
+    it 'writes each invoice to that output' do
+      expect(output_lines.length).to eql(3)
+      expect(output_lines[1]).to eql(
+        "#{invoice.submission_id}"
+      )
+    end
+
+    it 'has as many headers as row values' do
+      expect(Export::Invoices::HEADER.length).to eql(
+        Export::Invoices::Row.new(invoice).row_values.length
+      )
+    end
+  end
+end

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Export::Invoices do
 
     it 'writes a header to that output' do
       expect(output_lines.first).to eql(
-        'SubmissionID,CustomerURN,CustomerName,CustomerPostcode'
+        'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber'
       )
     end
 
     it 'writes each invoice to that output' do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
-        "#{invoice.submission_id},#MISSING,#MISSING,#MISSING"
+        "#{invoice.submission_id},#MISSING,#MISSING,#MISSING,#MISSING,#MISSING"
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe Export::Invoices do
         'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber,'\
         'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber,ProductDescription,'\
         'ProductGroup,ProductClass,ProductSubClass,ProductCode,UnitType,UnitPrice,UnitQuantity,'\
-        'InvoiceValue,Expenses,VATCharged,PromotionCode'\
+        'InvoiceValue,Expenses,VATCharged,PromotionCode,'\
+        'Additional1,Additional2,Additional3,Additional4,Additional5,Additional6,Additional7,Additional8'
       )
     end
 
@@ -37,14 +38,16 @@ RSpec.describe Export::Invoices do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98,#MISSING,-27.20,'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98,#MISSING,-27.20,'\
+        ',GITIS Terms and Conditions,0.00,0.00,0.00,N/A,Time and Material,,'
       )
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#MISSING,#NOTINDATA,'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#MISSING,#NOTINDATA,'\
+        ',,,,,,,,'
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -27,20 +27,23 @@ RSpec.describe Export::Invoices do
     it 'writes a header to that output' do
       expect(output_lines.first).to eql(
         'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber,'\
-        'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber'\
+        'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber,ProductDescription,'\
+        'ProductGroup,ProductClass,ProductSubClass,ProductCode'\
       )
     end
 
     it 'writes each invoice to that output' do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
-        "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1"
+        "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1,"\
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING'
       )
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
-        "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA"
+        "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,"\
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING'
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Export::Invoices do
         'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber,'\
         'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber,ProductDescription,'\
         'ProductGroup,ProductClass,ProductSubClass,ProductCode,UnitType,UnitPrice,UnitQuantity,'\
-        'InvoiceValue,Expenses'\
+        'InvoiceValue,Expenses,VATCharged'\
       )
     end
 
@@ -37,14 +37,14 @@ RSpec.describe Export::Invoices do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98,#MISSING'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98,#MISSING,-27.20'
       )
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#MISSING'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#MISSING,#NOTINDATA'
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Export::Invoices do
 
     it 'writes a header to that output' do
       expect(output_lines.first).to eql(
-        'SubmissionID'
+        'SubmissionID,CustomerURN,CustomerName,CustomerPostcode'
       )
     end
 
     it 'writes each invoice to that output' do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
-        "#{invoice.submission_id}"
+        "#{invoice.submission_id},#MISSING,#MISSING,#MISSING"
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Export::Invoices do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98,,-27.20,'\
+        ',,,,,Hourly,151.09,-0.9,-135.98,,-27.20,'\
         ',GITIS Terms and Conditions,0.00,0.00,0.00,N/A,Time and Material,,'
       )
     end
@@ -46,7 +46,7 @@ RSpec.describe Export::Invoices do
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,'\
+        ',,,,,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,'\
         ',,,,,,,,'
       )
     end

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Export::Invoices do
         'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber,'\
         'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber,ProductDescription,'\
         'ProductGroup,ProductClass,ProductSubClass,ProductCode,UnitType,UnitPrice,UnitQuantity,'\
-        'InvoiceValue,Expenses,VATCharged'\
+        'InvoiceValue,Expenses,VATCharged,PromotionCode'\
       )
     end
 
@@ -37,14 +37,14 @@ RSpec.describe Export::Invoices do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,,1,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98,#MISSING,-27.20'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,Hourly,151.09,-0.9,-135.98,#MISSING,-27.20,'
       )
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,"\
-        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#MISSING,#NOTINDATA'
+        '#MISSING,#MISSING,#MISSING,#MISSING,#MISSING,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#MISSING,#NOTINDATA,'
       )
     end
 

--- a/spec/models/export/invoices_spec.rb
+++ b/spec/models/export/invoices_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Export::Invoices do
                'Customer Invoice Date' => '5/31/18',
                'Customer Invoice Number' => '3307957',
                'Customer Organisation Name' => 'Department for Education',
+               'Supplier Reference Number' => 'DEP/0008.00032',
              }
     end
 
@@ -35,20 +36,21 @@ RSpec.describe Export::Invoices do
 
     it 'writes a header to that output' do
       expect(output_lines.first).to eql(
-        'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber'
+        'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber,'\
+        'SupplierReferenceNumber,CustomerReferenceNumber'\
       )
     end
 
     it 'writes each invoice to that output' do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
-        "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957"
+        "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,"
       )
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
-        "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA"
+        "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,"
       )
     end
 

--- a/spec/models/export/template_spec.rb
+++ b/spec/models/export/template_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Export::Template do
+  describe '.source_field_for' do
+    subject { Export::Template.source_field_for(dest_field_name, framework_short_name) }
+
+    context 'the framework does not exist' do
+      it 'tells us with a KeyError' do
+        expect do
+          Export::Template.source_field_for('some_field', 'NON-EXISTENT FRAMEWORK')
+        end.to raise_error(KeyError)
+      end
+    end
+
+    context 'a valid framework is given' do
+      let(:framework_short_name) { 'RM3756' }
+
+      context 'a valid field name for the framework is given' do
+        let(:dest_field_name) { 'CustomerURN' }
+        it { is_expected.to eql('Customer URN') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
# [Export the Invoices](https://trello.com/c/YGfZ8NTw/385-export-the-invoices)

Establish a `rake export:invoices` task.  Extract commonalities in export to base classes [`Export::ToIO`](https://github.com/dxw/DataSubmissionServiceAPI/blob/feature/385-export-the-invoices/app/models/export/to_io.rb) and [`Export::CsvRow`](https://github.com/dxw/DataSubmissionServiceAPI/blob/feature/385-export-the-invoices/app/models/export/csv_row.rb). Map fields from `SubmissionEntry.data` via a new [`Export::Template`](https://github.com/dxw/DataSubmissionServiceAPI/blob/feature/385-export-the-invoices/app/models/export/template.rb) module which establishes these mappings as multiple hashes, starting with the three [`Export::Template::LEGAL_FRAMEWORK`](https://github.com/dxw/DataSubmissionServiceAPI/blob/feature/385-export-the-invoices/app/models/export/template.rb#L27-L29)s.

Acknowledge that `Export::Template` is code for now and may become an admin-able thing later depending on the logic we find we are having to add to `Export::Template` both for the remaining `export:orders` mappings and when onboarding October's frameworks. 

## Outstanding Issues

1. The `Product*` fields are `#MISSING` (see the [Invoices mapping](https://docs.google.com/document/d/1p06xnthMOgdtWl6DDE_3QGuYTJ0bdJmOMK4gDx8mgwo/edit?ts=5b9a60d9#heading=h.sh341w7ysmzw))
2. The `Expenses` field is `#MISSING` (see the [Invoices mapping](https://docs.google.com/document/d/1p06xnthMOgdtWl6DDE_3QGuYTJ0bdJmOMK4gDx8mgwo/edit?ts=5b9a60d9#heading=h.sh341w7ysmzw))
3. The `InvoiceDate` field is passed through without transformation, and there are a number of classes of date formats in submission entries marked `validated` in the source `submission_entries.data` JSONB column. Top examples by occurrence

| length | example | 
|-----|-------------|
| 10 | 01.08.2018 |
| 6 | 4/9/18 |
| 7 | 10/3/57 |
| 9 | 12/072018 |
| 8 | 10/17/17 |
| 7 | 1/30/18 |


## Review notes

This PR's become somewhat large, for which, apologies.

It helps to follow the general purpose behind the commits, which came in these phases:

1. *Commits 1-4*: Establish the `rake export:invoices` task and minimal supporting classes. Start mapping some fields as `MISSING`
2. *Commits 5-7*: Now we have three exportable things, extract the common behaviour in both `Row` classes and the `Export::<Entity>` classes to `Export::CsvRow` and `Export::ToIO` classes respectively
3. *Commit 8*: Determine what's relevant to extract with `Export::Invoices::Extract.all_relevant`
4. *Commits 9-*: After a conversation about mapping values from `SubmissionEntry.data`, work through the fields in groups or one at a time (so as to explain reasoning for each in the commit messages) and establish mappings in a new `Export::Template` module