### PR TITLE
Errored rows are returned in numerical order

### DIFF
--- a/app/models/submission_entry.rb
+++ b/app/models/submission_entry.rb
@@ -10,7 +10,7 @@ class SubmissionEntry < ApplicationRecord
   scope :sheet, ->(sheet_name) { where("source->>'sheet' = ?", sheet_name) }
   scope :invoices, -> { where(entry_type: 'invoice') }
   scope :orders, -> { where(entry_type: 'order') }
-  scope :ordered_by_row, -> { order(Arel.sql("source->>'row' ASC")) }
+  scope :ordered_by_row, -> { order(Arel.sql("(source->>'row')::integer ASC")) }
   scope :sector, lambda { |sector|
     joins("INNER JOIN customers ON customers.urn = CAST(submission_entries.data->>'Customer URN' AS INTEGER)")
       .where('customers.sector = ?', sector)

--- a/spec/models/submission_entry_spec.rb
+++ b/spec/models/submission_entry_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe SubmissionEntry do
   end
 
   describe 'ordered_by_row' do
-    let!(:third_row)  { FactoryBot.create(:submission_entry, row: 3) }
+    let!(:tenth_row) { FactoryBot.create(:submission_entry, row: 10) }
     let!(:first_row)  { FactoryBot.create(:submission_entry, row: 1) }
     let!(:second_row) { FactoryBot.create(:submission_entry, row: 2) }
 
     it 'returns entries ordered by their source row' do
-      expect(SubmissionEntry.ordered_by_row).to eq [first_row, second_row, third_row]
+      expect(SubmissionEntry.ordered_by_row).to eq [first_row, second_row, tenth_row]
     end
   end
 end


### PR DESCRIPTION
By default, JSONB queries are returned as strings, which means that numeric values are sorted incorrectly *(i.e. 1, 10, 100, 2, etc)*. This fix ensures they are returned as integers.