### PR TITLE
Make `Export::Submissions::Extract#all_relevant` count IDs

### DIFF
--- a/app/models/export/submissions/extract.rb
+++ b/app/models/export/submissions/extract.rb
@@ -5,8 +5,8 @@ module Export
 
       def self.all_relevant
         Submission.select('submissions.*,' \
-                          'COUNT(DISTINCT orders) AS _order_entry_count,' \
-                          'COUNT(DISTINCT invoices) AS _invoice_entry_count,' \
+                          'COUNT(DISTINCT orders.id) AS _order_entry_count,' \
+                          'COUNT(DISTINCT invoices.id) AS _invoice_entry_count,' \
                           'MIN(blobs.filename)::text AS _first_filename')
                   .joins('LEFT JOIN submission_entries orders ON ' \
                          "(orders.submission_id = submissions.id AND orders.entry_type = 'order')")


### PR DESCRIPTION
This PR is as a result of @tekin's [comment](https://github.com/dxw/DataSubmissionServiceAPI/pull/62#discussion_r218751135) about query performance on #62.

We were unable to make a reasonable guess at performance characteristics because we didn't have live data. As of late Thursday afternoon we do, and the resulting query plans identified this:

## The problem

If we use `COUNT(DISTINCT orders)`, PostgreSQL will, by default, compare
a hash of the whole row.

If we use `COUNT(DISTINCT orders.id)`, PostgreSQL will compare the
identity of the underlying submission entry.

The difference in performance tested against a mid-Sep cut of production
data is ~5s -> 150ms.

Comparative query plans are at

https://gist.github.com/rgarner/4276e198f084e1574505b9bd9e56f0be

The differences are subtle; check the `width` cost of the comparisons
on these two lines:

Whole record:
https://gist.github.com/rgarner/4276e198f084e1574505b9bd9e56f0be#file-count_distinct_whole_record-sql-L47

Ids only:
https://gist.github.com/rgarner/4276e198f084e1574505b9bd9e56f0be#file-count_distinct_ids-sql-L46