### PR TITLE
Expose truncated errors in serialised submissions

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -32,4 +32,8 @@ class Submission < ApplicationRecord
   def all_entries_valid?
     entries.validated.count == entries.count
   end
+
+  def sheet_names
+    entries.distinct.pluck(Arel.sql("source->>'sheet'"))
+  end
 end

--- a/app/models/submission_entry.rb
+++ b/app/models/submission_entry.rb
@@ -10,6 +10,7 @@ class SubmissionEntry < ApplicationRecord
   scope :sheet, ->(sheet_name) { where("source->>'sheet' = ?", sheet_name) }
   scope :invoices, -> { where(entry_type: 'invoice') }
   scope :orders, -> { where(entry_type: 'order') }
+  scope :ordered_by_row, -> { order(Arel.sql("source->>'row' ASC")) }
   scope :sector, lambda { |sector|
     joins("INNER JOIN customers ON customers.urn = CAST(submission_entries.data->>'Customer URN' AS INTEGER)")
       .where('customers.sector = ?', sector)

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -5,7 +5,6 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
 
   belongs_to :framework
   belongs_to :task
-  has_many :entries
   has_many :files
 
   attributes :framework_id, :supplier_id, :task_id

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -11,14 +11,20 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
   attribute :purchase_order_number
 
   attribute :status do
-    @object.aasm.current_state
+    submission.aasm.current_state
   end
 
   attribute :invoice_count do
-    @object.entries.invoices.count
+    submission.entries.invoices.count
   end
 
   attribute :order_count do
-    @object.entries.orders.count
+    submission.entries.orders.count
+  end
+
+  private
+
+  def submission
+    @object
   end
 end

--- a/db/migrate/20180924083639_add_index_to_submission_entries_source_row.rb
+++ b/db/migrate/20180924083639_add_index_to_submission_entries_source_row.rb
@@ -1,0 +1,5 @@
+class AddIndexToSubmissionEntriesSourceRow < ActiveRecord::Migration[5.2]
+  def change
+    add_index :submission_entries, :source, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_17_160328) do
+ActiveRecord::Schema.define(version: 2018_09_24_083639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 2018_09_17_160328) do
     t.string "entry_type"
     t.index ["aasm_state"], name: "index_submission_entries_on_aasm_state"
     t.index ["entry_type"], name: "index_submission_entries_on_entry_type"
+    t.index ["source"], name: "index_submission_entries_on_source", using: :gin
     t.index ["submission_file_id"], name: "index_submission_entries_on_submission_file_id"
     t.index ["submission_id"], name: "index_submission_entries_on_submission_id"
   end

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -1,16 +1,22 @@
 FactoryBot.define do
   factory :submission_entry do
+    transient do
+      row 1
+      sheet_name 'Some sheet'
+    end
+
     submission
-    data(test_key: 'some data')
+    entry_type 'invoice'
+    data { { test_key: 'some data' } }
+    source { { sheet: sheet_name, row: row } }
 
     factory :invoice_entry do
-      entry_type 'invoice'
-      source(sheet: 'InvoicesRaised', row: 1)
+      sheet_name 'InvoicesRaised'
     end
 
     factory :order_entry do
       entry_type 'order'
-      source(sheet: 'OrdersReceived', row: 1)
+      sheet_name 'OrdersReceived'
     end
 
     trait :valid do

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :submission_entry do
     transient do
       row 1
+      column 'Column'
       sheet_name 'Some sheet'
     end
 
@@ -24,7 +25,10 @@ FactoryBot.define do
     end
 
     trait :errored do
+      transient { error_message 'Required value missing' }
+
       aasm_state :errored
+      validation_errors { [{ 'message' => error_message, 'location' => { 'row' => row, 'column' => column } }] }
     end
   end
 end

--- a/spec/models/submission_entry_spec.rb
+++ b/spec/models/submission_entry_spec.rb
@@ -31,4 +31,14 @@ RSpec.describe SubmissionEntry do
       expect(SubmissionEntry.wider_public_sector).to contain_exactly(bobs_charity_entry)
     end
   end
+
+  describe 'ordered_by_row' do
+    let!(:third_row)  { FactoryBot.create(:submission_entry, source: { 'row' => 3 }) }
+    let!(:first_row)  { FactoryBot.create(:submission_entry, source: { 'row' => 1 }) }
+    let!(:second_row) { FactoryBot.create(:submission_entry, source: { 'row' => 2 }) }
+
+    it 'returns entries ordered by their source row' do
+      expect(SubmissionEntry.ordered_by_row).to eq [first_row, second_row, third_row]
+    end
+  end
 end

--- a/spec/models/submission_entry_spec.rb
+++ b/spec/models/submission_entry_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe SubmissionEntry do
   it { is_expected.to validate_presence_of(:data) }
 
   describe 'sheet scope' do
-    let(:sheet_1_entry) { FactoryBot.create(:submission_entry, source: { 'sheet' => 'Sheet 1' }) }
-    let(:another_sheet_1_entry) { FactoryBot.create(:submission_entry, source: { 'sheet' => 'Sheet 1' }) }
-    let(:sheet_2_entry) { FactoryBot.create(:submission_entry, source: { 'sheet' => 'Sheet 2' }) }
+    let(:sheet_1_entry) { FactoryBot.create(:submission_entry, sheet_name: 'Sheet 1') }
+    let(:another_sheet_1_entry) { FactoryBot.create(:submission_entry, sheet_name: 'Sheet 1') }
+    let(:sheet_2_entry) { FactoryBot.create(:submission_entry, sheet_name: 'Sheet 2') }
 
     it 'returns entries for the specified sheet' do
       expect(SubmissionEntry.sheet('Sheet 1')).to contain_exactly(sheet_1_entry, another_sheet_1_entry)
@@ -33,9 +33,9 @@ RSpec.describe SubmissionEntry do
   end
 
   describe 'ordered_by_row' do
-    let!(:third_row)  { FactoryBot.create(:submission_entry, source: { 'row' => 3 }) }
-    let!(:first_row)  { FactoryBot.create(:submission_entry, source: { 'row' => 1 }) }
-    let!(:second_row) { FactoryBot.create(:submission_entry, source: { 'row' => 2 }) }
+    let!(:third_row)  { FactoryBot.create(:submission_entry, row: 3) }
+    let!(:first_row)  { FactoryBot.create(:submission_entry, row: 1) }
+    let!(:second_row) { FactoryBot.create(:submission_entry, row: 2) }
 
     it 'returns entries ordered by their source row' do
       expect(SubmissionEntry.ordered_by_row).to eq [first_row, second_row, third_row]

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -23,4 +23,14 @@ RSpec.describe Submission do
       expect(submission).to be_validation_failed
     end
   end
+
+  describe '#sheet_names' do
+    let(:submission) { FactoryBot.create(:submission) }
+    let!(:invoice) { FactoryBot.create(:submission_entry, submission: submission, source: { 'sheet' => 'Invoices' }) }
+    let!(:order) { FactoryBot.create(:submission_entry, submission: submission, source: { 'sheet' => 'Orders' }) }
+
+    it 'returns the sheets that the submission has entries for' do
+      expect(submission.sheet_names).to match_array %w[Invoices Orders]
+    end
+  end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Submission do
 
   describe '#sheet_names' do
     let(:submission) { FactoryBot.create(:submission) }
-    let!(:invoice) { FactoryBot.create(:submission_entry, submission: submission, source: { 'sheet' => 'Invoices' }) }
-    let!(:order) { FactoryBot.create(:submission_entry, submission: submission, source: { 'sheet' => 'Orders' }) }
+    let!(:invoice) { FactoryBot.create(:submission_entry, submission: submission, sheet_name: 'Invoices') }
+    let!(:order) { FactoryBot.create(:submission_entry, submission: submission, sheet_name: 'Orders') }
 
     it 'returns the sheets that the submission has entries for' do
       expect(submission.sheet_names).to match_array %w[Invoices Orders]

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe '/v1' do
       entry = FactoryBot.create(:submission_entry,
                                 submission_id: submission.id,
                                 submission_file_id: file.id,
-                                source: { sheet: 'Orders', row: 23 },
+                                sheet_name: 'Orders',
+                                row: 23,
                                 data: { test: 'test' })
 
       get "/v1/files/#{file.id}/entries/#{entry.id}"

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -12,30 +12,6 @@ RSpec.describe '/v1' do
       expect(json['data']).to have_id(submission.id)
     end
 
-    it 'optionally includes submission entries' do
-      submission = FactoryBot.create(:submission)
-      file = FactoryBot.create(:submission_file)
-      entry = FactoryBot.create(:submission_entry,
-                                submission: submission,
-                                submission_file: file,
-                                sheet_name: 'Orders',
-                                row: 23,
-                                data: { test: 'test' })
-
-      get "/v1/submissions/#{submission.id}?include=entries"
-
-      expect(response).to be_successful
-      expect(json['data']).to have_id(submission.id)
-      expect(json['data'])
-        .to have_relationship(:entries)
-        .with_data([{ 'id' => entry.id, 'type' => 'submission_entries' }])
-      expect(json['included'][0])
-        .to have_attribute(:submission_file_id).with_value(file.id)
-      expect(json['included'][0].dig('attributes', 'source', 'sheet')).to eql 'Orders'
-      expect(json['included'][0].dig('attributes', 'source', 'row')).to eql 23
-      expect(json['included'][0].dig('attributes', 'data', 'test')).to eql 'test'
-    end
-
     it 'optionally includes submission files' do
       submission = FactoryBot.create(:submission)
       file = FactoryBot.create(:submission_file, submission: submission)

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe '/v1' do
       entry = FactoryBot.create(:submission_entry,
                                 submission: submission,
                                 submission_file: file,
-                                source: { sheet: 'Orders', row: 23 },
+                                sheet_name: 'Orders',
+                                row: 23,
                                 data: { test: 'test' })
 
       get "/v1/submissions/#{submission.id}?include=entries"

--- a/spec/serializable/serializable_submission_spec.rb
+++ b/spec/serializable/serializable_submission_spec.rb
@@ -13,4 +13,52 @@ RSpec.describe SerializableSubmission do
       expect(serialized_submission.as_jsonapi[:attributes][:order_count]).to eq(3)
     end
   end
+
+  describe '#sheet_errors' do
+    let(:submission) { FactoryBot.create(:submission) }
+    let!(:errored_invoice) do
+      FactoryBot.create(
+        :invoice_entry,
+        :errored,
+        column: 'Total',
+        row: 1,
+        error_message: 'missing value',
+        submission: submission
+      )
+    end
+    let!(:errored_order) do
+      FactoryBot.create(
+        :order_entry,
+        :errored,
+        column: 'Total',
+        row: 1,
+        error_message: 'not a number',
+        submission: submission
+      )
+    end
+    let!(:errored_order_2) do
+      FactoryBot.create(
+        :order_entry,
+        :errored,
+        column: 'URN',
+        row: 2,
+        error_message: 'missing value',
+        submission: submission
+      )
+    end
+
+    let(:serialized_submission) { SerializableSubmission.new(object: submission) }
+
+    it 'returns the entry validation errors, grouped by their sheet name' do
+      expect(serialized_submission.as_jsonapi[:attributes][:sheet_errors]).to eq(
+        'InvoicesRaised' => [
+          { 'message' => 'missing value', 'location' => { 'row' => 1, 'column' => 'Total' } }
+        ],
+        'OrdersReceived' => [
+          { 'message' => 'not a number', 'location' => { 'row' => 1, 'column' => 'Total' } },
+          { 'message' => 'missing value', 'location' => { 'row' => 2, 'column' => 'URN' } }
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
This exposes the first 10 errored rows for every sheet in a submission as part of the serialised submission. This will allow the frontend app to show the user errors without having to load all the submission entries themselves (which there may end up being many thousands of).

10 was chosen arbitrarily. It may be worth checking some real submissions to inform a decision on what this value should be.

The PR for the corresponding frontend changes is here: https://github.com/dxw/DataSubmissionService/pull/90