### PR TITLE
454 import inactive companies

### DIFF
--- a/db/data_migrate/20181001100230_import_inactive_customers.csv
+++ b/db/data_migrate/20181001100230_import_inactive_customers.csv
@@ -1,0 +1,1303 @@
+URN,CustomerName,Acronym,Address1,Address2,Address3,Town,County,Country,PostCode,Sector,Subsector,Active
+10581312,Silva Homes Ltd,,Western Peninsula  Western Road Bracknell,berkshire,,berkshire,,England,RG12 1RF,Wider Public Sector,Charity,True
+10581303,Enable Leisure & Culture,,"The Park Offices, Staff Yard, Battersea Park",London,Greater London,London,Greater London,England,SW11 4NJ,Wider Public Sector,Charity,True
+10581288,EP Collier Primary School,,EP Collier Primary School and Nursery Ross Road,Reading,Berkshire,Reading,Berkshire,England,RG1 8DZ,Wider Public Sector,Education,True
+10581286,Sharnbrook Academy Federation,,Sharnbrook Academy Federation Great Ouse Primary Academy Seaforth Gardens,Bedford,Bedfordshire,Bedford,Bedfordshire,England,MK40 4TJ,Wider Public Sector,Academy (All Types),True
+10581285,Wise Origin College,,Wise Origin College 22 St Georges Way,Leicester,Leicestershire,Leicester,Leicestershire,England,LE1 1SH,Wider Public Sector,Colleges of Further Education,True
+10581279,Lincolnshire Housing Partnership,,"Westgate Park, Charlton Street",Grimsby,Lincolnshire,Grimsby,Lincolnshire,England,DN31 1SQ,Wider Public Sector,Housing Associations,True
+10581275,Homeschool Social Enterprise,,49 Manifold Way,Wednesbury,West Midlands,Wednesbury,West Midlands,England,WS10 0GB,Wider Public Sector,Education,True
+10581273,Ysgol Dyffryn Nantlle,,,,,,,,XXXX,Wider Public Sector,Health,True
+10581263,North Norfolk Academy Trust,,Holt Road,Sheringham,Norfolk,Sheringham,Norfolk,England,NR26 8ND,Wider Public Sector,Academy (All Types),True
+10581262,Esher Learning Trust,,ELT More Lane,Esher,Surrey,Esher,Surrey,England,KT10 8AP,Wider Public Sector,Education,True
+10581256,The Yare Education Trust,,Laundry Lane Thorpe St. Andrew,Norwich,Norfolk,Norwich,Norfolk,England,NR7 0XS,Wider Public Sector,Local Authority Maintained School (All Types),True
+10581253,Berkshire County Council,,,,,,,,XXXX,Wider Public Sector,County Council,True
+10581250,Ryde Inshore Rescue,,19 Greenway  Binstead  Ryde  Isle of White  PO33 3SD,,,,,,XXXX,Wider Public Sector,Charity,True
+10581248,Furniturelink,,2B Merrow Business Park,Guildford,Surrey,Guildford,Surrey,England,GU4 7WA,Wider Public Sector,Charity,True
+10581235,ASH Wales,,14-18 City Road,Cardiff,,Cardiff,,,CF24 3DL,Wider Public Sector,Charity,True
+10581209,Engineering and Physical Sciences Research Council,,Polaris House North Star Avenue,Swindon,Wiltshire,Swindon,Wiltshire,England,SN2 1ET,Central Government,,False
+10581208,Staffordshire Police & Crime Commissioner,,Weston Road Complex Weston Road,Stafford,Staffordshire,Stafford,Staffordshire,England,ST18 0YY,Wider Public Sector,TBA,True
+10581199,LFC Foundation,,Anfield Road,Liverpool,Merseyside,Liverpool,Merseyside,England,L4 0TH,Wider Public Sector,Charity,True
+10581150,Kingdom Abuse Survivors Project ,,,,,,,,XXXX,Wider Public Sector,Charity,True
+10581148,The Hurlingham Academy,,,,,,,,XXXX,Wider Public Sector,Education,True
+10581146,Systems Powering Healthcare,,369 Fulham Road,London,,London,,England,SW10 9NH,Wider Public Sector,Support,True
+10581139,GLOUCESTERSHIRE HOSPITALS SUBSIDIARY COMPANY LIMITED,,Riverside House College Baths Road,Cheltenham,Gloucestershire,Cheltenham,Gloucestershire,England,GL53 7QB,Wider Public Sector,TBA,True
+10581137,Send C of E Primary School,,Send Barns Ln Send,Woking,Surrey,Woking,Surrey,England,GU23 7BS,Wider Public Sector,Education,True
+10581132,Preston Care & Repair,,Suite 4 Hamilton House Leyland Business Park Centurion Way,Leyland,Lancashire,Leyland,Lancashire,England,PR25 3GR,Wider Public Sector,Charity,True
+10581130,Humanity First,,"Unit 27,  Red Lion Business Park, Red Lion Road",Surbiton,Greater London,Surbiton,Greater London,England,KT6 7QD,Wider Public Sector,Charity,True
+10581129,Easingwold District Community Care Association,,"Police House,  Church Hill",Easingwold,North Yorkshire,Easingwold,North Yorkshire,England,YO61 3JX,Wider Public Sector,Charity,True
+10581127,The Diocese of Sheffield Academies Trust,,"Flanderwell Early,  Excellence Centre, Greenfield Court",Rotherham,South Yorkshire,Rotherham,South Yorkshire,England,S66 2JF,Wider Public Sector,Charity,True
+10581126,East Sussex Hearing Resource Centre,,8 St Leonards Road,Eastbourne,East Sussex,Eastbourne,East Sussex,England,BN21 3UH,Wider Public Sector,Charity,True
+10581125,Nottingham City GP Alliance,,79A Upper Parliament Street,Nottingham,Nottinghamshire,Nottingham,Nottinghamshire,England,NG1 6LD,Wider Public Sector,GP Practice,True
+10581123,HMP & YOI Kirklevington Grange,,Yarm,Cleveland,North Yorkshire,Cleveland,North Yorkshire,England,TS15 9PA,Central Government,Prisons,True
+10581122,The Samara Trust,,"Upton Lane, Upton,","Chester,",Cheshire,"Chester,",Cheshire,England,CH2 1ED.,Wider Public Sector,Local Authority Maintained School (All Types),True
+10581100,OPENVIEW SECURITY SOLUTIONS LIMITED,,,,,,,,XXXX,Wider Public Sector,Private Sector Enabler,True
+10581099,Empowering Action and Social Esteem (EASE) Ltd,,,,,,,,XXXX,Wider Public Sector,Charity,True
+10581091,1207 Maldon Squadron Air Cadets,,"Drill Hall, Tenterfield Road",Maldon,,Maldon,,,CM9 5EW,Central Government,MoD - Reserve Forces & Cadets,True
+10581086,Star Academies,,,,,,,,XXXX,Wider Public Sector,Academy (All Types),True
+10581085,St Clememts Hill Primary Academy,,,,,,,,XXXX,Wider Public Sector,Academy (All Types),True
+10581074,170 Engineer Group,,,,,,,,XXXX,Central Government,MoD - Army,True
+10581060,NHS National Services Scotland,,,,,,,,XXXX,Wider Public Sector,TBA,True
+10581053,"HQ Force Troop Command, MOD",,,,,,,,XXXX,Central Government,Other,True
+10581051,LocatED,,,,,,,,XXXX,Wider Public Sector,,True
+10581043,Fort House Surgery,,32 Hersham Road ,Walton Surrey,Surrey,Walton Surrey,Surrey,England,KT12 1UX,Wider Public Sector,GP Practice,True
+10581038,Defence Primary Health Care CWX region,,,,,,,,XXXX,Central Government,Health,True
+10581034,Ted Wragg Multi Academy Trust,,Ted Wragg Multi-Academy Trust Cranbrook Education Campus Tillhouse Road Cranbrook,Exeter,Devon,Exeter,Devon,England,EX5 7EE,Wider Public Sector,Academy (All Types),True
+10581033,New Brighton Day Nursery CIC,,"New Brighton Children’s Centre, Mount Pleasant Road",Wallasey,Merseyside,Wallasey,Merseyside,England,CH45 5HU,Wider Public Sector,Other,True
+10581031,QEII Centre (MHCLG),,,,,,,,XXXX,Central Government,Other,False
+10581004,Davenport Road Evangelical Church,,Davenport Road,Derby,Derbyshire,Derby,Derbyshire,England,DE24 8AX,Wider Public Sector,Other,True
+10581003,Dumfries & Galloway Housing Partnership,,,,,,,,XXXX,Wider Public Sector,Housing Associations,True
+10580992,Chichester Diocesan Association for Family Support Work,,"Garton House, 22 Stanford Avenue",Brighton,East Sussex,Brighton,East Sussex,England,BN1 6AA,Wider Public Sector,Charity,True
+10580991,North and South Arden T.M.O Limited,,"16a Malcolm House, Arden Estate,",London,Greater London,London,Greater London,England,N1 6PN,Wider Public Sector,Housing Associations,True
+10580987,Aspire Oxfordshire Community Enterprises Ltd,,Osney Lane,Oxford,Oxfordshire,Oxford,Oxfordshire,England,OX1 1NJ,Wider Public Sector,Charity,True
+10580969,The Forest School Academy Trust,,"The Forest School, Robin Hood Lane, Winnersh,",Wokingham,,Wokingham,,,RG11 5NE,Wider Public Sector,Education,True
+10580966,Hightown,,Hightown House Maylands Avenue Hemel Hempstead,Hertfordshire,,Hertfordshire,,,HP2 4XH,Wider Public Sector,Housing Associations,True
+10580965,HMP Low Newton,,Brasside,Durham,,Durham,,,DH1 YA,Wider Public Sector,Other,True
+10580959,Learner Engagement and Achievement Partnership Multi-Academy Trust,,Brinsworth Road,Rotherham,,Rotherham,,England,S60 5EJ,Wider Public Sector,Education,False
+10580898,Birkenhead Sixth Form College,,"Park Road West, Claughton, Wirral",Birkenhead,Merseyside,Birkenhead,Merseyside,England,CH43 8SQ,Wider Public Sector,Colleges of Higher Education,False
+10579526,Save the Children UK,,,,,,,,XXXX,Wider Public Sector,Charity,False
+10579442,SEEMiS Group LLP,,Almada Street,Hamilton,Lanarkshire,Hamilton,Lanarkshire,Scotland,ML3 0AA.,Wider Public Sector,Not for Profit,False
+10579249,Llanbrynmair Community Council,,,,,,,,XXXX,Wider Public Sector,Local Government,False
+10579129,Carelink Homecare Services Ltd,,Parc Mount Glanhwfa Road,Llangefni,Gwynedd,Llangefni,Gwynedd,Wales,LL77 7EY,Wider Public Sector,Health,False
+10578659,NHS Sheffield CCG,,722 Prince of Wales Rd,Sheffield,South Yorkshire,Sheffield,South Yorkshire,England,S9 4EU,Wider Public Sector,Clinical Commissioning Group,False
+10578632,Vision Redbridge Culture and Leisure,,Central Library Clements Road,Ilford,,Ilford,,England,IG1 1EA,Wider Public Sector,Other,False
+10578276,East West Railway Company,,,,,,,,XXXX,Wider Public Sector,,False
+10578228,Brampton Manor Academy,,Roman Rd East Ham.,London,Greater London,London,Greater London,England,E6 3SQ,Wider Public Sector,Education,False
+10577945,Secretary of State for Justice acting through Her Majesty's Prison and Probation Services (HMPPS),,102 Petty France,London,,London,,,SW1H 9AJ,Central Government,Other,False
+10577915,Bradford District Care Foundation Trust,,,,,,,,XXXX,Wider Public Sector,TBA,False
+10577398,Henry Fawcett Primary School,,,London,,London,,,SE11 5BZ,Wider Public Sector,,False
+10577301,North Shropshire College,,,Oswestry,,Oswestry,,,SY11 4QB,Wider Public Sector,TBA,False
+10576043,Repton School,,Repton,Derby,,Derby,,,DE65 6FH,Wider Public Sector,Education,False
+10570661,Rayne Primary and Nursery School,,"Capel Road, Rayne",Braintree,,Braintree,,,CM77 6BZ,Wider Public Sector,,False
+10567654,Comberton Village College,,"West Street, Comberton",Cambridge,,Cambridge,,,CB23 7DU,Wider Public Sector,,False
+10567172,Brockworth Primary Academy,,"Moorfield Road, Brockworth",Gloucester,,Gloucester,,,GL3 4JL,Wider Public Sector,,False
+10565882,St Joseph's Catholic School,,Church Road Laverstock,Salisbury,Wiltshire,Salisbury,Wiltshire,England,SP1 1QY,Wider Public Sector,TBA,False
+10565590,Government of New South Wales,,2-24 Rawson Place McKell Building Sydney NSW,Sydney,,Sydney,,Australia,2000,Wider Public Sector,Central Government,False
+10565390,NEWLON HOUSING TRUST,,"NEWLON HOUSING TRUST OUTWARD HOUSING Newlon House 4 Daneland Walk, Hale Village LONDON United Kingdom   N17 9FE",,,,,,XXXX,Wider Public Sector,Other,False
+10565195,RAF,,,,,,,,XXXX,Central Government,MoD - RAF,False
+10564633,Customer001,,,,,,,,XXXX,Central Government,Health,False
+10563105,Scottish Canals,,Canal House Applecross Street,Glasgow,,Glasgow,,Scotland,G4 9SP,Wider Public Sector,Utility (Historic),False
+10563066,Local Authority (Test Account),,,,,,,,XXXX,Central Government,TBA,False
+10562824,Imperial College Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562823,Calderdale and Huddersfield NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562822,NHS Digital,,,,,,,,LS1 6AE,Wider Public Sector,,False
+10562821,Devon Partnership NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562820,Royal Surrey County Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562819,Oxleas NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562818,University Hospitals Of Leicester NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562817,Leeds and York Partnership NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562816,www.rbch.nhs.uk/,,,,,,,,XXXX,Wider Public Sector,,False
+10562815,The Royal Bournemouth and Christchurch Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562814,York Teaching Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562813,Avon and Wiltshire Mental Health Partnership NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562812,Yeovil District Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562811,Nottinghamshire Healthcare NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562810,Chesterfield Royal Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562809,Yorkshire Ambulance Service NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562808,Mid Essex Hospital Services NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562807,Sherwood Forest Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562806,Sheffield Teaching Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562805,Isle Of Wight NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562804,Oxford University Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562803,West Hertfordshire Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562802,Salisbury NHS FT,,,,,,,,XXXX,Wider Public Sector,,False
+10562801,Papworth Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562800,Surrey and Borders Partnership NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562799,Solent NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562798,Central Manchester University Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562797,Ipswich Hospital NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562796,West London Mental Health NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562795,Royal Free London Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562794,Lancashire Teaching Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562793,"Northumberland, Tyne and Wear NHS Foundation Trust",,,,,,,,XXXX,Wider Public Sector,,False
+10562792,Royal Free London Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562791,Epsom and St Helier University Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562790,The Walton Centre NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562789,University Hospital Southampton NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562788,South Tees Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562787,Bolton NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562786,Sheffield Children's NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562785,The Royal Marsden NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562784,"The Queen Elizabeth Hospital, King's Lynn. NHS Foundation Trust",,,,,,,,XXXX,Wider Public Sector,,False
+10562783,The Royal Bournemouth and Christchurch Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562782,Royal Cornwall Hospitals NHS Trust / Cornwall Partnership NHS FT,,,,,,,,XXXX,Wider Public Sector,,False
+10562781,Staffordshire and Stoke On Trent Partnership NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562779,Norfolk and Norwich University Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562778,Stockport NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562777,Great Western Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562776,West Suffolk NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562775,Yeovil District Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562774,Nottingham University Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562773,Royal Liverpool and Broadgreen University Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562772,Leeds Community Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562771,Dorset HealthCare University NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562770,Kent Community Health NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562769,Walsall Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562768,"Tees, Esk and Wear Valleys NHS Foundation Trust",,,,,,,,XXXX,Wider Public Sector,,False
+10562767,Oxford Health NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562766,Norfolk and Suffolk NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562765,Mersey Care NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562764,Doncaster and Bassetlaw Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562763,NHS Digital,,,,,,,,BL5 2RQ,Wider Public Sector,,False
+10562762,NHS South of England Procurement Services,,,,,,,,XXXX,Wider Public Sector,,False
+10562761,Medway NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562760,Leeds Teaching Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562759,Torbay & South Devon NHS FT,,,,,,,,XXXX,Wider Public Sector,,False
+10562758,The Christie NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562757,Royal Free London NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562756,Salisbury NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562755,The Royal Wolverhampton NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562754,Berkshire Healthcare NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562752,Chelsea and Westminster Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562751,Royal Free London Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562750,Harrogate and District NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562749,University Hospital Birmingham NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562748,Whittington Health Hospital,,,,,,,,XXXX,Wider Public Sector,,False
+10562747,Portsmouth Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562746,Northampton General Hospital NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562745,Pennine Care NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562744,Sussex Community NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562743,Cambridgeshire and Peterborough NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562742,The Royal Bournemouth and Christchurch Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562741,The Royal Bournemouth & Christchurch Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562740,The Royal Bournemouth and Christchurch Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562739,South East Coast Ambulance Service NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562738,Rotherham Doncaster and South Humber NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562737,Wirral Community NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562736,London North West Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562735,Blackpool Teaching Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562734,Northern Devon Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562733,George Eliot Hospital NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562732,County Durham and Darlington NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562731,St George's University Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562730,United Lincolnshire Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562729,Lincolnshire Community Health Services NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562728,Worcestershire Health and Care NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562727,South Western Ambulance Service NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562726,Warrington and Halton Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562725,Department of Health,,,,,,,,LS2 7UE,Wider Public Sector,,False
+10562724,James Paget University Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562723,Northumbria Healthcare NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562722,General Medical Council,,,,,,,,M3 3AW,Wider Public Sector,,False
+10562721,Countess Of Chester Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562720,Great Ormond Street Hospital,,,,,,,,XXXX,Wider Public Sector,,False
+10562719,Black Country Partnership NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562718,Camden and Islington NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562717,City Hospitals Sunderland NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562716,"Wrightington, Wigan and Leigh NHS Foundation Trust",,,,,,,,XXXX,Wider Public Sector,,False
+10562715,Imperial College Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562714,East London NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562713,South Central Ambulance Service NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562712,"Barnet, Enfield and Haringey Mental Health NHS Trust",,,,,,,,XXXX,Wider Public Sector,,False
+10562711,Birmingham Women's NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562710,Birmingham Community Healthcare NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562709,Birmingham and Solihull Mental Health NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562708,Mid Cheshire Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562707,Peninsula Purchasing & Supply Alliance (Host: Plymouth Hospitals NHS Trust),,,,,,,,XXXX,Wider Public Sector,,False
+10562706,University Hospital Southampton NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562705,Peninsula Purchasing & Supply Alliance (Host: Plymouth Hospitals NHS Trust),,,,,,,,XXXX,Wider Public Sector,,False
+10562704,East Cheshire NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562703,The Royal Orthopaedic Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562702,Sandwell and West Birmingham Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562701,Royal Berkshire NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562700,Burton Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562699,Moorfields Eye Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562698,UCL Partners Procurement Service,,,,,,,,XXXX,Wider Public Sector,,False
+10562697,Royal Free London Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562696,South London and Maudsley NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562695,Plymouth Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562694,Lancashire Care NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562693,Southern Health NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562692,Maidstone and Tunbridge Wells NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562691,Homerton University Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562690,Dudley and Walsall Mental Health Partnership NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562689,Dorset County Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562688,Cambridgeshire Community Services NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562687,Hull and East Yorkshire Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562686,Bradford District Care NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562685,Gateshead Health NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562684,North Middlesex University Hospital,,,,,,,,XXXX,Wider Public Sector,,False
+10562683,The Dudley Group NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562682,Salford Royal NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562681,Taunton & Somerset NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562680,Guy's and St Thomas' NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562679,University College London Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562678,Hounslow and Richmond Community Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562677,Ashford and St. Peter?s Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562676,"Barking, Havering and Redbridge University Hospitals NHS Trust",,,,,,,,XXXX,Wider Public Sector,,False
+10562675,Bradford Teaching Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562674,York Teaching Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562673,Worcestershire Acute Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562672,Barnsley Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562671,South West London and St George's Mental Health NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562670,Royal Free London Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562669,Lewisham and Greenwich NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562668,Liverpool Community Health NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562667,Derby Teaching Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562666,University Hospitals of North Midlands,,,,,,,,XXXX,Wider Public Sector,,False
+10562665,North Staffordshire Combined Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562664,Frimley Health NHS Foundation Trust. (formerly Park Health NHSFT),,,,,,,,XXXX,Wider Public Sector,,False
+10562663,University Hospitals Bristol NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562662,Southend University Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562661,Barts Health NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562660,Sheffield Health and Social Care NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562659,Northern Lincolnshire and Goole NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562658,General Medical Council,,,,,,,,M3 3AW,Wider Public Sector,,False
+10562657,North Cumbria University Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562656,King's College Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562655,The Newcastle Upon Tyne Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562654,Royal United Hospital Bath NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562653,Hampshire Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562652,Derbyshire Healthcare NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562651,Shropshire Community Health NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562650,North West Ambulance Service NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562649,Cambridge University Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562648,The Rotherham NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562647,Leicestershire Partnership NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562646,Royal Devon & Exeter NHS FT,,,,,,,,XXXX,Wider Public Sector,,False
+10562645,Lincolnshire Partnership NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562644,South Warwickshire NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562643,Northamptonshire Healthcare NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562642,Brighton and Sussex University Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562641,North Tees and Hartlepool NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562640,Southport and Ormskirk Hospital NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562638,Peninsula Purchasing & Supply Alliance (Host: Plymouth Hospitals NHS Trust),,,,,,,,XXXX,Wider Public Sector,,False
+10562637,Birmingham Children's Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562636,Weston Area Health NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562635,University Hospitals Bristol NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562634,Bristol Community Health,,,,,,,,XXXX,Wider Public Sector,,False
+10562633,Bristol & Weston Purchasing Consortium,,,,,,,,XXXX,Wider Public Sector,,False
+10562632,Great Ormond Street Hospital for Children NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562631,Moorfields Eye Foundation Trust Hospital,,,,,,,,XXXX,Wider Public Sector,,False
+10562630,The Princess Alexandra Hospital NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562629,Gloucestershire Care Services CIC,,,,,,,,XXXX,Wider Public Sector,,False
+10562628,2gether NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562627,St Helens and Knowsley Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562626,Milton Keynes University Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562625,Greater Manchester West Mental Health NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562624,Buckinghamshire Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562623,Hertfordshire Partnership University NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562622,Hertfordshire Community NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562621,East and North Hertfordshire NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562620,Tameside Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562619,Taunton and Somerset NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562618,The Whittington Hospital NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562617,North Middlesex University Hospital NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562616,Colchester Hospital University NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562615,Yeovil District Hospital NHS Trust / Somerset Partnership NHS FT,,,,,,,,XXXX,Wider Public Sector,,False
+10562614,Surrey and Sussex Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562613,Dorset County Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562612,Hampshire Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562611,Bridgewater Community Healthcare NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562610,Liverpool Heart and Chest NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562609,Dorset HealthCare University Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562608,University Hospitals Coventry and Warwickshire NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562607,Coventry and Warwickshire Partnership NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562606,North East London NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562605,Bedford Hospital NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562604,Peninsula Purchasing & Supply Alliance (Host: Plymouth Hospitals NHS Trust),,,,,,,,XXXX,Wider Public Sector,,False
+10562603,London Ambulance Service NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562602,The Robert Jones and Agnes Hunt Orthopeadic Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562601,Peterborough and Stamford Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562600,Shrewsbury and Telford Hospital NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562599,Royal Free London Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562598,Croydon Health Services NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562597,Mid Yorkshire Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562596,Western Sussex Hospitals NHS Foundation Trust (Worthing),,,,,,,,XXXX,Wider Public Sector,,False
+10562595,NHS Lothian,,,,,,,,EH1 3EG,Wider Public Sector,,False
+10562594,Taunton & Somerset NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562593,South West Yorkshire Partnership NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562592,Wye Valley NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562591,West Midlands Ambulance Service NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562590,University Hospitals Of Morecambe Bay NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562589,Heart Of England NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562588,Aintree University Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562586,Wirral University Teaching Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562585,East Kent Hospitals University NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562584,Plymouth Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562583,Kent and Medway NHS and Social Care Partnership Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562582,East Midlands Ambulance Service NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562581,Royal Devon and Exeter NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562580,Cumbria Partnership NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562579,Luton and Dunstable University Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562578,East Of England Ambulance Service NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562577,South Tyneside NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562576,Dartford & Gravesham NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562575,Huddersfield Royal Infirmary,,,,,,,,HD3 3EA,Wider Public Sector,,False
+10562574,Somerset Partnership NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562573,Dorset County Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562572,5 Boroughs Partnership NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562571,Western Sussex Hospital Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562570,Hinchingbrooke Health Care NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562568,Kingston Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562567,Alder Hey Children's NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562566,Airedale NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562565,Taunton & Somerset NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562564,Sirona Care & Health,,,,,,,,XXXX,Wider Public Sector,,False
+10562563,Pennine Acute Hospitals NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562562,Manchester Mental Health and Social Care Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562561,Moorfields Eye Foundation Trust Hospital,,,,,,,,XXXX,Wider Public Sector,,False
+10562560,Great Western Hospital,,,,,,,,XXXX,Wider Public Sector,,False
+10562559,University Hospitals Bristol NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562558,Poole Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562557,Basildon and Thurrock University Hospitals NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562556,Queen Victoria Hospital NHS Foundation Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562555,Central London Community Healthcare NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562554,Norfolk Community Health and Care NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562553,Royal National Orthopaedic Hospital NHS Trust,,,,,,,,XXXX,Wider Public Sector,,False
+10562552,Yeovil District Hospital,,,,,,,,XXXX,Wider Public Sector,,False
+10562060,test,,,,,,,,XXXX,Central Government,Army,False
+10550148,TFLTEST,,,,,,,,XXXX,Wider Public Sector,,False
+10550105,Leicestershire County Council,,,,,,,England,LE3 8RL,Wider Public Sector,,False
+10550104,Leicestershire County Council,,,,,,,England,LE3 8RE,Wider Public Sector,,False
+10542238,Torbay And South Devon Nhs Foundation Trust,,,,,,,England,XXXX,Wider Public Sector,Strategic Health Authority,False
+10542036,PROTONTEST,,,,,,,,XXXX,Wider Public Sector,,False
+10542035,BBCTEST,,,,,,,,XXXX,Wider Public Sector,,False
+10542033,GIOGASTEST,,,,,,,,XXXX,Wider Public Sector,,False
+10541916,Hastings & Rother Primary Care Trust,,,,,,,England,TN33 0EN,Wider Public Sector,TBA,False
+10541909,Hailey Hall Academy,,Hailey Lane,Hertford,Hertfordshire,Hertford,Hertfordshire,England,SG13 7PB,Wider Public Sector,Academy (All Types),False
+10541621,Defence Electronics & Components Agency (DECA MOD),,DECA headquarters Welsh Road  Deeside,Flintshire,,Flintshire,,,CH5 2LS,Central Government,Executive Agency,False
+10541515,Department of International Trade,,King Charles Street,London,,London,,England,SW1A 2AH,Central Government,Department,False
+10541100,Wickham Parish Council,,Heatherdene Turkey Island Shedfield Southampton,,,,,,SO32 2JE,Wider Public Sector,Parish Council,False
+10541099,Bourton on the Water Parish Council,,"The George Moore Community Centre, Moore Rd, Bourton-on-the-Water",,,,,,GL54 2AZ,Wider Public Sector,Parish Council,False
+10541098,Whiteley Town Council,,Heatherdene Turkey Island  Shedfield  Southampton,,,,,,SO32 2JE,Wider Public Sector,District Council,False
+10053997,MOD,,,,,,,,XXXX,Central Government,TBA,False
+10051681,University of Leeds,,,,West Yorkshire,,West Yorkshire,England,XXXX,Wider Public Sector,Universities,False
+10051542,Land Forces (Army),,Monxton Road,Andover,Hampshire,Andover,Hampshire,England,SP11 8HJ,Central Government,MoD - Army,False
+10051541,Air Command (RAF),,Naphill,High Wycombe,,High Wycombe,,England,HP14 4UE,Central Government,MoD - RAF,False
+10051398,Efficiancy North,,Unit A6 Magna Business Park Temple Road,Rotherham,South Yorkshire,Rotherham,South Yorkshire,England,S60 1FG,Wider Public Sector,Housing Associations,False
+10051370,Joint Forces Command (2),,Sandy Lane,Northwood,,Northwood,,England,HA6 3HP,Central Government,MoD - JFC,False
+10051367,Department of Finance (Northern Ireland),,,,,,,,XXXX,Wider Public Sector,Other,False
+10051362,Victims' Advisory Panel,,,,,,,,XXXX,Central Government,Advisory non-departmental public body,False
+10051350,The Pensions Regulator,,Napier House  Trafalgar Place,Brighton,,Brighton,,England,BN1 4DW,Central Government,Executive non-departmental public body,False
+10051348,The National Archives,,,,,,,,XXXX,Central Government,,False
+10051339,(closed) Service Complaints Ombudsman,,Po Box 72252,London,,London,,England,SW1P 9ZZ,Central Government,Other,False
+10051319,Ofsted,,,,,,,,XXXX,Central Government,Non-ministerial department,False
+10051301,National Employer Advisory Board,,Main Building Horse Guards Avenue Whitehall,London,,London,,England,SW1A 2HB,Central Government,Advisory non-departmental public body,False
+10051282,Independent Dormant Assets Commission,,1 Horse Guards Road,London,,London,,England,SW1A 2HQ,Central Government,Advisory non-departmental public body,False
+10051248,z (Closed Record) Defence Sixth Form College,,Forest Road Woodhouse,Loughborough,Leicestershire,Loughborough,Leicestershire,England,LE12 8WD,Central Government,Other,False
+10051244,Defence Academy of the United Kingdom,,Shrivenham,Swindon,,Swindon,,England,SN6 8LA,Central Government,Other,False
+10051221,DSTL - Centre for Defence Enterprise,,,,,,,,XXXX,Central Government,Executive Agency,False
+10051008,Newton Primary School,,Caxton End Eltisley,St. Neots,Cambridgeshire,St. Neots,Cambridgeshire,England,PE19 6TL,Wider Public Sector,Local Authority Maintained School (All Types),False
+10050967,STRATEGIC WEAPONS PROJECT TEAM,,Abbey Wood,Bristol,Somerset,Bristol,Somerset,England,BS34 8JH,Central Government,TBA,False
+10044048,"Southfield Trust, the",,Lindfield Road,Eastbourne,East Sussex,Eastbourne,East Sussex,England,BN22 0BQ,Wider Public Sector,Academy (All Types),False
+10043948,York St John University,,Lord Mayors Walk,York,North Yorkshire,York,North Yorkshire,England,YO31 7EX,Wider Public Sector,Universities,False
+10043925,"Wherry School, the",,Hall Road,Norwich,Norfolk,Norwich,Norfolk,England,NR4 6AJ,Wider Public Sector,Academy (All Types),False
+10043820,Peninsula Trust The,,The Methodist Hall New Street,Millbrook,Cornwall,Millbrook,Cornwall,England,PL10 1BY,Wider Public Sector,Other,False
+10043732,Rowena House Care Home,,Old Road Conisbrough,Doncaster,South Yorkshire,Doncaster,South Yorkshire,England,DN12 3LX,Wider Public Sector,TBA,False
+10043413,Bishop Cornish CEVA Primary School,,Lynher Drive,Saltash,Cornwall,Saltash,Cornwall,England,PL12 4PA,Wider Public Sector,Local Authority Maintained School (All Types),False
+10043166,Valley Gardens Middle School,,"3Rd Floor Left, Quadrant East",North Tyneside,,North Tyneside,,England,NE25 9AQ,Wider Public Sector,Local Authority Maintained School (All Types),False
+10043068,Police Scotland,,2 French Street,Glasgow,Lanarkshire,Glasgow,Lanarkshire,Scotland,G40 4EH,Wider Public Sector,TBA,False
+10043060,Computer Emergency Response Team (CERT UK ),,8-10 Great George Street,London,Greater London,London,Greater London,England,SW1P 3AE,Central Government,TBA,False
+10042979,PCA Test,,20 Shaftesbury Square,Belfast,County Antrim,Belfast,County Antrim,Northern Ireland,BT2 7DB,Wider Public Sector,Education,False
+10042964,Eirol Advocacy,,59 Heol Y Brenin,Caerfyrddin,Carmarthenshire,Caerfyrddin,Carmarthenshire,Wales,SA31 1BA,Wider Public Sector,Not for Profit,False
+10042957,South West Herts Partnership,,The Lodge 95A Gammons Lane,Watford,Hertfordshire,Watford,Hertfordshire,England,WD24 5HX,Wider Public Sector,Other,False
+10042940,Porton Biopharma Ltd,,Porton Down,Salisbury,Wiltshire,Salisbury,Wiltshire,England,SP4 0JG,Central Government,Public Corporation,False
+10042820,Elliot Foundation Acadamies Trust,,1 Naoroji Street,London,Greater London,London,Greater London,England,WC1X 0GB,Wider Public Sector,Academy (All Types),False
+10042808,Ridgeway Middle School,,Evesham Road,,,Redditch,Worcestershire                ,England                       ,B96 6BD,Wider Public Sector,Education,False
+10042728,Derby Manufacturing UTC,,Locomotive Way,Pride Park,,Derby,Derbyshire                    ,England                       ,DE24 8ZS,Wider Public Sector,Education,False
+10042683,Veolia UK plc,,210 Pentonville Road,,,London,Middlesex                     ,England                       ,N1 9JY,Wider Public Sector,,False
+10042534,Scottish Police Authority,,1 Pacific Quay,,,Glasgow,,England                       ,G51 1DZ,Wider Public Sector,,False
+10042524,North and East London Commissioning Support Unit,,75 Worship Street,London,Middlesex,London,Middlesex,England,EC2A 2DU,Wider Public Sector,Commissioning Support Unit,False
+10042521,Natural Envrionment Research Couuncil,,Polaris House,,,London,Middlesex,England,SN2 1EU,Wider Public Sector,,False
+10042514,Hertfordshire Constabulary,,Stanborough Road,,,Welwyn Garden City,Hertfordshire,England,AL8 6XF,Wider Public Sector,TBA,False
+10042454,Westgate Academy,,Westgate,Lincoln,Lincolnshire,Lincoln,Lincolnshire,England,LN1 3BQ,Wider Public Sector,Academy (All Types),False
+10042407,ERS Medical,,Indigo House,Sussex Avenue,,Leeds,West Yorkshire                ,England                       ,LS10 2LF,Wider Public Sector,,False
+10042276,Age UK Leicester Shire And Rutland,,CLARENCE HOUSE,,,Leicester,Leicestershire,England,LE1 3PJ,Wider Public Sector,Not for Profit,False
+10042251,MOD Navy,,Main Building,London,Greater London,London,Greater London,England,SW1A 2HB,Central Government,MoD - Navy,False
+10042248,Stratford-on-Avon District Council,,Elizabeth House,Stratford-upon-Avon,,Stratford-upon-Avon,,England,CV37 6HX,Wider Public Sector,District Council,False
+10042220,North Tyneside Council,,16 The Silverlink North,,,Newcastle upon Tyne,Tyne and Wear                 ,England                       ,NE270BY,Wider Public Sector,District Council,False
+10042206,Patient Care at Home,,16 The Square,Crewe,,Crewe,,England,CW4 7AB,Wider Public Sector,Private Sector Enabler,False
+10042164,University Hospital of North Midlands NHS Trust,,Newcastle Road,Stoke-on-Trent,,Stoke-on-Trent,,England,ST4 6QG,Wider Public Sector,,False
+10042142,Framingham Earl High School,,Norwich Road,Norwich,Norfolk,Norwich,Norfolk,England,NR147QP,Wider Public Sector,Local Authority Maintained School (All Types),False
+10042059,St. Leger Homes Of Doncaster Ltd,,St. Leger Court,White Rose Way,,Doncaster,South Yorkshire               ,England                       ,DN45ND,Wider Public Sector,,False
+10042014,Mid Essex NHS Trust,,Broomfield Hospital,Chelmsford,Essex,Chelmsford,Essex,England,CM17ET,Wider Public Sector,,False
+10041964,St. Peter's Church in Wales Primary School,,Chapel Lane,Rossett,,Wrexham,,Wales                         ,LL12 0EE,Wider Public Sector,,False
+10041804,Southwest Heritage Trust The,,Brunel Way,Norton Fitzwarren,,Taunton,Somerset,England,TA2 6SF,Wider Public Sector,Charity,False
+10041648,New Forest Citizens Advice Bureau,,91 Junction Road,Totton,,Southampton,Hampshire                     ,England                       ,SO40 3BU,Wider Public Sector,Charity,False
+10041644,Shuttleworth College,,Burnley Road Padiham,Burnley,Lancashire,Burnley,Lancashire,England,BB12 8ST,Wider Public Sector,Colleges of Further Education,False
+10041617,Citizens Advice Services Corby and Kettering,,The Corby Cube,"Parkland Gateway, George Street",Corby,Northants,Northamptonshire              ,England                       ,NN17 1QG,Wider Public Sector,,False
+10041581,ARK School,,65 Kingsway,,,London,,England                       ,WC2B 6TD,Wider Public Sector,Specialist Schools,False
+10041490,Westminster School,,7-9 Dean Bradley Street,London,Greater London,London,Greater London,England,SW1P 3EP,Wider Public Sector,Non-maintained Schools,False
+10041380,Children's Links,,Holland House,Mareham Road,,Horncastle,Lincolnshire                  ,England                       ,LN9 6PH,Wider Public Sector,Charity,False
+10041353,Sport England,,50 George Street,,,London,,England                       ,W1U 7GA,Wider Public Sector,Charity,False
+10041339,Arden Commissioning Support Unit,,Worcester Countryside Centre,Wildwood Drive,,Worcester,Worcestershire,England,WR5 2LG,Wider Public Sector,,False
+10041331,Plantsbrook School,,Upper Holland Road,,,Sutton Coldfield,West Midlands                 ,England                       ,B72 1RB,Wider Public Sector,Secondary Schools,False
+10041309,Northern Ireland Blood Transfusion Service,,PO Box 2086,,,Belfast,,Northern Ireland              ,BT1 9QH,Wider Public Sector,Health,False
+10041286,Culturenl Limited,,Heritage Way,Coatbridge,Strathclyde,Coatbridge,Strathclyde,Scotland,ML5 1QD,Wider Public Sector,Education,False
+10041249,Greater Durham Citizens Advice Bureau,,32 Claypath,,,Durham,,England                       ,DH1 1RH,Wider Public Sector,Charity,False
+10041144,Wythenshawe Community Housing Group,,8 Poundswick Lane,,,Manchester,Greater Manchester            ,England                       ,M22 9TA,Wider Public Sector,,False
+10041023,St Giles Junior School,,Hayes Lane Exhall,Coventry,West Midlands,Coventry,West Midlands,England,CV7 9NF,Wider Public Sector,TBA,False
+10041020,Bracknell and District Citizens Advice Bureau,,Market Street,,,Bracknell,Berkshire                     ,England                       ,RG12 1JG,Wider Public Sector,,False
+10040863,University of Essex,,Wivenhoe Park,,,Colchester,Essex,England,CO4 3SQ,Wider Public Sector,Universities,False
+10040800,Cambridgeshire and Peterborough CCG,,Lockton House,Clarendon Road,,Cambridge,Cambridgeshire                ,England                       ,CB2 8FH,Wider Public Sector,,False
+10040670,Pathways Housing,,65 Tawny Close,,,London,,England                       ,W13  9LX,Wider Public Sector,Housing Associations,False
+10040669,RSPCA,,Wilberforce Way,Southwater,,Horsham,West Sussex,England,RH13 9RS,Wider Public Sector,Charity,False
+10040656,Pennine Care NHS Foundation Trust,,225 Old Street,,,Ashton-under-Lyne,Greater Manchester            ,England                       ,OL6 7SR,Wider Public Sector,Care Trust,False
+10040626,Percy Hedley Foundation,,Forest Hall,Newcastle upon Tyne,Tyne and Wear,Newcastle upon Tyne,Tyne and Wear,England,NE12 8YY,Wider Public Sector,TBA,False
+10040481,George Eliot Hospital NHS Trust,,Lewis House,College Street,,Nuneaton,Warwickshire                  ,England                       ,CV10 7DJ,Wider Public Sector,,False
+10040434,NHS South Yorkshire And Bassetlaw Commissioning Support Unit,,722 Prince of Wales Road,Sheffield,South Yorkshire,Sheffield,South Yorkshire,England,S9 4EU,Wider Public Sector,Commissioning Support Unit,False
+10040360,Intelligence Information Solutions,,"#1247, Yew 2B NH1, DE&S Abbey Wood",Bristol,Hampshire,Bristol,Hampshire,England,BS34 8JH,Central Government,TBA,False
+10040356,Op KIPION (Closed),,Op KIPION RAF,,,,,England,BFPO 639,Central Government,TBA,False
+10040341,The UK Green Investment Bank Plc,,144 Morrison Street,,,Edinburgh,,Scotland                      ,EH3 8EX,Central Government,,False
+10040280,London Borough Of Harrow,,Sudbury Hill,,,Harrow,,England                       ,HA1 3SB,Wider Public Sector,,False
+10040263,East Berks Primary Care Trust,,Clarendon Business Centre,,,Berkshire          ,Berkshire                     ,England                       ,RG12 1BP,Wider Public Sector,,False
+10040250,Asfordby Captain's Close Primary School,,Saxelby Road,Leics,Leicestershire,Leics,Leicestershire,England,LE14 3TU,Wider Public Sector,TBA,False
+10040245,Aberdeen Council Of Voluntary Organisations,,Voluntary Organisations,Aberdeen,Aberdeenshire,Aberdeen,Aberdeenshire,Scotland,AB10 1LU,Wider Public Sector,Not for Profit,False
+10040191,Chadlington CE Primary School,,Church Road Chadlington,"Chipping Norton ,",Oxfordshire,"Chipping Norton ,",Oxfordshire,England,OX7 3LY,Wider Public Sector,Local Authority Maintained School (All Types),False
+10040190,Checkendon CE Primary School,,Checkendon Checkendon,Reading,Kent,Reading,Kent,England,RG8 0SR,Wider Public Sector,Local Authority Maintained School (All Types),False
+10040189,Middle Barton County Primary School,,27 Church Lane Middle Barton,Chipping Norton,Oxfordshire,Chipping Norton,Oxfordshire,England,OX7 7BX,Wider Public Sector,Local Authority Maintained School (All Types),False
+10040188,Brize Norton Primary School,,Station Road Brize Norton,Carterton,Oxfordshire,Carterton,Oxfordshire,England,OX18 3PL,Wider Public Sector,Local Authority Maintained School (All Types),False
+10040187,BrightwellCumSotwell CofEC Primary School,,Greenmere Brightwell-cum-Sotwell,Wallingford,Oxfordshire,Wallingford,Oxfordshire,England,OX10 0QH,Wider Public Sector,Local Authority Maintained School (All Types),False
+10040186,Brookside Primary School,,Bucknell Road Bicester,Bicester,Oxfordshire,Bicester,Oxfordshire,England,OX26 2DB,Wider Public Sector,Local Authority Maintained School (All Types),False
+10040184,Blewbury Endowed CE Primary School,,Westbrook Street Blewbury,Didcot,Oxfordshire,Didcot,Oxfordshire,England,OX11 9QB,Wider Public Sector,Local Authority Maintained School (All Types),False
+10040183,Badgemore Community School,,Hop Gardens,Henley-on-Thames,Oxfordshire,Henley-on-Thames,Oxfordshire,England,RG9 2HL,Wider Public Sector,Local Authority Maintained School (All Types),False
+10040134,Representative Body of the Church in Wales The,,39 Cathedral Road,Cardiff,South Glamorgan,Cardiff,South Glamorgan,Wales,CF11 9XF,Wider Public Sector,Not for Profit,False
+10040130,South Hams Citizens Advice Bureau,,Follaton House,Plymouth Road,,Totnes,Devon                         ,England                       ,TQ9 5NE,Wider Public Sector,,False
+10040106,Bletchingdon Parochial CofE Primary School,,Weston Road,Bletchingdon,,Kidlington,Oxfordshire                   ,England                       ,OX5 3DH,Wider Public Sector,,False
+10040088,Central Manchester CCG,,Parkway One,Parkway Business Centre,Princess Road,Manchester,Greater Manchester            ,England                       ,M14 7LU,Wider Public Sector,,False
+10040031,Natural Resources Wales,,Cambria House,29 Newport Road,,Cardiff,,Wales                         ,CF24 0TP,Central Government,,False
+10040012,NHS Northumerland CCG,,County Hall,,,Morpeth,Northumberland                ,England                       ,NE61 2EF,Wider Public Sector,,False
+10040011,NHS North West Surrey CCG,,2nd Floor,Weybridge Hospital,Church Street,Weybridge,Surrey                        ,England                       ,KT13 8DY,Wider Public Sector,,False
+10040001,Wolverhampton Citizens Advice Bureau,,26 Snow Hill,,,Wolverhampton,West Midlands                 ,England                       ,WV2 4AD,Wider Public Sector,,False
+10039991,NHS North Tyneside Clinical Commissioning Group,,12 Hedley Court,Orion Business Park,,North Shields,Tyne and Wear                 ,England                       ,NE29 7ST,Wider Public Sector,PCT - Commissioning,False
+10039968,Rhondda Cynon Taf County Council,,Valleys Innovation Centre,Navigation Park,Abercynon,Mountain Ash,,Wales                         ,cf45 4sn,Wider Public Sector,County Council,False
+10039905,South Manchester CCG,,Parkway Three,Parkway Business Centre,Princess Road,Manchester,Greater Manchester            ,England                       ,M14 7LU,Wider Public Sector,,False
+10039820,Cadbury College,,Downland Close,Kings Norton,,Birmingham,,England                       ,B38 8QT,Wider Public Sector,,False
+10039819,Business Academy Bexley The,,Yarnton Way Thamesmead,Erith,Kent,Erith,Kent,England,DA18 4DW,Wider Public Sector,Academy (All Types),False
+10039782,Torfaen Leisure Trust Limited,,Henllys Way,Cwmbran,Torfaen,Cwmbran,Torfaen,Wales,NP44 3YS,Wider Public Sector,TBA,False
+10039747,City of London Corporation,,Guildhall,,,London,,England                       ,EC2P 2EJ,Wider Public Sector,,False
+10039742,Government of St Helena,,Post Office Building Jamestown St Helena Island,South Atlantic Ocean,,South Atlantic Ocean,,BFP,STHL 1ZZ,Wider Public Sector,TBA,False
+10039741,NHS BEST WEST CSU,,Phoenix House,Topcliffe Lane,Tingley,Wakefield,West Yorkshire                ,England                       ,WF3 1WE,Wider Public Sector,,False
+10039652,University Of Bristol,,Accounts Office,Queens Road,,Clifton,Somerset                      ,England                       ,BS8 1LN,Wider Public Sector,Universities,False
+10039641,Torbay and South Devon NHS Foundation Trust,,Bay House,Nicholson Road,,Torquay,Devon,England,TQ2 7TD,Wider Public Sector,Care Trust,False
+10039624,Prostate Cancer Charity The,,1St Floor  Cambridge House 100 Cambridge Grove,London,Greater London,London,Greater London,England,W6 0LE,Wider Public Sector,TBA,False
+10039602,The Lennard Surgery,,1 Lewis Road,,,Bristol,,England                       ,BS13 7JD,Wider Public Sector,,False
+10039584,The David Ross Education Trust,,Havelock Academy,Holyoake Road,,Grimsby,Lincolnshire                  ,England                       ,DN32 8JH,Wider Public Sector,,False
+10039554,Summercroft Primary School,,Plawhatch Close,Bishops Stortford,Hertfordshire,Bishops Stortford,Hertfordshire,England,CM23 5BJ,Wider Public Sector,Academy (All Types),False
+10039548,Stonebow Primary,,Stonebow Close,Loughborough,Leicestershire,Loughborough,Leicestershire,England,LE11 4ZH,Wider Public Sector,TBA,False
+10039515,Somerset Partnership,,2Nd Flr   Mallard Court,Express Park   Bristol Road,,Bridgewater,,England                       ,TA6 4RN,Wider Public Sector,,False
+10039435,Prostate Cancer Uk,,1St Floor  Cambridge House 100 Cambridge Grove,London,Greater London,London,Greater London,England,W6 0LE,Wider Public Sector,TBA,False
+10039394,Old Mill Primary School,,Station Road,Broughton Astley,Leicestershire,Broughton Astley,Leicestershire,England,LE9 6PW,Wider Public Sector,TBA,False
+10039161,Gmb Southern Region,,Cooper House,205 Hook Road,,Chessington,Surrey                        ,England                       ,KT9 1EA,Wider Public Sector,,False
+10039050,Cosby Primary School,,Portland Street Cosby,Leicester,Leicestershire,Leicester,Leicestershire,England,LE9 1TE,Wider Public Sector,Academy (All Types),False
+10038983,Brookside Primary School,,Copse Close,Oadby,Leicestershire,Oadby,Leicestershire,England,LE2 4FU,Wider Public Sector,TBA,False
+10038939,Averroes Pharmacy Limited,,Woodroyd Centre,Woodroyd Road,,Bradford,,England                       ,BD5 8EL,Wider Public Sector,,False
+10038919,All Saints Church of England Academy Plymouth,,Honicknowle Lane Pennycross,Plymouth,Devon,Plymouth,Devon,England,PL5 3NE,Wider Public Sector,TBA,False
+10038913,Age Uk Spalding District,,1 The Meadows,,,Spalding,Lincolnshire                  ,England                       ,PE11 1XR,Wider Public Sector,,False
+10038912,Age Uk Mid Mersey Trading,,24-28 Claughton Street,,,St Helens,Merseyside                    ,England                       ,WA10 1RZ,Wider Public Sector,,False
+10038892,Heathlands Citizens Advice Bureau,,Ridgewood Centre,Old Bisley Road,Frimley,Camberley,Surrey                        ,England                       ,GU16 9QE,Wider Public Sector,,False
+10038884,NHS St Helen's CCG,,Nutgrove Villa,Westmorland Road,Huyton,Liverpool,Merseyside                    ,England                       ,L36 6GA,Wider Public Sector,,False
+10038852,LeSoCo,,Breakspears Road,,,London,,England                       ,SE4 1UT,Wider Public Sector,,False
+10038840,Salford Primary Care Trust,,St James House ,Pendleton Way ,,Salford ,Lancashire                    ,England                       ,M6 5FW,Wider Public Sector,,False
+10038838,NHS North and East London Commissioning Support Unit,,Clifton House,75 - 77 Worship Street ,,London ,,England                       ,EC2A 2DU,Wider Public Sector,,False
+10038825,NHS PROPERTY SERVICES Limited,,Phoenix House,Topcliffe Lane,Tingley,Wakefield,West Yorkshire,England,WF3 1WE,Wider Public Sector,TBA,False
+10038817,Turriff Citizens Advice Bureau,,Masonic Temple,,,Turriff,,NULL,AB53 4AT,Wider Public Sector,,False
+10038795,City and Hackney PCT Commissioning Unit,,Clifton House,75-77 Worship Street,,London,,England                       ,EC2A 2DU,Wider Public Sector,,False
+10038791,North Staffordshire Combined Healthcare NHS Trust,,"c/o North Staffs Finance Registration Agency, Heron House",120 Grove Road,Fenton,Stoke-on-Trent,,England,ST4 4LX,Wider Public Sector,Commissioning Support Unit,False
+10038785,County Durham PCT ,,John Snow House ,Durham University Science Park ,,County Durham ,County Durham                 ,England                       ,DH1 3YG,Wider Public Sector,,False
+10038745,NHS Lancashire Commissioning Support Unit,,Jubilee House,Lancashire Business Park,Centurion Way,Leyland,Lancashire                    ,England                       ,PR26 6TR,Wider Public Sector,Health,False
+10038742,NHS Staffordshire and Lancashire Clinical Support Unit,,Heron House,120 Grove Road,,Stoke-on-Trent,Staffordshire                 ,England                       ,ST4 4LX,Wider Public Sector,,False
+10038735,Asfordby Hill Primary School,,Welby Road Asfordby Hill,Melton Mowbray,Leicestershire,Melton Mowbray,Leicestershire,England,LE14 3RB,Wider Public Sector,Local Authority Maintained School (All Types),False
+10038679,NHS Greater Manchester Clinical Support Unit,,St. James House,Pendleton Way,,Salford,Greater Manchester            ,England                       ,M6 5FW,Wider Public Sector,,False
+10038616,NHS Shropshire CCG,,William Farr House ,,,Shrewsbury,Shropshire                    ,England                       ,SY3 8XL,Wider Public Sector,,False
+10038615,West Kent Primary Care Trust,,Wharf House,,,Tonbridge,,England                       ,TN9 1RE,Wider Public Sector,,False
+10038614,NHS East of England,,Victoria House,,,Cambridge,Cambridgeshire                ,England                       ,CB21 5XB,Wider Public Sector,,False
+10038613,Hull Teaching PCT,,The Maltings,,,Hull,Humberside                    ,England                       ,HU1 3HA,Wider Public Sector,,False
+10038612,StocktononTees PCT,,Teesdale House,,,Stockton-on-Tees,County Durham                 ,England                       ,TS17 6BL,Wider Public Sector,,False
+10038611,Havering PCT,,Suttons View,,,Essex,Essex                         ,England                       ,RM12 6RS,Wider Public Sector,,False
+10038610,South East Essex PCT,,Suffolk House,,,Essex,Essex                         ,England                       ,SS2 6HZ,Wider Public Sector,,False
+10038609,NHS City and Hackney,,St Leonards Hospital,,,London,,England                       ,N1 5LZ,Wider Public Sector,,False
+10038607,Royal Free London NHS Foundation Trust,,Pond Street,,,London,,England                       ,NW3 2QG,Wider Public Sector,,False
+10038606,Royal Liverpool University Hospital NHS Trust,,Pembroke House,,,Liverpool,Merseyside                    ,England                       ,L3 5PH,Wider Public Sector,,False
+10038605,Rotherham NHS Foundation Trust,,Moorgate Road,,,Rotherham,Yorkshire                     ,England                       ,S60 2UD,Wider Public Sector,,False
+10038604,NHS Anglia CSU,,Lakeside 400,,,Norwich,Norfolk                       ,England                       ,NR7 0WG,Wider Public Sector,,False
+10038603,Outer North East London NHS Trust,,Kirkdale House ,,,London,Greater Manchester            ,England                       ,E11 1HP,Wider Public Sector,,False
+10038602,Lancashire Commissioning Support Service,,Jubilee House,,,Leyland,Lancashire                    ,England                       ,PR26 6TR,Wider Public Sector,,False
+10038601,NHS Worcestershire Commissioning,,Isaac Maddox House,,,Worcester,Worcestershire                ,England                       ,WR4 9RW,Wider Public Sector,,False
+10038600,NHS Swindon CCG,,David Murray John Building,,,Swindon,,England                       ,SN1 1LH,Wider Public Sector,,False
+10038599,NHS Cheshire and Merseyside CSU,,Countess of Chester Health Park,,,Chester,Cheshire                      ,England                       ,CH2 1HJ,Wider Public Sector,,False
+10038598,Tower Hamlets Primary Care Trust,,Clifton House,,,London,,England                       ,EC2A 2EJ,Wider Public Sector,,False
+10038597,East London and City Sector Acute Commissioning Unit,,Clifton House,,,London,,England                       ,EC2A  2EJ,Wider Public Sector,,False
+10038596,Surrey PCT,,Cedar Court,,,Leatherhead,Surrey                        ,England                       ,KT22 9AE,Wider Public Sector,,False
+10038595,East Anglia Local Area Team,,Capital Park,,,Fulbourn,Cambridgeshire                ,England                       ,CB21 5XE,Wider Public Sector,,False
+10038594,NHS Camden Clinical Commissioning Group,,Camden Borough Office,,,London,,England                       ,NW1 0PE,Wider Public Sector,,False
+10038593,Barking and Dagenham Primary Care Trust,,Barking Town Hall,,,Barking,Essex                         ,England                       ,IG11 7LU,Wider Public Sector,,False
+10038592,NHS Bexley CCG,,43 Granville Road,,,Sidcup,Kent                          ,England                       ,DA14 4TA,Wider Public Sector,,False
+10038591,NHS Guildford and Waverley CCG,,"3rd Floor, Crossweys House",,,Guildford,Surrey                        ,England                       ,GU1 3EL,Wider Public Sector,,False
+10038589,NHS Greenwich CCG,,31-37 Greenwich Park Street,,,London,,England                       ,SE10 9LR,Wider Public Sector,,False
+10038588,NHS Coventry and Rugby CCG,,2nd Floor Christchurch House,,,Coventry,Warwickshire                  ,England                       ,CV1 2GC,Wider Public Sector,,False
+10038587,Southwark BSU,,160 Tooley Street,,,London,,England                       ,SE1 2TZ,Wider Public Sector,,False
+10038586,Royal Marsden NHS Foundation Trust,,149 Dubhouse Street,,,London,,England                       ,SW3 6JJ,Wider Public Sector,,False
+10038585,NHS South West London,,120 The Broadway ,,,Wimbledon,,England                       ,SW19 1RH,Wider Public Sector,,False
+10038584,NHS South London CSU,,120 The Broadway ,,,Wimbledon,,England                       ,SW19 1RH,Wider Public Sector,,False
+10038583,NHS Brent CCG,,116 Chaplin Road,,,Wembley,Middlesex                     ,England                       ,HA0 4UZ,Wider Public Sector,,False
+10038582,Whipps Cross University Hospital NHS Trust,,Whipps Cross Road,,,London,Greater Manchester            ,England                       ,E11 1NR,Wider Public Sector,,False
+10038581,NHS Arden CSU,,Westgate House ,,,Warwick ,Warwickshire                  ,England                       ,CV34 4DE,Wider Public Sector,,False
+10038580,Lambeth BSU,,1 Lower Marsh,London,Greater London,London,Greater London,England,SE1 7NT,Wider Public Sector,TBA,False
+10038579,South East Essex PCT,,Suffolk House,,,Essex,Essex                         ,England                       ,SS2 6HZ,Wider Public Sector,,False
+10038574,Rotherham NHS Foundation Trust,,Moorgate Road,,,Rotherham,Yorkshire                     ,England                       ,S60 2UD,Wider Public Sector,,False
+10038571,Lancashire Commissioning Support Service,,Jubilee House,,,Leyland,Lancashire                    ,England                       ,PR26 6TR,Wider Public Sector,,False
+10038567,Tower Hamlets Primary Care Trust,,Clifton House,,,London,,England                       ,EC2A 2EJ,Wider Public Sector,,False
+10038565,Surrey PCT,,Cedar Court,,,Leatherhead,Surrey                        ,England                       ,KT22 9AE,Wider Public Sector,,False
+10038562,Barking and Dagenham Primary Care Trust,,Barking Town Hall,,,Barking,,England                       ,IG11 7LU,Wider Public Sector,,False
+10038559,NHS Eastbourne Halisham and Seaford CCG,,36-38 Friars Walk,,,Lewes,East Sussex                   ,England                       ,BN7 2PB,Wider Public Sector,,False
+10038555,Royal Marsden NHS Foundation Trust,,149 Dubhouse Street,,,London,,England                       ,SW3 6JJ,Wider Public Sector,,False
+10038548,West Kent Primary Care Trust,,Wharf House,,,Tonbridge,Kent                          ,England                       ,TN9 1RE,Wider Public Sector,,False
+10038547,NHS Arden CSU,,Westgate House ,,,Warwick ,Warwickshire                  ,England                       ,CV34 4DE,Wider Public Sector,,False
+10038545,Hull Teaching PCT,,The Maltings,,,Hull,Humberside                    ,England                       ,HU1 3HA,Wider Public Sector,,False
+10038544,StocktononTees PCT,,Teesdale House,,,Stockton-on-Tees,County Durham                 ,England                       ,TS17 6BL,Wider Public Sector,,False
+10038543,Havering PCT,,Suttons View,,,Essex,Essex                         ,England                       ,RM12 6RS,Wider Public Sector,,False
+10038525,NHS Greater East Midlands Commissioning Support Unit,,9 Brookfield Gardens,Arnold,,Nottingham,Nottinghamshire               ,England                       ,NG5 7EW,Wider Public Sector,,False
+10038522,Washwood Heath Technology College,,Burney Lane,,,Birmingham,West Midlands                 ,England                       ,B8 2AS,Wider Public Sector,,False
+10038499,Citizens Advice Bureau Caldicot,,5A Church Road,,,Caldicot,,Wales                         ,NP26 4BP,Wider Public Sector,,False
+10038494,NHS TRUST DEVELOPMENT AUTHORITY,,9TH FLOOR,SOUTHSIDE,105 VICTORIA STREET,LONDON,,England                       ,SW1E 6QT,Wider Public Sector,,False
+10038490,Hounslow & Richmond Community Healthcare,,Thames House,180-194 High Street,,Teddington,,England                       ,TW11 8HU,Wider Public Sector,,False
+10038486,NHS Property Services Limited,,South West House,Blackbrook Park Avenue,,Taunton,Somerset,England,TA1 2PX,Wider Public Sector,TBA,False
+10038458,Legal Aid Agency,,102 Petty France,,,London,,England                       ,SW1H 9AJ,Central Government,,False
+10038398,Barnet CCG,,WESTGATE HOUSE,EDGEWARE COMMUNITY HOSPITAL,BURNT OAK BROADWAY,EDGEWARE,,England                       ,HA8 0AD,Wider Public Sector,,False
+10038397,West Leicestershire CCG,,55 WOODGATE,,,LOUGHBOROUGH,Leicestershire                ,England                       ,LE11 2TZ,Wider Public Sector,,False
+10038396,East Leicestershire and Rutland CCG,,SUITE 2 AND 3,BRIDGE PARK PLAZA,"BRIDGE PARK ROAD, THURMASTON",LEICESTER,Leicestershire                ,England                       ,LE4 8BL,Wider Public Sector,,False
+10038391,Central Midlands CSU,,Kingston House,438-450 High Street,,West Bromwich,West Midlands                 ,England                       ,B70 9LD,Wider Public Sector,,False
+10038390,NHS North Yorkshire and Humber Commissioning Support Unit,,Willerby Office Health House Grange Park Lane,Hull,North Humberside,Hull,North Humberside,England,HU10 6DT,Wider Public Sector,Commissioning Support Unit,False
+10038364,Wandsworth Teaching Pct,,Barnes Hospital,QMH Medical Records,,London,,England                       ,SW14 8SU,Wider Public Sector,,False
+10038363,Waltham Forest PCT,,46 Ravenswood Road,Walthamstow,,London,,England                       ,E17 9LY,Wider Public Sector,,False
+10038359,Tower Hamlets PCT  Medical,,Public Health,Mile End Hospital,,London,,England                       ,E1 4DG,Wider Public Sector,,False
+10038358,Tower Hamlets PCT  Archive,,Aneurin Bevan House,81-91 Commercial Road,,London,,England                       ,E1 1RD,Wider Public Sector,,False
+10038352,Stockport PCT,,Fiinance Department,Regent House,,Manchester,Cheshire                      ,England                       ,SK4 1BS,Wider Public Sector,,False
+10038340,Victoria Infirmary,,Queens Park House,Langside Road,,Glasgow,Strathclyde                   ,Scotland                      ,G42 9TY,Wider Public Sector,,False
+10038297,Chelsea Citizens Advice Bureau,,140 Ladbroke Grove,,,London,,England                       ,W10 5ND,Wider Public Sector,,False
+10038293,Brent Citizens Advice Bureau,,270 - 272 High Road,Willesden,,London,,England                       ,NW10 2EY,Wider Public Sector,,False
+10038289,Primary Care Trust Comm and Men Health,,Gartnavel Royal Hospital,1055 Gt Western Road,,Glasgow,,Scotland                      ,G12 0XH,Wider Public Sector,,False
+10038233,Colville House Management Company,,Colvilee House School Road,Oulton Broad,,Lowestoft,Suffolk                       ,England                       ,NR33 9NB,Wider Public Sector,,False
+10038207,Gedney Hill CE Primary School,,North Road,Gedney Hill,,Spalding,Lincolnshire                  ,England                       ,PE12 ONL,Wider Public Sector,Primary Schools,False
+10038097,Quality Assurance Agency For Higher Education The,,3Rd Floor Southgate House Southgate Street,Gloucester,Gloucestershire,Gloucester,Gloucestershire,England,GL1 1UB,Wider Public Sector,TBA,False
+10038057,Royal Academy of Music,,Marylebone Road,,,London,,England                       ,NW1 5HT,Wider Public Sector,Colleges of Further Education,False
+10038053,Shenstone Lodge School,,Birmingham Road,Staffordshire,Staffordshire,Staffordshire,Staffordshire,England,WS14 0LB,Wider Public Sector,TBA,False
+10038022,North East Derbyshire Citizens Advice Bureau,,126 High Street,Clay Cross,,Chesterfield,Derbyshire                    ,England                       ,S45 9EE,Wider Public Sector,Charity,False
+10037960,PRIMARY CARE COMMISSIONING COMMUNITY INTEREST COMPANY,,Unit 2,Manor Mills,Manor Road,Leeds,West Yorkshire                ,England                       ,LS11 9AH,Wider Public Sector,Other,False
+10037948,NHS Connecting For Health,,Vantage House,40 Aire Street,,Leeds,West Yorkshire                ,England                       ,LS1 4HT,Wider Public Sector,,False
+10037936,Gloucester Care Services,,"Unit 1010 Pioneer Avenue Gloucester Business Park, Brockworth",Gloucester,Gloucestershire,Gloucester,Gloucestershire,England,GL3 4AW,Wider Public Sector,TBA,False
+10037934,NHS Sheffield CCG,,722 Prince of Wales Road,,,Sheffield,South Yorkshire               ,England                       ,S9 4EU,Wider Public Sector,,False
+10037929,Unison,,St. Woolos Hospital,131 Stow Hill,,Newport,,Wales                         ,NP20 4SZ,Wider Public Sector,,False
+10037910,Office of the Public Guardian,,PO Box 16185,,,Birmingham,West Midlands                 ,England                       ,B2 2WH,Central Government,,False
+10037888,Dysgu Bro Ceredigion Community Learning,,Penparcau,,,Aberystwyth,,Wales                         ,SY23 1SH,Wider Public Sector,,False
+10037848,Wyggeston and Queen Elizabeth I College,,University Road,,,Leicester,Leicestershire                ,England                       ,LE1 7RJ,Wider Public Sector,,False
+10037847,Wigan and Leigh College,,Finance Department   ,,Wigan And Leigh College,Parsons Walk Wigan,Greater Manchester            ,England                       ,WN1 1RR,Wider Public Sector,,False
+10037836,Cottenham AcademyCottenham Vc The,,Cottenham Village College,,High Street,Cottenham,Cambridgeshire,England,CB24 8UA,Wider Public Sector,Education,False
+10037829,Strode'S College,,High Street,Egham,Surrey,Egham,Surrey,England,TW20 9DR,Wider Public Sector,TBA,False
+10037821,St Edmund'S College,,Mount Pleasant,Cambridge,Cambridgeshire,Cambridge,Cambridgeshire,England,CB3 0BN,Wider Public Sector,TBA,False
+10037811,North Warwickshire and Hinckley Colleg,,Hinckley Road ,,,Nuneaton ,Warwickshire                  ,England                       ,CV11 6BH,Wider Public Sector,,False
+10037777,Cottenham Academy TA The Centre Sch,,Cottenham Village College,,High Street,Cottenham,Cambridgeshire,England,CB24 8UA,Wider Public Sector,Education,False
+10037761,Government Digital Service,,Aviation House,125 Kingsway,,London,,England                       ,WC2B 6NH,Central Government,,False
+10037727,North Essex Partnership Foundation Trust,,Stapleford House Stapleford Close,Chelmsford,Essex,Chelmsford,Essex,England,cm2 0qx,Wider Public Sector,TBA,False
+10037712,Lickey Hills Primary School,,Old Birmingham Road,Lickey,,Birmingham,Worcestershire                ,England                       ,B45 8EU,Wider Public Sector,,False
+10037680,St Helens Council,,Wesley House,Corporation Street,,St Helens,Merseyside                    ,England                       ,WA10 1HF,Wider Public Sector,,False
+10037633,NHS EAST RIDING OF YORKSIRE CCG,,Health House,Grange Park Lane,Willerby,Hull,,England                       ,HU10 6DT,Wider Public Sector,,False
+10037632,Southwark PCT,,160 Tooley Street,,,London,,England                       ,SE1 2TZ,Wider Public Sector,,False
+10037577,Civil Service Resourcing,,100 Parliament Street,,,London,,England                       ,SW1A 2BQ,Central Government,,False
+10037534,Brnsley MBC,,Smithies Lane,,,Barnsley,South Yorkshire               ,England                       ,S71 1NL,Wider Public Sector,,False
+10037524,Edinburgh City Council,,Waverley Court,4 East Market Street,,Edinburgh,,Scotland                      ,eh8 8bg,Wider Public Sector,,False
+10037499,CEFAS,,Pakefield Road,,,Lowestoft,Suffolk                       ,England                       ,NR33 0HT,Central Government,,False
+10037495,George Mitchell School,,Farmer Road,London,Greater London,London,Greater London,England,E10 5DN,Wider Public Sector,TBA,False
+10037481,Scottish Government,,450 Argyle Street,Europa Building,,Glasgow,,England                       ,G2 8LG,Wider Public Sector,,False
+10037454,College of Policing,,Leamington Road,Ryton on Dunsmore,,Coventry,Warwickshire                  ,England                       ,CV8 3EN,Central Government,,False
+10037389,Age UK LeicesterShire & Rutland,,Lansdowne House,113 Princess Road East,,Leicester,Leicestershire                ,England                       ,LE1 7LA,Wider Public Sector,Charity,False
+10037318,Wiltshire Primary Care Trust,,Marlborough Road,,,Swindon,Wiltshire                     ,England                       ,SN3 6BB,Wider Public Sector,PCT - Commissioning,False
+10037317,Lincolnshire Teaching Primary Care Trust,,Sibsey Road,,,Boston,Lincolnshire                  ,England                       ,PE21 9QS,Wider Public Sector,,False
+10037316,Mid Essex Primary Care Trust,,Stapleford House,Stapleford Close,,Chelmsford,Essex                         ,England                       ,CM2 0QX,Wider Public Sector,,False
+10037315,Newcastle Primary Care Trust,,7-8 Silver Fox Way,Cobalt Business Park,,Newcastle upon Tyne,Tyne and Wear                 ,England                       ,NE27 0QJ,Wider Public Sector,,False
+10037294,Genome Analysis Centre The,,The Genome Analysis Centre (Tgac)        Norwich Research Centre                  Colney Lane,Norwich,Norfolk,Norwich,Norfolk,England,NR4 7UH,Wider Public Sector,TBA,False
+10037198,National Association Citizens Advice Bureaux,,"North Region,3rd Floor                  ","Rotterdam Hse,116 Quayside              ",                                        ,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE1 3DY,Wider Public Sector,,False
+10037072,St Stephens Church of England Primary School,,Woden Road,Wolverhampton,West Midlands,Wolverhampton,West Midlands,England,WV10 0BB,Wider Public Sector,Local Authority Maintained School (All Types),False
+10037045,Redbridge Primary Care Trust,,The Green,Great Bentley,,Colchester,Essex                         ,England                       ,CO7 8QG,Wider Public Sector,PCT - Provisioning,False
+10037036,Mansfield Citizens Advice Bureau,,Suite 22-24,Brunts Business Park,Samuel Brunts Way,Mansfield,Nottinghamshire               ,England                       ,NG18 2AH,Wider Public Sector,,False
+10037026,Spires academy,,Bredlands Lane,,,Canterbury,,England                       ,CT2 0HD,Wider Public Sector,,False
+10036971,St Peters Church of England Primary School,,Whitefield Road,,,Bury,Greater Manchester            ,England                       ,BL9 9PW,Wider Public Sector,,False
+10036930,Microlise Ltd,,Farrington Way,Eastwood,,Nottingham,Nottinghamshire               ,England                       ,NG16 3AG,Wider Public Sector,,False
+10036929,Clare School The,,South Park Avenue,Norwich,Norfolk,Norwich,Norfolk,England,NR4 7AU,Wider Public Sector,TBA,False
+10036905,Prenton Medical Centre,,516-518 Woodchurch Road,,,Prenton,Merseyside                    ,England                       ,CH43 0TS,Wider Public Sector,GP Practice,False
+10036895,RICHMOND & TWICKENHAM Primary Care Trust,,Thames House,180-194 High Street,,Teddington,,England                       ,TW11 8HU,Wider Public Sector,,False
+10036893,South Gloucestershire PCT,,8 Brook Office Park,Emersons Green,,Bristol,Gloucestershire               ,England                       ,BS16 7FL,Wider Public Sector,,False
+10036877,Age UK Dorchester,,Rowan Cottage,4 Prince of Wales Road,,Dorchester,Dorset                        ,England                       ,DT1 1PW,Wider Public Sector,Charity,False
+10036871,Home Group Limited,,2 St. Andrews House,Vernon Gate,,Derby,Derbyshire                    ,England                       ,DE1 1UJ,Wider Public Sector,Housing Associations,False
+10036854,North Thoresby School,,High Street North Thoresby,Grimsby,Lincolnshire,Grimsby,Lincolnshire,England,DN36 5PL,Wider Public Sector,Local Authority Maintained School (All Types),False
+10036798,North Hampshire Hospital Nhs Trust,,North Hants Hospital,Aldermaston,Mid Glamorgan,Aldermaston,Mid Glamorgan,Wales,HOSPBASI,Wider Public Sector,Health,False
+10036795,Mid Essex Hospitals NHS Trust,,Station Road,,,Witham,Essex                         ,England                       ,CM8 2TL,Wider Public Sector,,False
+10036776,Warrington Primary Care Trust,,930-932 Birchwood Boulevard,,,Warrington,Cheshire                      ,England                       ,WA3 7QN,Wider Public Sector,,False
+10036754,Cynnal,,Shirehall Street,,,Caernarfon,Gwynedd                       ,Wales                         ,LL55 1SH,Wider Public Sector,,False
+10036703,Wanstead High School,,Redbridge Lane West,,,London,,England                       ,E11 2JZ,Wider Public Sector,Secondary Schools,False
+10036702,Valentines High School,,CRANBROOK ROAD,,, ILFORD ,Essex                         ,England                       ,IG26HX,Wider Public Sector,Secondary Schools,False
+10036693,Churchfields Junior School,,CHURCHFIELDS ,,,LONDON,,England                       ,E182RB,Wider Public Sector,Primary Schools,False
+10036624,(Closed) (Army) Field Army Budget,,Internal distribution List 29 Blenheim Building 300 HQ Land Forces Marlborough Lines Monxton Road,Andover,Hampshire,Andover,Hampshire,England,SP11 8HJ,Central Government,MoD - Army,False
+10036618,Director Business Resiliance,,Main Building Horseguards Avenue,London,Greater London,London,Greater London,England,SW1A 2HB,Central Government,TBA,False
+10036612,Defence Equipment and Support DEandS,,2050 Maple 0c,MOD Abbey Wood,,Bristol,Lancashire                    ,England                       ,BS34 8JH,Central Government,,False
+10036610,Deputy Chief of the Defence Staff Capability,,Main Building Horseguards Avenue,London,Greater London,London,Greater London,England,SW1A 2HB,Central Government,MoD - HOCS,False
+10036590,Staffordshire and Stoke on Trent Partnership Trust,,Jupiter House,Drummond Road,,Stafford,Staffordshire                 ,England                       ,ST16 3HJ,Wider Public Sector,Care Trust,False
+10036578,Overton Grange School,,36 Stanley Road,,,Sutton,Surrey                        ,England                       ,SM2 6TQ,Wider Public Sector,,False
+10036562,Central and North West London NHS Foundation Trust,,Stephenson House,75 Hampstead Road,,London,,England                       ,NW1 2PL,Wider Public Sector,Care Trust,False
+10036543,NHS South London,,Frognal Avenue,,,Sidcup,,England                       ,DA14 6LT,Wider Public Sector,Care Trust,False
+10036458,Trafford Primary Care Trust,,One Stop Resource Centre,Dane Road Industrial Estate,,Sale,Greater Manchester            ,England                       ,M33 7BH,Wider Public Sector,,False
+10036427,Kent and Medway PCT Cluster,,"The Oast, Tenacre Court",Ashford Road,Harrietsham,Maidstone,Kent                          ,England                       ,ME17 1AH,Wider Public Sector,PCT - Commissioning,False
+10036421,Age UK Nottingham & Nottinghamshire,,Bradbury House,12 Shakespeare Street,,Nottingham,Nottinghamshire               ,England                       ,NG1 4FQ,Wider Public Sector,,False
+10036415,Liverpool Community Health Nhs,,65 Stephenson Way,Bevan House,,Liverpool,Merseyside                    ,England                       ,L13 1HN,Wider Public Sector,,False
+10036404,Earlham Primary School,,Earlham Grove,,,London,,England                       ,E7 9AW,Wider Public Sector,,False
+10036360,Vauvert Primary School,,Vauvert,St. Peter Port,,Guernsey,,England                       ,GY1 1NQ,Wider Public Sector,,False
+10036349,Teaching Agency,CWDC,Piccadilly Gate,Store Street,,Manchester,Greater Manchester            ,England                       ,M1 2WD,Central Government,NDPB,False
+10036344,Syston Health Centre,,Melton Road,Leicester,Leicestershire,Leicester,Leicestershire,England,LE7 2EQ,Wider Public Sector,TBA,False
+10036318,Hazelwood Integrated Primary School,,242 Whitewell Road,Newtownabbey,County Antrim,Newtownabbey,County Antrim,Northern Ireland,BT36 7EN,Wider Public Sector,Education,False
+10036196,NHS Commissioning Board,,Quarry House,Quarry Hill,,Leeds,West Yorkshire                ,England                       ,LS2 7UE,Wider Public Sector,Strategic Health Authority,False
+10036120,Hillingdon & Ealing Citizens Advice,,Key House,106 High Street,Yiewsley,West Drayton,,England                       ,UB7 7BQ,Wider Public Sector,,False
+10036083,Animal Health and Veterinary Laboratories Agency,,Central Veterinary Laboratory,Woodham Lane,New Haw,Addlestone,Surrey,England,KT15 3NB,Central Government,Executive Agency,False
+10035943,North Somerset Community Partnership,,Tickenham Road,Clevedon,Somerset,Clevedon,Somerset,England,BS21 6AB,Wider Public Sector,Care Trust,False
+10035918,Coventry and Warwickshire Award Trust,,Bell Green Road,,,Coventry,West Midlands                 ,England                       ,CV6 7GP,Wider Public Sector,,False
+10035915,UCLH NHS Foundation Trust,,Maple House 149 Tottenham Court Road,London,Greater London,London,Greater London,England,W1T 7DN,Wider Public Sector,TBA,False
+10035802,A2Dominion,,15th Floor Capital House 25 Chapel Street,London,Greater London,London,Greater London,England,NW1 5WX,Wider Public Sector,Housing Associations,False
+10035701,Borough Care Limited,,Elm House 5 Acorn Business Park Heaton Lane,Stockport,Greater Manchester,Stockport,Greater Manchester,England,SK4 1AS,Wider Public Sector,TBA,False
+10035692,Cheshire and Wirral NHS Foundation Trust,,St. Catherines Hospital,Church Road,,Birkenhead,Merseyside                    ,England                       ,CH42 OLQ,Wider Public Sector,Care Trust,False
+10035600,London Early Years Foundation,,121 Marsham Street,London,Greater London,London,Greater London,England,SW1P 4LX,Wider Public Sector,TBA,False
+10035572,North Middlesex University Hospital By North Limited  ,,"4th Floor, Elizabeth House",39 York Road,,London,,England                       ,SE1 7NQ,Wider Public Sector,,False
+10035570,Cornwall and Isles of Scilly Primary Care Trust,,Sedgemoor Centre,Priory Road,,St. Austell,Cornwall                      ,England                       ,PL25 5AS,Wider Public Sector,,False
+10035556,METROPOLITAN BOROUGH OF KNOWSLEY,,21 ARCHWAY RD,,,LIVERPOOL,Merseyside                    ,England                       ,L36 9YU,Wider Public Sector,,False
+10035450,London Borough of Merton,,Facilities Management,London Borough of Merton,"Civic Centre, London",Morden,Surrey                        ,England                       ,SM4 5DX,Wider Public Sector,,False
+10035449,London Borough of Barking and Dagenham,,City Learning Centre Green Lane,"Robert Clack, Lower School Site",Green Lane,Dagenham,Essex                         ,England                       ,RM8 1AL,Wider Public Sector,,False
+10035442,Kings College London,,Estates Department,"3rd Floor, Capital House",42 Weston Street,London,,England                       ,SE1 3QD,Wider Public Sector,,False
+10035434,H M Prison Belmarsh,,HM Prison Service,High Security Finance & Procurement,Unit 8 Silkwood Park Village,Wakefield,West Yorkshire                ,England                       ,WF5 9AD,Central Government,,False
+10035405,University of Greenwich,,University of Greenwich,Flat 46 Aragon Court,Southwood Site Avery Hill Road,London,,England                       ,SE9 2HB,Wider Public Sector,,False
+10035340,Leeds and York Partnership NHS Foundation Trust,,"South Wing, St Mary’s House, St Mary’s Road, Leeds",Leeds,West Yorkshire,Leeds,West Yorkshire,England,LS7 3JX,Wider Public Sector,TBA,False
+10035339,Isle of Wight NHS Trust,,St Mary's House Parkhurst Road,Newport,Isle of Wight,Newport,Isle of Wight,England,PO30 5TG,Wider Public Sector,TBA,False
+10035338,Heart of Birmingham PCT,,"Birmingham Primary Care Shared Services Agency, Carnegie Centre, Hunters Road, Hockley, Birmingham                   ",,, ,West Midlands                 ,England                       ,B19 1DR,Wider Public Sector,,False
+10035337,Haringey Primary Care Trust,,"Holbrook House, Cockfosters Road, Barnet,     ",,, ,Hertfordshire                 ,England                       ,EN4 0DR,Wider Public Sector,,False
+10035336,Enfield PCT,,"Holbrook House, Cockfosters Road, Barnet,     ",,, ,Hertfordshire                 ,England                       ,EN4 0DR,Wider Public Sector,,False
+10035331,Coventry PCT,,"Christchurch House, Greyfriars Lane,Coventry",,,Coventry,,England                       ,CV1 2GQ,Wider Public Sector,,False
+10035329,Westminster PCT,,"15 Marylebone Road, London",,, ,,England                       ,NW1 5JD,Wider Public Sector,,False
+10035326,Telford and Wrekin PCT,,"Halesfield 6, Telford, Shropshire",,, ,Shropshire                    ,England                       ,TF7 4BF,Wider Public Sector,,False
+10035325,South Tyneside Primary Care Trust,,Clarendon Windmill Way City: Tyne and Wear ,,, ,,England                       ,NE31 1AT,Wider Public Sector,,False
+10035324,Solihull Primary Care Trust,,"Friars Gate, Stratford Road, Shirley, Solihull",,, ,West Midlands                 ,England                       ,B90 4BN,Wider Public Sector,,False
+10035322,Oxfordshire PCT,,"Jubilee House, 5510 John Smith Drive, Oxford Business Park South, Cowley, Oxford ",,, ,Oxfordshire                   ,England                       ,OX4 2LH,Wider Public Sector,,False
+10035320,Nottingham City Primary Care Trust,,1 Standard Court,Park Row,,Nottingham,Nottinghamshire               ,England                       ,NG1 6GN,Wider Public Sector,,False
+10035318,Medway Community Healthcare,,"Riverside House, Riverside 2, Sir Thomas Longley Road, Medway City Estate, Rochester, Kent  ",,, ,Kent                          ,England                       ,ME2 4FN,Wider Public Sector,,False
+10035269,Brent PCT,,"Wembley Centre for Health & Care, 116 Chaplin Road, Wembley  ",,, ,Middlesex                     ,England                       ,HA0 4UZ,Wider Public Sector,,False
+10035247,Southampton City Primary Care Trust,,Josian Centre,Unit 3&4 Imperial Park,,Southampton,Hampshire                     ,England                       ,SO14  0JW,Wider Public Sector,,False
+10035246,South West Essex PCT,,Draycott House,Thurrock Hospital,Long Lane,Grays,Essex                         ,England                       ,RM16 2PX,Wider Public Sector,,False
+10035226,UNI HOSPITAL OF MORECAMBE BAY,,ASHTON RD,,,LANCASTER,Lancashire                    ,England                       ,LA1 4RP,Wider Public Sector,,False
+10035175,Cambrideshire Primary Care Trust,,4 GRESHAM ROAD,,,CAMBRIDGE,Cambridgeshire                ,England                       ,PE13 3AB,Wider Public Sector,,False
+10035168,London Borough of Bexley,,Footscray Offices,,,SIDCUP,Kent                          ,England                       ,DA14 5HS,Wider Public Sector,,False
+10035150,Barnardos Carlisle,,Carlisle West Childrens Centre,,,CARLISLE,Cumbria                       ,England                       ,CA2 6JP,Wider Public Sector,,False
+10035112,THPCT East London and The City,,44-56 HESSEL STREET,,,LONDON,,England                       ,E1 2LP,Wider Public Sector,,False
+10035103,Manchester Citizens Advice Bureaux,,59 Withington Road,,,MANCHESTER,Greater Manchester            ,England                       ,M16 7EX,Wider Public Sector,,False
+10035092,Sunderland Teaching PCT,,Hendon Heath Centre,,,SUNDERLAND,Tyne and Wear                 ,England                       ,SR1 2LR,Wider Public Sector,,False
+10035084,MARITIME and COAST GUARD AGENCY,,SPRING PLACE,,,SOUTHAMPTON,Hampshire                     ,England                       ,SO15 1EG,Wider Public Sector,,False
+10035035,Inside Government,,St. James Buildings,Oxford Street,,Manchester,Greater Manchester            ,England                       ,M1 6PP,Wider Public Sector,Other,False
+10035030,Other CG,oCG,,,,,,,XXXX,Central Government,Option 1,False
+10035009,Abmu Local Health Board,,Abertawe Bro Morgannwg University,Local Health BoardGlanrhyd Hospital,Tondu Road,Bridgend,Mid Glamorgan                 ,Wales                         ,CF31 4LN,Wider Public Sector,,False
+10034974,Healthcare Financial Management Association The,,Albert House,BRISTOL,Avon,BRISTOL,Avon,England,BS1 6AX,Wider Public Sector,TBA,False
+10034956,Carr Manor Primary School,,Carr Manor Road,Leeds,West Yorkshire,Leeds,West Yorkshire,England,LS17 5DJ,Wider Public Sector,Local Authority Maintained School (All Types),False
+10034938,University of Cambridge,,University of Cambridge New Museums Site,CAMBRIDGE,Cambridgeshire,CAMBRIDGE,Cambridgeshire,England,CB2 3QH,Wider Public Sector,Universities,False
+10034929,Telford and Wrekin Primary Care Trust,,Anchorage Avenue,Shrewsbury Business Park,,Shrewsbury,Shropshire                    ,England                       ,SY2 6LG,Wider Public Sector,,False
+10034928,Stoke On Trent Primary Care Trust,,The Boland Suite,Rear Bancroft Court,Henshaw Lane,Leeds,West Yorkshire                ,England                       ,LS19 7RW,Wider Public Sector,,False
+10034927,Plymouth Hospitals NHS Trust,,Mount Gould Hospital,Mount Gould Road,,Plymouth,Devon                         ,England                       ,PL4 7QD,Wider Public Sector,,False
+10034924,National Trust The,,Tpu Epsom Court Epsom Road White Horse Business Park,TROWBRIDGE,Cornwall,TROWBRIDGE,Cornwall,England,TR3 6QG,Wider Public Sector,TBA,False
+10034877,St Ann'S Church,,182 St. Ann's Hill,London,Greater London,London,Greater London,England,SW18 2RS,Wider Public Sector,Other,False
+10034819,Southend Hospital Nhs Trust,,Finance Department Britannia House Comet Way,SOUTHEND ON SEA,Essex,SOUTHEND ON SEA,Essex,England,SS2 6GE,Wider Public Sector,TBA,False
+10034818,Southampton City PCT,,Com Cl1 Payables C455,Phoenix House Topcliffe Lane,Tingley,WAKEFIELD,,England                       ,SO16 4BZ,Wider Public Sector,,False
+10034766,Preston Primary Care Trust,,WATLING ST RD,,,PRESTON,Lancashire                    ,England                       ,PR2 8DW,Wider Public Sector,,False
+10034730,Northumberland Tyne and Wear NHS,,ST NICHOLAS HOSPITAL JUBILEE RD,Newcastle Upon Tyne,Tyne and Wear,Newcastle Upon Tyne,Tyne and Wear,England,NE4 8RR,Wider Public Sector,TBA,False
+10034727,North Tyneside Nhs Pct,,T/A NHS Ncle & NT Community HLTH,"Bevan Place, Esh Plaza","Sir Bobby Robson Way, Great Park",NEWCASTLE UPON TYNE,Tyne and Wear                 ,England                       ,NE1 6ND,Wider Public Sector,,False
+10034724,North Hertfordshire D Council,,COUNCIL OFFICES,GERNON RD,,LETCHWORTH GARDEN CITY,Hertfordshire                 ,England                       ,SG6 3JF,Wider Public Sector,,False
+10034723,North East Sha,,9 Kingfisher Way,Silverlink Business Park,,WALLSEND,Berkshire                     ,England                       ,RG2 0SX,Wider Public Sector,,False
+10034722,North East Essex Pct,,C/O ESSA Finance,Unit 16 Atlantic Square,Station Road,WITHAM,,England                       ,CO15 1LH,Wider Public Sector,,False
+10034719,Norfolk Pct,,C/O Accounts Payable Elliott House,130 Ber Street,,NORWICH,Norfolk                       ,England                       ,NR6 5DR,Wider Public Sector,,False
+10034717,Norfolk and Norwich University Hospitals Nhs Trust,,NNUH Microbiology Department,PHLS,Bowthorpe Road,NORWICH,Norfolk                       ,England                       ,NR4 7GJ,Wider Public Sector,,False
+10034711,Newham Pct,,5C5 Payables 6735,Phoenix House,Topcliffe Lane,WAKEFIELD,,England                       ,E7 9HZ,Wider Public Sector,,False
+10034682,Manchester Pct,,3rd Floor,"Mauldeth House, Mauldeth Road West",Chorlton cum Hardy,MANCHESTER,Lancashire                    ,England                       ,M20 2LR,Wider Public Sector,,False
+10034681,Manchester Nhs Pct,,Finance Department. Accounts Payable,1st Floor - Parkway Three. Parkway B Ctr,Princess Road,MANCHESTER,Lancashire                    ,England                       ,M21 7RL,Wider Public Sector,,False
+10034668,London Borough Of Greenwich,,PARKS AND OPEN SPACES-PARKS AND OPEN S,SHOOTERS HILL,,LONDON,Derbyshire                    ,England                       ,DE24 8HS,Wider Public Sector,,False
+10034667,London Borough Of Ealing,,PO Box 4,Ealing,,LONDON,Middlesex                     ,England                       ,UB6 9SE,Wider Public Sector,,False
+10034665,Liverpool Pct,,Latham Court,Bridgemere Close,,LIVERPOOL,Merseyside                    ,England                       ,L7 0LS,Wider Public Sector,,False
+10034658,Lewisham Healthcare Nhs Trust,,RJ2 Payables 4715,Phoenix House,Topcliffe Lane,WAKEFIELD,,England                       ,SE12 8NP,Wider Public Sector,,False
+10034646,Knowsley Metro Borough Council,,MUSIC & PERFORMING ARTS SERVICE-MUSIC,KNOWSLEY LANE,,LIVERPOOL,Merseyside                    ,England                       ,L36 8HW,Wider Public Sector,,False
+10034645,Kirklees Primary Care Trust,,5N2 Payables C415,PHOENIX HOUSE TOPCLIFFE LANE,,WAKEFIELD,West Yorkshire                ,England                       ,HD1 4EW,Wider Public Sector,,False
+10034625,Humber Mntl Health Teaching Nhs Trust,,Finance Dept Mary Seacole Building Willerby Hill Beverley Road Willerby,Hull,East Yorkshire,Hull,East Yorkshire,England,HU2 8HP,Wider Public Sector,TBA,False
+10034624,Humber Mental Health,,"Finance Department Mary Seacole Building, Willerby Hill Beverly Road, Willerby",Hull,East Yorkshire,Hull,East Yorkshire,England,HU2 8HP,Wider Public Sector,TBA,False
+10034612,Hillingdon Primary Care Trust,,Finance Department,Kirk House,97-109 High Street,WEST DRAYTON,Middlesex                     ,England                       ,HA5 1TG,Wider Public Sector,,False
+10034607,Hertfordshire Partnership Nhs Trust,,Finance Department,99 Waverley Road,,ST. ALBANS,Hertfordshire                 ,England                       ,CM23 3LB,Wider Public Sector,,False
+10034578,Great Western Hospital  Nhs Foundation Trust,,RN3 Payables 7435 Phoenix House Topcliffe Lane,WAKEFIELD,Wiltshire,WAKEFIELD,Wiltshire,England,BA14 8PH,Wider Public Sector,TBA,False
+10034550,Energy Solutions Eu Limited,,Stella Building,Windmill Hill Business Park,Whitehill Way,SWINDON,Somerset                      ,England                       ,SN5 6NX,Wider Public Sector,,False
+10034542,Eastern and Costal Kent Pct,,Ethelbert Road,,,CANTERBURY,Kent                          ,England                       ,CT5 3QT,Wider Public Sector,,False
+10034541,East Midland Ambulance Service NHS Trust,,RX9 Payables 6815 Phonenix House Topcliffe Lane,WAKEFIELD,Lincolnshire,WAKEFIELD,Lincolnshire,England,LN4 2HL,Wider Public Sector,TBA,False
+10034535,Durham Dales PCT,,Henson Close,,,BISHOP AUKLAND,,England                       ,DL3 6JL,Wider Public Sector,,False
+10034531,Drd Roads Service,,Carn Depot,Carn Industrial Estate,Portadown,CRAIGAVON,,Northern Ireland              ,BT63 5RY,Central Government,,False
+10034530,Drd Road Service,,DEVELOPMENT CONTROL-DEVELOPMENT CONTRO,CASTLE BARRACKS,WELLINGTON PLACE,ENNISKILLEN,Fermanagh                     ,Northern Ireland              ,BT74 7HN,Central Government,,False
+10034521,Dorset Healthcare Nhs Foundation Trust,,11 SHELLY RD,BOURNEMONTH,Dorset,BOURNEMONTH,Dorset,England,BH7 6JE,Wider Public Sector,TBA,False
+10034520,Dorset Healthcare Nhs,,TRUST HQ,Creditors Payments Department,11 SHELLEY RD,BOURNEMONTH,Dorset                        ,England                       ,BH21 1SF,Wider Public Sector,,False
+10034509,Derbyshire County Pct Dchs,,PN6 Payables 7005,"Phoenix House,",Topcliffe Lane,WAKEFIELD,Derbyshire                    ,England                       ,WF3 1SN,Wider Public Sector,,False
+10034508,Derby City Primary Care Trust,,5N7 Payables 6965,Phoenix House,Topcliffe Lane,WAKEFIELD,Derbyshire                    ,England                       ,DE1 2RG,Wider Public Sector,,False
+10034493,Coventry Teaching Pct,,FINANCE DEPT-FINANCE DEPT,PARKSIDE HOUSE,QUINTON RD,COVENTRY,West Midlands                 ,England                       ,CV6 6MY,Wider Public Sector,,False
+10034477,City and Hackney Pct Com,,CC3 Payables 6775,Phoenix House,Topcliffe Lane,WAKEFIELD,,England                       ,EC2A 2EJ,Wider Public Sector,,False
+10034476,Citizens Advice Solihull Borough Limited,,176 Bosworth Drive,Chelmsley Wood,,BIRMINGHAM,West Midlands                 ,England                       ,B91 3LF,Wider Public Sector,,False
+10034455,Central Primary Care Trust,,204 PLATT LANE,,,MANCHESTER,Lancashire                    ,England                       ,M14 7BS,Wider Public Sector,,False
+10034454,Catherine Junior School,,BRANDON ST,Leicester,Leicestershire,Leicester,Leicestershire,England,LE4 6AZ,Wider Public Sector,TBA,False
+10034444,Calderdale and Huddersfield Nhs Trust,,FINANCE DEPTACCOUNTS PAYABLE-FINANCE,ACRE HOUSE,ACRE ST,HUDDERSFIELD,,England                       ,HX3 0PW,Wider Public Sector,,False
+10034433,Bournemouth and Poole Pct,,TRUST HQ,11 SHELLEY RD,,BOURNEMOUTH,Dorset                        ,England                       ,BH17 9DW,Wider Public Sector,,False
+10034429,Bolton Nhs Foundation Trust,,Finance Department,Dowling House,Minerva Road,BOLTON,Greater Manchester,England,BL1 1SQ,Wider Public Sector,TBA,False
+10034425,Blackburn With Darwen Pct,,Cornerstone Healthcare,Infirmary Street,,BLACKBURN,Lancashire                    ,England                       ,BB2 3SF,Wider Public Sector,,False
+10034380,Ashton Leigh and Wigan PCT NHS,,Bryan House,61-69 Standishgate,,Wigan,Lancashire                    ,England                       ,WN1 1AH,Wider Public Sector,Care Trust,False
+10034301,Aster Group,,Sarson Court,Horton Avenue,,Devizes,Wiltshire                     ,England                       ,SN10 2AZ,Wider Public Sector,Housing Associations,False
+10034243,Otley Labour Party,,OTLEY LABOUR ROOMS,NELSON STREET,,Leeds,North Yorkshire               ,England                       ,LS21 1HB,Central Government,,False
+10034236,Gloucestershire Primary Care Trust,,Gloucestershire Shared Services,P O Box 9103 ,,Gloucester,Gloucestershire               ,England                       ,GL1 2WT,Wider Public Sector,Care Trust,False
+10034235,The Queen Elizabeth Hospital Kings Lynn NHS Foundation Trust,,Gayton Road,,,Kings Lynn,Norfolk                       ,England                       ,PE30 4ET,Wider Public Sector,,False
+10034148,Archbishop Lanfranc School The,,MITCHAM ROAD,Croydon,Surrey,Croydon,Surrey,England,CR9 3AS,Wider Public Sector,TBA,False
+10034139,Swindon Primary Care Trust,,CHILD HEALTH DEPT,CHATSWORTH HOUSE BATH ROAD,,Swindon,Wiltshire                     ,England                       ,SN1 4BP,Wider Public Sector,,False
+10034058,South Downs Community Special School,,SHINEWATER LANE LANGNEY,Eastbourne,East Sussex,Eastbourne,East Sussex,England,BN23 8AT,Wider Public Sector,TBA,False
+10034039,Oldham Primary Care Trust,,CHADDERTON HEALTH CENTRE,H/V & D/N MANAGERS,,Oldham,Lancashire                    ,England                       ,OL9 8RG,Wider Public Sector,,False
+10033952,Guildford Citizens Advice Bureau,,15-21 HAYDON PLACE,GUILDFORD,,Guildford,Surrey                        ,England                       ,GU1 4LL,Wider Public Sector,,False
+10033926,Farnborough Citizens Advice Bureau,,35-39 HIGH STREET,ALDERSHOT,,Aldershot,Hampshire                     ,England                       ,GU11 1BH,Wider Public Sector,,False
+10033897,Devon And Cornwall Housing,,SUPPORTED TEAM,12-14 OCTAGON STREET. STONEHOUSE,,Plymouth,Devon                         ,England                       ,PL1 1TU,Wider Public Sector,,False
+10033889,Dacorum Primary Care Trust,,ISBISTER CENTRE,CHAULDEN HOUSE GARDENS,,Bourne End,,England                       ,HP1 2BW,Wider Public Sector,,False
+10033800,South Tyneside NHS,,Bevan House,Newcastle,Tyne and Wear,Newcastle,Tyne and Wear,England,NE14 9BA,Wider Public Sector,TBA,False
+10033797,Grampion Primary Care Trust,,Transport Department,Forester Hill Hospital,,Aberdeen,Aberdeenshire                 ,Scotland                      ,AB15 5LS,Wider Public Sector,,False
+10033785,NHS Stoke on Trent Primary Care Trust,,Herbert Minton Building,79 London Road,,Stoke on Trent,Staffordshire                 ,England                       ,ST4 7PZ,Wider Public Sector,,False
+10033783,Sunderland Teaching Primary Care Trust,,Pemberton House,Colima Avenue,Enterprise Park,Sunderland,Tyne and Wear                 ,England                       ,SR5 3XB,Wider Public Sector,Primary Schools,False
+10033782,South Birmingham PCT,,Triplex House,Eckersall Road,Kings Norton,Birmingham,West Midlands                 ,England                       ,B38 8SS,Wider Public Sector,,False
+10033781,Kensington and Chelsea PCT,,Southside,105 Victoria Street,,London,,England                       ,SW1E 6QT,Wider Public Sector,,False
+10033779,Derby City PCT,,Cardinal Square,10 Nottingham Road,,Derby,Derbyshire                    ,England                       ,DE1 3QT,Wider Public Sector,,False
+10033771,Herefordshire Primary Care Trust,,Brockington,35 Hafod Road,,Hereford,Herefordshire                 ,England                       ,HR1 1SH,Wider Public Sector,,False
+10033758,Birmingham East and North PCT,,Waterlinks House,Richard Street,Aston,Birmingham,West Midlands                 ,England                       ,B7 4AA,Wider Public Sector,,False
+10033757,Bath and North East Somerset PCT,,"Clara Cross Lane,",,,Bath,,England                       ,BA2 5RP,Wider Public Sector,,False
+10033723,Hampshire Primary Care Trust,,Lymington New Forest Hospital,Wellworthy Road,,Lymington,Hampshire                     ,England                       ,SO50 8QD,Wider Public Sector,Care Trust,False
+10033706,Derbyshire Community Health Services,,CONEY GREEN RECEPTION 1 CHURCH VIEW CLAY CROSS,CHESTERFIELD,Derbyshire,CHESTERFIELD,Derbyshire,England,S45 9HA,Wider Public Sector,TBA,False
+10033690,OAKS Secondary School The,,"THE OAKS Secondary School Rock Road,",Spennymoor,County Durham,Spennymoor,County Durham,England,DL16 7DB,Wider Public Sector,Local Authority Maintained School (All Types),False
+10033578,Bridge Childrens Centre,,Hayesdown First School,Wyville Road,,Frome,Somerset                      ,England                       ,BA11 2BN,Wider Public Sector,,False
+10033564,Kent Community Healthcare,,"Trust HQ Unit D, The Oast Hermitage Court, Hermitage Way",Barming,Kent,Barming,Kent,England,ME16 9NT,Wider Public Sector,TBA,False
+10033562,Wm Housing Group,,Barnsley Hall,Barnsley Hall Road,,Bromsgrove,Worcestershire                ,England                       ,B61 0TX,Wider Public Sector,,False
+10033504,Bromley Primary Care Trust,,379-397 Croydon Road,,,Beckenham,Kent                          ,England                       ,BR3 3QL,Wider Public Sector,,False
+10033438,South And West Leicestershire Citizens Advice Bureau,,10 Forge Corner,,,Leicester,Leicestershire                ,England                       ,LE8 4FZ,Wider Public Sector,,False
+10033425,Banbury Citizens Advice Bureau,,CORNHILL HOUSE,26 Cornhill,,Banbury,Oxfordshire                   ,England                       ,OX16 5NG,Wider Public Sector,,False
+10033305,Feltham Citizens Advice Bureau,,"Feltham, Middlesex TW13 5BH",High Street,,Feltham,Middlesex                     ,England                       ,TW13 4GU,Wider Public Sector,,False
+10033165,Torridge And Bude Citizens Advice Bureau,,28A BRIDGELAND STREET,,,BIDEFORD,,England                       ,EX39 2PZ,Wider Public Sector,,False
+10033134,Crown Office and Procurator Fiscals Service,,25 Chambers Street,Edinburgh,Lothian,Edinburgh,Lothian,Scotland,EH1 1LA,Wider Public Sector,TBA,False
+10033044,Brooke The,,30 Farringdon Street,London,Greater London,London,Greater London,England,EC4A 4HH,Wider Public Sector,TBA,False
+10032968,Outwood Grange Academy,,Potovens Lane OPutwood,Wakefield,West Yorkshire,Wakefield,West Yorkshire,England,WF1 2PF,Wider Public Sector,Academy (All Types),False
+10032956,Dwr Cymru Welsh Water,,Business Information Services,P.O. Box 690,,Cardiff,,Wales                         ,CF3 5WL,Wider Public Sector,,False
+10032895,Defence Infrastructure Organisation,,Whittington Barracks,Lichfield,Staffordshire,Lichfield,Staffordshire,England,WS14 9PY,Central Government,TBA,False
+10032765,My Civil Service Pension,MyCSP,70 Whitehall,,,London,,England                       ,SW1A 2AS,Central Government,,False
+10032749,Sir Antony Browne's Trust,,Ingrave Road,,,Brentwood,Essex                         ,England                       ,CM15 8AS,Wider Public Sector,,False
+10032705,(Closed) Office of the Health Professions Adjudicator,,New Kings Beam House 22 Upper Ground,London,Greater London,London,Greater London,England,SE1 9BW,Central Government,Executive Agency,False
+10032686,Sherborne Castle Estate,,Digby Estate Office,9 Cheap Street,,Sherborne,Dorset                        ,England                       ,DT9 3PY,Wider Public Sector,Charity,False
+10032685,Slade School,,Slade Road,Erdingtdon,,Birmingham,,England                       ,B23 7PX,Wider Public Sector,,False
+10032683,Fairfield Halls,,Park Lane,,,Croydon,Surrey                        ,England                       ,CR9 1DG,Wider Public Sector,Charity,False
+10032660,Higher Education Academy The,,Innovation Way York Science Park,York,Yorkshire,York,Yorkshire,England,YO10 5BR,Wider Public Sector,Purchasing Consortium,False
+10032520,Gloucester Citizens Advice Bureau,,75-81 Eastgate Street,,,Gloucester,Gloucestershire               ,England                       ,GL1 1PN,Wider Public Sector,Charity,False
+10032426,Timothy Hackworth Primary School,,Byerley Road,Shildon,County Durham,Shildon,County Durham,England,DL14 1HN,Wider Public Sector,TBA,False
+10032420,Money Advice Service The,,25 The North Colonnade,,Canary Wharf,London,,England,E14 5HS,Wider Public Sector,TBA,False
+10032360,County Durham Primary Care Trust,,John Snow House,Durham University Science Park,,Durham,,England                       ,DH1 3YG,Wider Public Sector,,False
+10032359,Durham and Darlington Acute Hospital,,North Road,,,Durham,County Durham                 ,England                       ,DH14ST,Wider Public Sector,,False
+10032357,South Birmingham Primary Care Trust,,Windsor House,11A High Street,Kings Heath,Birmingham,,England                       ,B14 7BB,Wider Public Sector,,False
+10032354,National Primary Care Development Team,,Improvement Foundation,Suite 12,112-116 Chorley Road,"Westhoughton, Bolton",,England                       ,BL5 3PL,Wider Public Sector,,False
+10032350,Somerset Primary Care Trust,,Wynford House,Lufton Way,Brympton,Yeovil,Somerset                      ,England                       ,BA228HR,Wider Public Sector,,False
+10032347,Cumbria Teaching PCT,,4 Wavell Drive,Carlisle,,Carlisle,,England,CA1 2SE,Wider Public Sector,,False
+10032344,Oxford Health NHS Foundation Trust,,4000 John Smith Drive,Oxford Business Park,,Oxford,,England                       ,OX4 2GX,Wider Public Sector,,False
+10032253,Government Hospitality,,Protocol Directorate,Lancaster House,Stable Yard,"St James's, London",,England                       ,SW1A 1BB,Central Government,,False
+10032192,Harrow Citizens Advice Bureau,,Civic 8,Milton Road,,Harrow,Middlesex                     ,England                       ,HA1 2XH,Wider Public Sector,,False
+10031983,Conservative Association,,14A Ardross Street,,,Inverness,,Scotland                      ,IV3 5NS,Wider Public Sector,,False
+10031865,Brigham Young University,,27 Palace Court,,,London,,England                       ,W2 4LP,Wider Public Sector,,False
+10031661,Sligo Law Centre,,Bridgwater House,Rockwood Parade,Thomas Street,Co. Sligo,,England                       ,SLIGO,Wider Public Sector,,False
+10031643,Sheffield High School,,1 Melbourne Avenue,Sheffield,South Yorkshire,Sheffield,South Yorkshire,England,S10 2QN,Wider Public Sector,TBA,False
+10031564,Public Prosecution Services,,Omagh Court House Omagh,Belfast,County Tyrone,Belfast,County Tyrone,Northern Ireland,BT71 1DU,Central Government,TBA,False
+10031448,Monaghan Law Centre,,Alma House,The Diamong,Monaghan,Co. Monaghan,,England                       ,MONAGHAN,Wider Public Sector,,False
+10031405,Longford Law Centre,,Credit Union Court Yard,Main Street,,Co. Longford,,England                       ,LONGFORD,Wider Public Sector,,False
+10031260,Stockton On Tees Labour Group,,4 Spennithorne Road,,,Stockton-On-Tees,,England                       ,TS18 4JW,Wider Public Sector,,False
+10031198,WestonSuperMare Conservative,,24-26 Alexandra Parade,,,Weston-Super-Mare,Somerset                      ,England                       ,BS23 1QX,Wider Public Sector,,False
+10031059,Barrow and Furness Conservatives,,Bob Inn T,Unit 52,Iron Works Road,Barrow-In-Furness,Cumbria                       ,England                       ,LA14 2PN,Wider Public Sector,,False
+10030956,Royal Society of Wildlife Trusts The,,The Kiln Waterside Mather Road,Newark,Nottinghamshire,Newark,Nottinghamshire,England,NG24 1WT,Wider Public Sector,TBA,False
+10030899,Health Record,,Unit H,Beacon Bus Park,,Stafford,Staffordshire                 ,England                       ,ST18 0WL,Wider Public Sector,,False
+10030886,Caldew School,,Dalston,Carlisle,Cumbria,Carlisle,Cumbria,England,CA5 7NN,Wider Public Sector,Academy (All Types),False
+10030817,University of Greenwich,,Blake 57 Central Ave,,,Chatham,Kent                          ,England                       ,ME4 4TB,Wider Public Sector,Universities,False
+10030764,International Advertising Agency,,Parklands 825A Wilmslo,W Road Didsbury,,Manchester,Greater Manchester            ,England                       ,M20 2RE,Wider Public Sector,,False
+10030749,Chester West And Cheshire Council,,Stanney Lane,Ellesmere Port,,Ellesmere Port,Merseyside                    ,England                       ,CH65 6QL,Wider Public Sector,,False
+10030727,School Of Management,,Cledwyn Building,,,Penglais,Dyfed                         ,Wales                         ,SY23 3DD,Wider Public Sector,,False
+10030298,Powys Citizens Advice Bureau,,The Welfare Hall,,,Swansea,,Wales                         ,SA9 1JJ,Wider Public Sector,Local Government,False
+10030260,Newtown Abbey Borough Council,,Central Services Depot,Belfast,County Antrim,Belfast,County Antrim,Northern Ireland,BT36 5BU,Wider Public Sector,Local Government,False
+10030259,Newry and Mourne Dist Council,,Newry Swimming Pool,Belfast,County Down,Belfast,County Down,Northern Ireland,BT34 2QU,Wider Public Sector,Local Government,False
+10030138,Lands End Airport,,The Supplies Officer,,,Truro,Cornwall                      ,England                       ,TR19 7RL,Wider Public Sector,,False
+10030133,Knowsley Borough Council,,Sport Management Team,,,Liverpool,Merseyside                    ,England                       ,L36 4HD,Wider Public Sector,District Council,False
+10030091,HMRC Evesham,,"Invoice Processing Centre, Po Box 2092",,,Brighton,West Sussex                   ,England                       ,BN12 9AN,Central Government,,False
+10030088,HM Courts Service North West Region,,Po Box 697,,,Newport,Gwent                         ,Wales                         ,NP10 8ZF,Central Government,,False
+10030000,Irwell Valley Housing Association,,Unit 2 Wadsworth Comm Park,,,Bolton,,England,BL3 6FR,Wider Public Sector,Housing Associations,False
+10029403,South London Healthcare NHS Trust,,Frognal Avenue,,,Sidcup,,England                       ,DA14 6LT,Wider Public Sector,Acute Trust,False
+10029289,High Park School,,Boothroyd Drive,Bradford,West Yorkshire,Bradford,West Yorkshire,England,BD10 8LU,Wider Public Sector,Local Authority Maintained School (All Types),False
+10029005,Garston Citizens Advice Bureau,,Community House,2 Speke Road,Garston,Liverpool,Merseyside                    ,England                       ,L19 2PA,Wider Public Sector,Charity,False
+10028928,Comhairle Nan Eileen,,Council Offices,Sandwick Road,,Stornoway,,Scotland                      ,HS12BW,Wider Public Sector,Local Government,False
+10028913,Charles Darwin School,,Jail Lane Biggin Hill,Westerham,Kent,Westerham,Kent,England,TN16 3AU,Wider Public Sector,Academy (All Types),False
+10028891,Temp Testing 2,,1 A Street,,,Norwich,,England                       ,NR1 A23,Wider Public Sector,,False
+10028890,Temp Testing 1,,1 A Street,,,Norwich,,England                       ,NR1 A23,Wider Public Sector,,False
+10028859,Halsford Park Primary School,,Manor Road,East Grinstead,West Sussex,East Grinstead,West Sussex,England,RH19 1LR,Wider Public Sector,Academy (All Types),False
+10028784,NEST Corporation,,St Dunstan's House,201-211 Borough High Street,,London,,England                       ,SE1 1JA,Central Government,NDPB,False
+10028761,Homes and Communities Agency Milton Keynes,,414-428 Summer Boulevard,,,Milton Keynes,Buckinghamshire               ,England                       ,MK9 2EA,Central Government,,False
+10028672,Orchard Hospital,,189 Fairlee Road,,,Newport,,Channel Islands               ,PO30 2EP,Wider Public Sector,Health,False
+10028612,North Mersey Health Economy NHS Trust,,Executiuve HR Directorate,Royal Liverpool Hospital,Prescot Street,Liverpool,Merseyside                    ,England                       ,L7 8XP,Wider Public Sector,Acute Trust,False
+10028602,Teignbridge Citizens Advice Bureau,,5B Bank Street,,,Newton Abbot,Devon                         ,England                       ,TQ12 2JL,Wider Public Sector,Charity,False
+10028600,Derbyshire County Primary Care Trust,,Headquarters Nightingale Close,Chesterfield,Derbyshire,Chesterfield,Derbyshire,England,S41 7PF,Wider Public Sector,TBA,False
+10028582,Citizens Advice Bureau Norwich,,48 Chester Way,,,Northwich,Cheshire                      ,England                       ,CW9 5JA,Wider Public Sector,Charity,False
+10028571,MUHLEMANN MF JERSEY,,Little Grove Clinic,La Rue De Haut,St. Lawrence,Jersey,,Channel Islands               ,JE3 1JQ,Wider Public Sector,Health,False
+10028570,MUHLEMANN MF GUERNSEY,,C/O Little Grove Clinic,La Rue De Haut,St. Lawrence,Jersey,,Channel Islands               ,JE3 1JQ,Wider Public Sector,Health,False
+10028554,Victoria Park Home Ownership Limited,,,,,,,,XXXX,Wider Public Sector,TBA,False
+10028498,Royal Borough Of Kingston Upon Thames,,NULL,,,NULL,,NULL,NULL,Wider Public Sector,,False
+10028496,Riverside Housing Association Limited,,2 Estuary Boulevard Speke,Liverpool,Merseyside,Liverpool,Merseyside,England,L24 8RF,Wider Public Sector,TBA,False
+10028495,Riverside Group Limited The,,,,,,,,XXXX,Wider Public Sector,TBA,False
+10028461,No Trust,,NULL,,,NULL,,NULL,NULL,Wider Public Sector,Health Trust,False
+10028414,Leicester City West Primary Care Trust Patient Home Delivery,,NULL,,,NULL,,NULL,XXXX,Wider Public Sector,Private Sector Enabler,False
+10028393,Isle Of Man Nobles Hospital Other,,NULL,,,NULL,,NULL,XXXX,Wider Public Sector,Private Sector Enabler,False
+10028306,City and County Swansea,,NULL,,,NULL,,NULL,XXXX,Wider Public Sector,,False
+10028190,Abbeyfield / Ssafa Hereford Society Limited The,,,,,,,,XXXX,Wider Public Sector,TBA,False
+10028175,Dyfed Powys Deputy,,ST.DAVIDS HOSPITAL,CARMARTHEN,,DYFED,,Wales                         ,SA31 3HB,Wider Public Sector,Health,False
+10028115,North Yorkshire and York PCT,,BLUEBECK DRIVE,SHIPTON ROAD,,YORK,North Yorkshire               ,England                       ,YO30 5RA,Wider Public Sector,Private Sector Enabler,False
+10027978,Earl Mountbatten Hospice,,HALBERRY LANE,,,NEWPORT,Isle of Wight                 ,England                       ,PO30 2ER,Wider Public Sector,,False
+10027885,The Ipswich Hospital NHS Trust,,IPSWICH HOSPITAL N H S TRUST,HEATH ROAD,,IPSWICH,Suffolk                       ,England                       ,IP4 5PD,Wider Public Sector,,False
+10027829,Dental Vocational Training Authority,,MASTERS HOUSE,TEMPLE GROVE,COMPTON PLACE ROAD,EASTBOURNE,East Sussex                   ,England                       ,BN20 8AD,Wider Public Sector,Dental Practice,False
+10027673,Dr Pw Hunts Practice,,VENELLE DU VAL DU SUD,,,ALDERNEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027672,Dr Jf Marks Practice,,FORT CORBLETS,,,ALDERNEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027671,CASTEL and KING EDWARD V11 HOSPITAL,,CASTEL,,,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027670,Hugh Je,,8 ELIZABETH PLACE,,,ST.HELIER,,Channel Islands               ,JE2 3PN,Wider Public Sector,Health,False
+10027669,Shetty S,,CASTEL HOSPITAL,,,CASTEL,,Channel Islands               ,GY5 7NJ,Wider Public Sector,Health,False
+10027668,Mckeough Gn,,CASTEL HOSPITAL,,,CASTEL,,Channel Islands               ,GY5 7NJ,Wider Public Sector,Health,False
+10027667,Kelly A,,CASTEL HOSPITAL,,,CASTEL,,Channel Islands               ,GY5 7NJ,Wider Public Sector,Health,False
+10027666,Coslett A,,CASTEL HOSPITAL,,,CASTEL,,Channel Islands               ,GY5 7NJ,Wider Public Sector,Health,False
+10027665,Blakemore B,,CASTEL HOSPITAL,,,CASTEL,,Channel Islands               ,GY5 7NJ,Wider Public Sector,Health,False
+10027664,Browne Rv,,GLENCOE CLINIC,,,ST MARTINS,,Channel Islands               ,GY4 6DZ,Wider Public Sector,Health,False
+10027663,Redpath Th,,LA PARCHONNERIE,LES ROUVETS,,VALE,,Channel Islands               ,GY6 8NQ,Wider Public Sector,Health,False
+10027662,Laumoneandstsampsons PRAC,,L'AUMONE&ST.SAMPSONS PRAC,ST.SAMPSONS MEDICAL CTR.,GRANDES MAISONS ROAD,ST.SAMPSONS,,Channel Islands               ,GY2 4JS,Wider Public Sector,Health,False
+10027661,Deacon M,,C/O MRS STIEVENARD,LE RUISSELET MONT,ROSSIGNOL,ST.OUEN,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027660,Medical Specialist Group,,MEDICAL SPECIALIST GROUP,ALEXANDRA HOUSE,LES FRIETEAUX,ST.MARTINS,,Channel Islands               ,GY1 3EX,Wider Public Sector,Health,False
+10027659,Evans Dg,,MAISON DES CARRIERES,LA GRANDE ROUTE DE,ST.MARTIN,ST.MARTIN,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027658,Mattock C,,C/O GENERAL HOSPITAL,GLOUCESTER STREET,,ST.HELIER,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027657,Newell J,,LE BAS CENTRE,PHILIP LE FEUVRE HOUSE,LA MOTTE STREET,ST.HELIER,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027656,Milner S,,LE BAS CENTRE,PHILIP LE FEUVRE HOUSE,LA MOTTE STREET,ST.HELIER,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027655,Hullah Jm,,LE BAS CENTRE,PHILIP LE FEUVRE HOUSE,LA MOTTE STREET,ST.HELIER,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027654,Gruchy Cy,,LE BAS CENTRE,PHILIP LE FEUVRE HOUSE,LA MOTTE STREET,ST.HELIER,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027653,Blandin B,,LE BAS CENTRE,PHILIP LE FEUVRE HOUSE,LA MOTTE STREET,ST.HELIER,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027652,Dr Ug Eichners Practice,,FIRST TOWER MEDICAL PRACT,"BERESFORD HOUSE, ROUTE ES NOUAUX",FIRST TOWER,ST.HELIER,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027651,Curran Jg,,HEALTHXCHANGE,ALBERT HOUSE,SOUTH ESPLANADE,ST PETER PORT,,Channel Islands               ,GY1 1AW,Wider Public Sector,Health,False
+10027650,St Marks Medical Centre,,ST MARKS MEDICAL CENTRE,1 JUBILEE PROMENADE,LA ROUTE DU PORT E'BETH,ST HELIER,,Channel Islands               ,JE2 4FJ,Wider Public Sector,Health,False
+10027649,Douglas Hgk,,LA JOANIERE,LES RUETTES,,ST ANDREWS,,Channel Islands               ,GY6 8UG,Wider Public Sector,Health,False
+10027648,Ramsey Cottage Hospital,,CUMBERLAND ROAD,,,RAMSEY,,Channel Islands               ,IM8 3RH,Wider Public Sector,Health,False
+10027647,Foster Sj,,PUBLIC HEALTH DEPARTMENT,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027646,Fleet Jd,,C/O GENERAL HOSPITAL,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027645,Dingle Hr,,C/O GENERAL HOSPITAL,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027644,Reid J,,BON AIR CONSULTING ROOMS,ST.SAVIOUR,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027643,Purcell-Jones G,,BON AIR CONSULTING ROOMS,ST.SAVIOUR,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027642,Nicolle Fv,,BON AIR CONSULTING ROOMS,ST.SAVIOUR,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027641,Gleeson Mh,,BON AIR CONSULTING ROOMS,ST.SAVIOUR,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027640,Ginks W,,BON AIR CONSULTING ROOMS,ST.SAVIOUR,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027639,Faiz Gf,,BON AIR CONSULTING ROOMS,ST.SAVIOUR,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027638,Day J,,BON AIR CONSULTING ROOMS,ST.SAVIOUR,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027637,Dodd Af,,BEECHFIELD,TRINITY,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027636,Williams Ad,,BEAU VALLON,ST.SAVIOUR,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027635,Bruce Mp,,BEAU PARC,TRINITY,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027634,Spencer D,,ABBEVILLE LODGE,LA ROCQUE,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027633,De Kr,,84 HALKETT PLACE,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027632,Lapasset Mf,,8 ELIZABETH PLACE,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027631,Como Village Surgery,,7 CLARENDON ROAD,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027630,Spratt Hc,,56 DAVID PLACE,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027629,Fullerton Ds,,56 DAVID PLACE,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027628,YOUNG ELLIS and OVERTON,,41 DAVID PLACE,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027627,Messervy M,,19 MIDVALE ROAD,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027626,Macmichael I,,19 MIDVALE ROAD,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027625,Alwitry M,,19 MIDVALE ROAD,ST.HELIER,,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027624,T/A 7 David Place,,7 DAVID PLACE,ST.HELIER,,JERSEY,,Channel Islands               ,JE2 4TD,Wider Public Sector,Health,False
+10027623,Les Saisons Surgery,,20 DAVID PLACE,ST.HELIER,,JERSEY,,Channel Islands               ,JE2 4TD,Wider Public Sector,Health,False
+10027622,DR POPE and PARTNERS,,84 HALKETT PLACE,ST.HELIER,,JERSEY,,Channel Islands               ,JE1 4XL,Wider Public Sector,Health,False
+10027621,York House Surgery,,YORK HOUSE,5 GROSVENOR STREET,ST.HELIER,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027620,White Lodge Med Practvincent,,WHITE LODGE MEDICAL CTR,21 GROSVENOR STREET,ST HELIER,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027619,White Lodge,,WHITE LODGE,GROSVENOR STREET,ST.HELIER,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027618,Howell D,,THE WARREN,CASTLE GREEN,GOREY,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027617,Crill Dh,,THE FARM,L'ETACQ,ST.OUEN,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027616,Clinton C,,SPORTS INJURY CLINIC,DONGOLA ROAD,ST.HELIER,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027615,War Pensioner,,PHILIP LE FEUVRE HOUSE,LA MOTTE STREET,ST.HELIER,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027614,Retired Doctors,,PHILIP LE FEUVRE HOUSE,LA MOTTE STREET,ST.HELIER,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027613,Sayers D,,LITTLE CROFT,BON AIR LANE,ST.SAVIOUR,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027612,Myles Jb,,CRAHAMEL HOUSE,DUHAMEL PLACE,ST.HELIER,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027611,Fogarty Jp,,CRAHAMEL HOUSE,DUHAMEL PLACE,ST.HELIER,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027610,Shah Nd,,BON AIR CONSULTING ROOMS,BON AIR LANE,ST.SAVIOUR,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027609,Maclachlan Na,,BON AIR CONSULTING ROOMS,BON AIR LANE,ST.SAVIOUR,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027608,Trunchion J,,3 VALLEY CREST,LA MARQUANDERIE,ST.BRELADE,JERSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027607,Visitors Clinic,,PHILIP LE FEUVRE HOUSE,LA MOTTE STREET,ST.HELIER,JERSEY,,Channel Islands               ,JE4 8PE,Wider Public Sector,Health,False
+10027606,St Peters Surgery,,ST.PETER'S SURGERY,RUE DE L'EGLISE,ST.PETER,JERSEY,,Channel Islands               ,JE3 7AG,Wider Public Sector,Health,False
+10027605,Twiston Davies Cw,,LITTLE GROVE CLINIC,RUE DU HAUT,ST.LAWRENCE,JERSEY,,Channel Islands               ,JE3 1JQ,Wider Public Sector,Health,False
+10027604,Ingram Np,,LITTLE GROVE CLINIC,RUE DU HAUT,ST.LAWRENCE,JERSEY,,Channel Islands               ,JE3 1JQ,Wider Public Sector,Health,False
+10027603,Clifford Rp,,LITTLE GROVE CLINIC,RUE DU HAUT,ST.LAWRENCE,JERSEY,,Channel Islands               ,JE3 1JQ,Wider Public Sector,Health,False
+10027602,Crahamel Medical Practice,,CRAHAMEL MEDICAL PRACTICE,CRAHAMEL HOUSE,"DUHAMEL PLACE, ST.HELIER",JERSEY,,Channel Islands               ,JE2 4TR,Wider Public Sector,Health,False
+10027601,Clifden House Surgery,,CLIFDEN HOUSE SURGERY,24 VAUXHALL STREET,ST.HELIER,JERSEY,,Channel Islands               ,JE2 4TJ,Wider Public Sector,Health,False
+10027600,DR STEVENSBALMER and WEBSTER,,6 WINDSOR CRESCENT,VAL PLAISANT,ST.HELIER,JERSEY,,Channel Islands               ,JE2 4TB,Wider Public Sector,Health,False
+10027599,David Place Medical Centre,,"HEALTH PLUS,QUEENS RD H/C",QUEENS ROAD,ST HELIER,JERSEY,,Channel Islands               ,JE2 4NY,Wider Public Sector,Health,False
+10027598,Laurels Medical Practice The,,THE LAURELS,28 CLARENDON ROAD,ST.HELIER,JERSEY,,Channel Islands               ,JE2 3YS,Wider Public Sector,Health,False
+10027597,States Of Jersey Health and Social Services,,PETER CRILL HOUSE,GLOUCESTER ST,ST HELIER,JERSEY,,Channel Islands               ,JE2 3QS,Central Government,,False
+10027596,Lister House Surgery,,LISTER HOUSE,THE PARADE,ST.HELIER,JERSEY,,Channel Islands               ,JE2 3QQ,Wider Public Sector,Health,False
+10027595,Ivy House Surgerywildy,,IVY HOUSE SURGERY,27 THE PARADE,ST.HELIER,JERSEY,,Channel Islands               ,JE2 3QQ,Wider Public Sector,Health,False
+10027594,Ivy House Surgeryhughes,,IVY HOUSE SURGERY,27 THE PARADE,ST.HELIER,JERSEY,,Channel Islands               ,JE2 3QQ,Wider Public Sector,Health,False
+10027593,Jersey Hospice Care,,CLARKSON HOUSE,MONT COCHON,ST HELIER,JERSEY,,Channel Islands               ,JE2 3JB,Wider Public Sector,Health,False
+10027592,Lido Medical Practice,,THE LIDO MEDICAL CENTRE,ST SAVIOURS ROAD,ST HELIER,JERSEY,,Channel Islands               ,JE1 7XP,Wider Public Sector,Health,False
+10027591,DR SPARROW and PARTNERS,,ROUTE DU FORT SURGERY,"LIDO M/C,ST SAVIOURS ROAD",ST SAVIOUR,JERSEY,,Channel Islands               ,JE1 7XP,Wider Public Sector,Health,False
+10027590,Cleveland Clinic Limited,,CLEVELAND CLINIC LTD,12 CLEVELAND ROAD,ST.HELIER,JERSEY,,Channel Islands               ,JE1 4HD,Wider Public Sector,Health,False
+10027589,DR INCE and PARTNERS,,INDIGO HOUSE,2-8 OXFORD ROAD,ST.HELIER,JERSEY,,Channel Islands               ,JE1 4HB,Wider Public Sector,Health,False
+10027588,Manx Emergency Drmedsooh,,NOBLES HOSPITAL,STRANG,,ISLE OF MAN,,Channel Islands               ,IM4 4RJ,Wider Public Sector,Health,False
+10027587,Childrens Secure Unit The,,OLD CASTLETOWN ROAD,DOUGLAS,,ISLE OF MAN,,Channel Islands               ,IM3 1QD,Wider Public Sector,Health,False
+10027586,Southern Group Practice,,SOUTHERN GROUP PRACTICE,CASTLETOWN ROAD,PORT ERIN,ISLE OF MAN,,Channel Islands               ,IM9 6BD,Wider Public Sector,Health,False
+10027585,Ballasalla Medical Centre,,BALLASALLA MEDICAL CENTRE,MAIN ROAD,BALLASALLA,ISLE OF MAN,,Channel Islands               ,IM9 2RQ,Wider Public Sector,Health,False
+10027584,Castletown Medical Centre,,CASTLETOWN MEDICAL CENTRE,SANDFIELD,CASTLETOWN,ISLE OF MAN,,Channel Islands               ,IM9 1EX,Wider Public Sector,Health,False
+10027583,Ramsey Group Practice,,RAMSEY GROUP PRACTICE,BOWRING ROAD,RAMSEY,ISLE OF MAN,,Channel Islands               ,IM8 3EY,Wider Public Sector,Health,False
+10027582,Peel Group Practice,,PEEL GROUP PRACTICE,THE MEDICAL CENTRE,"DERBY ROAD, PEEL",ISLE OF MAN,,Channel Islands               ,IM5 1HP,Wider Public Sector,Health,False
+10027581,DRUG and ALCOHOL SERVICE DA,,REAYRT NOA,STRANG,BRADDAN,ISLE OF MAN,,Channel Islands               ,IM4 4RF,Wider Public Sector,Health,False
+10027580,Laxey Health Centre,,VILLAGE WALK HEALTH CTR,1 VILLAGE WALK,ONCHAN,ISLE OF MAN,,Channel Islands               ,IM3 4EA,Wider Public Sector,Health,False
+10027579,Palatine Group Practice,,PALATINE GROUP PRACTICE,MURRAYS ROAD,DOUGLAS,ISLE OF MAN,,Channel Islands               ,IM2 3TD,Wider Public Sector,Health,False
+10027578,Snaefell Surgery,,SNAEFELL SURGERY,"CUSHAG ROAD, ANAGH COAR",DOUGLAS,ISLE OF MAN,,Channel Islands               ,IM2 2SU,Wider Public Sector,Health,False
+10027577,Kensington Group Practice,,KENSINGTON HEALTH CENTRE,WESTMORELAND ROAD,DOUGLAS,ISLE OF MAN,,Channel Islands               ,IM1 4QA,Wider Public Sector,Health,False
+10027576,Family Planning Clinic,,COMMUNITY HEALTH CLINIC,BALLAKERMEEN ROAD,DOUGLAS,ISLE OF MAN,,Channel Islands               ,IM1 4BR,Wider Public Sector,Health,False
+10027575,IOM Nurses,,CROOKALL HOUSE,DEMESNE ROAD,DOUGLAS,ISLE OF MAN,,Channel Islands               ,IM1 3QA,Wider Public Sector,Health,False
+10027574,Finch Hill Health Centre,,FINCH HILL HEALTH CTR,KENSINGTON ROAD,DOUGLAS,ISLE OF MAN,,Channel Islands               ,IM1 3PF,Wider Public Sector,Health,False
+10027573,Promenade Medical Centre,,PROMENADE MEDICAL CENTRE,46 LOCH PROMENADE,DOUGLAS,ISLE OF MAN,,Channel Islands               ,IM1 2LZ,Wider Public Sector,Health,False
+10027572,Daff Ja,,VARCLIN FARM,ST. MARTINS,,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027571,Princess Elizabeth Hospital,,LE VAUQUIEDOR,ST. ANDREWS,,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027570,Dr Gha Simmons Practice,,LE MONT D'AVAL,CASTEL,,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027569,Allison Sn,,LA HOUGUETTE,ST PETERS,,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027568,Mowbray S,,KING EDWARD VII HOSPITAL,CASTEL,,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027567,Locum For Castel Hospital,,CASTEL HOSPITAL,CASTEL,,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027566,Les Nicolles Prison,,LES NICOLLES,ST.SAMPSONS,,GUERNSEY,,Channel Islands               ,GY2 4YF,Wider Public Sector,Health,False
+10027565,Eddie G,,THE CLINIC,EBANISTA,"BRAYE ROAD, VALE",GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027564,Visiting Consultants,,PRINCESS ELIZABETH HOSP.,LE VAUQUIEDOR,ST ANDREWS,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027563,Accidentandemergency DEPARTMENT,,PRINCESS ELIZABETH HOSP.,LE VAUQUIEDOR,ST. ANDREWS,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027562,Hanaghan J,,LES RAIES COTTAGE,RUE DE RAIES,ST. SAVIOURS,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027561,Roussel On,,LA CORBIERE,HOUGUE DU MOULIN,VALE,GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027560,Mela Ma,,ASSOCIATE SPECIALIST IN,PSYCHIATARY,"CASTEL HOSPITAL,CASTEL",GUERNSEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027559,States Of Alderney Social Security and Medical Care,,PO BOX 1,,ALDERNAY,GUERNSEY,,Channel Islands               ,GY9 3AA,Central Government,,False
+10027558,Brannan Ma,,LA FONTAINE VILLA,ROUTE DES DOMAINES,ST SAVIOURS,GUERNSEY,,Channel Islands               ,GY7 9SS,Wider Public Sector,Health,False
+10027557,Les Bourgs Hospice,,ANDREW MITCHELL HOUSE,RUE DE TERTRE,ST ANDREW'S,GUERNSEY,,Channel Islands               ,GY6 8SF,Wider Public Sector,Health,False
+10027556,Strickland Jet,,SIZERGH,LE PONT VAILLANT LANE,VALE,GUERNSEY,,Channel Islands               ,GY6 8BN,Wider Public Sector,Health,False
+10027555,Razzak D,,BAS SEJOUR,"RUETTES DES FRIES,COBO",CASTEL,GUERNSEY,,Channel Islands               ,GY5 7PW,Wider Public Sector,Health,False
+10027554,Seibold U,,CASTEL HOSPITAL,,CASTEL,GUERNSEY,,Channel Islands               ,GY5 7NJ,Wider Public Sector,Health,False
+10027553,Brennand-Roper Sm,,RHEUMATOLOGY CLINIC,PRINCESS ELIZABETH HPL,"LE VAUQUIEDOR,ST MARTINS",GUERNSEY,,Channel Islands               ,GY4 6UU,Wider Public Sector,,False
+10027552,Jeffs D,,PRINCESS ELIZABETH HOSP,LE VAUQUIEDOR,ST. MARTINS,GUERNSEY,,Channel Islands               ,GY4 6UU,Wider Public Sector,Health,False
+10027551,States Of Guernsey Health and Social Services,,JOHN HENRY HOUSE,LE VANQUIEDOR,ST MARTINS,GUERNSEY,,Channel Islands               ,GY4 6UU,Central Government,,False
+10027550,Reilly Gd,,DERMATOLOGY CLINIC,PRINCESS ELIZABETH HOSP,"LE VAUQUIEDOR, ST MARTINS",GUERNSEY,,Channel Islands               ,GY4 6UU,Wider Public Sector,Health,False
+10027549,Department Of Sexual Health,,ORCHARD CENTRE,GRANDE RUE,ST MARTINS,GUERNSEY,,Channel Islands               ,GY4 6RX,Wider Public Sector,Health,False
+10027548,Seth-Smith Ab,,FLEUR DE LYS,JERBOURG ROAD,ST MARTINS,GUERNSEY,,Channel Islands               ,GY4 6BG,Wider Public Sector,Health,False
+10027547,Farmer Cj,,LA COUTURE,BELVAL ROAD,VALE,GUERNSEY,,Channel Islands               ,GY3 5LW,Wider Public Sector,Health,False
+10027546,Thompson Pj,,CHILD HEALTH SERVICES,"BELL HOUSE, GRAND BOUET",ST PETER PORT,GUERNSEY,,Channel Islands               ,GY1 2QG,Wider Public Sector,Health,False
+10027545,Mellors S,,CHILD HEALTH SERVICES,"BELL HOUSE,GRAND BOUET",ST PETER PORT,GUERNSEY,,Channel Islands               ,GY1 2QG,Wider Public Sector,Health,False
+10027544,Godinho E,,CHILD HEALTH SERVICES,BELL HOUSE,GRAND BOUET ST PETER PORT,GUERNSEY,,Channel Islands               ,GY1 2QG,Wider Public Sector,Health,False
+10027543,Reilly S,,GUERNSEY FAM PLANNING SER,7 LE POLLET,ST PETER PORT,GUERNSEY,,Channel Islands               ,GY1 1WQ,Wider Public Sector,Health,False
+10027542,Queens Road Medical Prac,,QUEENS ROAD MEDICAL PRAC.,QUEENS ROAD,ST.PETER PORT,GUERNSEY,,Channel Islands               ,GY1 1RH,Wider Public Sector,Health,False
+10027541,Bolt Jf,,BUHEZ NEVEZ,"7 NEW PLACE,LOWER VAUVERT",ST PETER PORT,GUERNSEY,,Channel Islands               ,GY1 1ND,Wider Public Sector,Health,False
+10027540,Primary Care Centre The,,ROHAIS HEALTH CENTRE,ROHAIS,ST. PETER PORT,GUERNSEY,,Channel Islands               ,GY1 1FF,Wider Public Sector,Health,False
+10027539,Healthcare Group,,HEALTHCARE GROUP,"THE SURGERY, ROHAIS",ST. PETER PORT,GUERNSEY,,Channel Islands               ,GY1 1FF,Wider Public Sector,Health,False
+10027538,Bacon Hf,,OPHTHALMIC SURGEONS,64A HAUTEVILLE,ST.PETER PORT,GUERNSEY,,Channel Islands               ,GY1 1DQ,Wider Public Sector,Health,False
+10027537,Creery Rdg,,LEAF HOUSE,LA ROUTE DE PLEINMONT,TORTEVAL,GUERNSEY,,Channel Islands               ,GY1 0LP,Wider Public Sector,Health,False
+10027536,Fox Vm,,LONG CAMPS,ST SAMPSONS,,GUENRSEY,,Channel Islands               ,GY2 4UQ,Wider Public Sector,Health,False
+10027535,Carre Ij,,LE VAL FARM,LES BLICQS,ST ANDREWS,GUENRSEY,,Channel Islands               ,GY6 8YD,Wider Public Sector,Health,False
+10027534,Hailwood Medical Centre,,HAILWOOD MEDICAL CENTRE,2 HAILWOOD COURT,GOVERNORS HILL,DOUGLAS,,Channel Islands               ,IM2 7EA,Wider Public Sector,Health,False
+10027533,Isle Of Man Secondary Healthcare Directorate,,CROOKALL HOUSE,DEMESNE ROAD,,DOUGLAS,,Channel Islands               ,IM1 3QA,Wider Public Sector,Health,False
+10027532,Isle Of Man Public Health Directorate,,CROOKALL HOUSE,DEMESNE ROAD,,DOUGLAS,,Channel Islands               ,IM1 3QA,Wider Public Sector,Health,False
+10027531,Isle Of Man Primary Healthcare Directorate,,CROOKALL HOUSE,DEMESNE ROAD,,DOUGLAS,,Channel Islands               ,IM1 3QA,Wider Public Sector,Health,False
+10027530,ISLE OF MAN DEPARTMENT OF HEALTH and SOCIAL SECURITY,,CROOKALL HOUSE,DEMESNE ROAD,,DOUGLAS,,Channel Islands               ,IM1 3QA,Wider Public Sector,,False
+10027529,Crookall House,,CROOKALL HOUSE,DEMESNE ROAD,,DOUGLAS,,Channel Islands               ,IM1 3QA,Wider Public Sector,Health,False
+10027528,St Bridgets Hospice,,DOROTHY PANTIN HOUSE,KENSINGTON ROAD,,DOUGLAS,,Channel Islands               ,IM1 3PE,Wider Public Sector,Health,False
+10027527,Turner P,,CASTEL HOSPITAL,,,CASTEL,,Channel Islands               ,GY5 7NJ,Wider Public Sector,Health,False
+10027526,Macey L,,CASTEL HOSPITAL,,,CASTEL,,Channel Islands               ,GY5 7NJ,Wider Public Sector,Health,False
+10027525,Costen M,,CASTEL HOSPITAL,,,CASTEL,,Channel Islands               ,GY5 7NJ,Wider Public Sector,Health,False
+10027524,Birchall H,,CASTEL HOSPITAL,,,CASTEL,,Channel Islands               ,GY5 7NJ,Wider Public Sector,Health,False
+10027523,Isle Of Man Ambulance Service,,JANE CROOKALL MATERNITY WING,NOBLES HOSPITAL,STRANG,BRADDON,,Channel Islands               ,IM4 4RJ,Wider Public Sector,Health,False
+10027522,Dr Lhf Waltons Practice,,LES SAPINS,6 AUDERVILLE,ST. ANNE'S,ALDERNEY,,Channel Islands               ,NULL,Wider Public Sector,Health,False
+10027521,Dr Jf Coopers Practice,,THE ISLAND MEDICAL CENTRE,SUNDIAL HOUSE,LES ROCQUETTES,ALDERNEY,,Channel Islands               ,GY9 3TF,Wider Public Sector,Health,False
+10027520,Dr R Lyons Practice,,EAGLE MEDICAL PRACTICE,"STEFAN HOUSE,OLLIVIER CT.","OLLIVIER STREET,ST.ANNES",ALDERNEY,,Channel Islands               ,GY9 3TD,Wider Public Sector,Health,False
+10027408,Partnership for Young London,,PO Box 270,,,London,,England                       ,EC2P 2EJ,Wider Public Sector,Charity,False
+10027386,Business Services Organisation,,2 Franklin Street,Belfast,County Antrim,Belfast,County Antrim,Northern Ireland,BT2 8DQ,Wider Public Sector,Health,False
+10027359,Coventry PCT,,Wilsons Lane,,,Coventry,West Midlands                 ,England                       ,CV6 6NY,Wider Public Sector,PCT - Commissioning,False
+10027276,Breast Cancer Care,,5-13 Great Suffolk Street,,,London,,England,SE1 0NS,Wider Public Sector,GP Practice,False
+10027210,Chief Executive of Skills Funding,,Cheylesmore House 5 Quinton Road,Coventry,West Midlands,Coventry,West Midlands,England,CV1 2WT,Central Government,Executive Agency,False
+10027198,Young Peoples Learning Agency,,Cheylesmore House,5 Quinton Road,,Coventry,West Midlands                 ,England                       ,CV1 2WT,Central Government,,False
+10027065,Grimsdyke First and Middle School,,Sylvia Avenue,Pinner,,Pinner,,England,HA5 4QE,Wider Public Sector,Local Authority Maintained School (All Types),False
+10027063,Fabrick Group,,"4th Floor Centre, North East",73-75 Albert Road,,Middlesbrough,,England                       ,TS1 2RU,Wider Public Sector,Housing Associations,False
+10027058,Knowsley Citizens Advice Bureau,,2 Newtown Gardens,,,Liverpool,Merseyside                    ,England                       ,L32 8RR,Wider Public Sector,Charity,False
+10027030,Government Offices Network Centre and Services,http://www.gos.gov.uk/,4th Floor,Eland House,Bressenden Place,London,,England                       ,SW1E 5DU,Central Government,NDPB,False
+10027005,National Association of Teachers of Travellers and Other Professionals,NATT,West Park Centre,Spen Lane,,Leeds,Yorkshire                     ,England                       ,LS16 5BE,Wider Public Sector,Charity,False
+10026946,Citizens Advice Doncaster,,Old Guildhall Yard,French Gate,,Doncaster,South Yorkshire               ,England                       ,DN1 1QW,Wider Public Sector,Charity,False
+10026926,NHS Lincolnshire,,Bootle House,Sleaford Road,Bracebridge Heath,Lincoln,Lincolnshire                  ,England                       ,LN4 2NW,Wider Public Sector,PCT - Commissioning,False
+10026884,Flintshire Citizens Advice Bureau,,The Annexe,Terrig House,Chester Street,Mold,Flintshire                    ,Wales                         ,CH7 1EG,Wider Public Sector,Charity,False
+10026877,Norfolk Community Health and Care,,Elliott House 130 Ber Street,Norwich,Norfolk,Norwich,Norfolk,England,NR1 3FR,Wider Public Sector,PCT - Provisioning,False
+10026876,Technology Strategy Board,,North Star House North Star Avenue,Swindon,Wiltshire,Swindon,Wiltshire,England,SN2 1UE,Central Government,NDPB,False
+10026831,Capital for Enterprise Limited,,1 Broadfield Close Broadfield Business Park,Sheffield,South Yorkshire,Sheffield,South Yorkshire,England,S8 0XN,Central Government,NDPB,False
+10026785,DES Clothing Store,,Building 1241 Faslane Helensburgh,Argyll and Bute,,Argyll and Bute,,England,G84 8HL,Central Government,MoD - DE&S,False
+10026727,Origo,,61 Lemon Street,,,Truro,,England                       ,TR1 2PE,Wider Public Sector,Charity,False
+10026726,North Wiltshire Citizens Advice Bureau,,3 Avon Reach,,,Chippenham,,England                       ,SN15 1EE,Central Government,,False
+10026694,Scottish National Party,,Gordon Lamb House,3 Jacksons Entry,,Edinburgh,,Scotland                      ,XXXX,Wider Public Sector,,False
+10026681,National Housing and Planning Advice Unit,,National Housing and Planning Advice Unit,CB04 Ground Floor,Segensworth Road,Fareham,Hampshire                     ,England                       ,PO15 5RR,Central Government,,False
+10026606,Sports Coach UK,,114 Cardigan Road,Leeds,West Yorkshire,Leeds,West Yorkshire,England,LS6 3BJ,Wider Public Sector,TBA,False
+10026562,County Durham and Darlington Fire Rescue Service,,Fire Station,4 St. Cuthberts Way,,Darlington,,England                       ,DL1 5LN,Wider Public Sector,Fire and Rescue Services,False
+10026547,BATUS,,10-12 Pall Mall,,,Liverpool,Lancashire                    ,England                       ,L3 6AL,Central Government,,False
+10026503,Green Wrythe Primary School,,Green Wrythe Lane,Carshalton,Surrey,Carshalton,Surrey,England,SM5 1JP,Wider Public Sector,Local Authority Maintained School (All Types),False
+10026283,City Challenge,,Century Buildings,Great Smith Street,Westminster,London,,England                       ,FW1P 3BT,Wider Public Sector,,False
+10026057,Cornwall Council,,County Hall,Truro,Cornwall,Truro,Cornwall,England,TR1 3AY,Wider Public Sector,Region:South West,False
+10026038,Andover Citizens Advice Bureau,,Wessex Chambers,South Street,,Andover,Hampshire                     ,England                       ,SP10 2BN,Wider Public Sector,Charity,False
+10025914,Sheffield Health and Social Care NHS Foundation Trust,,Fulwood House Old Fulwood Road,Sheffield,South Yorkshire,Sheffield,South Yorkshire,England,S10 3TH,Wider Public Sector,Care Trust,False
+10025855,West Buckland School,,West Buckland,South Molton,Devon,South Molton,Devon,England,EX32 OSX,Wider Public Sector,Local Authority Maintained School (All Types),False
+10025837,School of Pharmacy The,,29-39 Brunswick Square,,,London,,England                       ,WC1N 1AX,Wider Public Sector,,False
+10025783,Government Offices For The English Regions,,4th Floor,Eland House,Bressenden Place,London,,England                       ,SW1E 5DU,Central Government,NDPB,False
+10025745,North Wales NHS Trust,,Ysbyty Alltwen Hospital,,,Tremadog,Gwynedd                       ,Wales                         ,LL49 9RN,Wider Public Sector,Health,False
+10025692,Harlow Renaissance,,Unit 5 Mitre Buildings Kitson Way,Harlow,Essex,Harlow,Essex,England,CM20 1DR,Wider Public Sector,,False
+10025628,Citizens Advice Bureau,,120 - 126 Old Hall,Wellgate,,Rotherham,,England                       ,S60 2LN,Wider Public Sector,Charity,False
+10025543,Greenwood Dale Specialist School,GDSS,Sneinton Boulevard,,,Nottingham,Nottinghamshire               ,England                       ,NG2 4GL,Wider Public Sector,Specialist Schools,False
+10025497,Penicuik Citizens Advice Bureau,,14a John Street,,,Penicuik,Mid Lothian                   ,Scotland                      ,EH26 8AB,Wider Public Sector,Charity,False
+10025468,Directgov,,Hercules House,Hercules Road,,London,,England                       ,SE1 7DU,Central Government,,False
+10025452,Berwickshire Citizens Advice Service,,Southfield Community Centre,Station Road,,l,,England                       ,TD11 3EL,Wider Public Sector,Charity,False
+10025450,Falkirk Citizens Advice Bureau,,27-29 Vicar Street,,,Falkirk,Falkirk                       ,Scotland                      ,FK1 1LL,Wider Public Sector,Charity,False
+10025409,(DE&S) - FCMT,,Spur 12 Block D Foxhill,Bath,Somerset,Bath,Somerset,England,BA2 5BZ,Central Government,MoD - DE&S,False
+10025351,Dudley PCT,CBSA,St. Johns House,Union Street,,Dudley,West Midlands                 ,England                       ,DY2 8PP,Wider Public Sector,Support,False
+10025327,Atwood Primary School,,Limpsfield Road,Sanderstead,,South Croydon,Surrey                        ,England                       ,CR2 9EE,Wider Public Sector,Primary Schools,False
+10025322,National Probation Service West Yorkshire,,Cliff Hill House,Sandy Walk,,Wakefield,West Yorkshire                ,England                       ,WF1 2DJ,Central Government,,False
+10025317,Hillcrest School,,Stonehouse Lane,,,Birmingham,,England                       ,B32 3AE,Wider Public Sector,School Other,False
+10025311,States of jersey Chief Ministers Department,,PO Box 140,Cyril Le Marquand House,The Parade,St Helier,Jersey                        ,Channel Islands               ,JE4 8QT,Wider Public Sector,,False
+10025284,DSDA (E) Dulmen,,SBS DAS Section,Building 6,Tuzostr. 1,Tuzostr. 1,,England                       ,48249 Dulmen,Central Government,Army,False
+10025279,Personal Accounts Delivery Authority,,St. Dunstans House,201-211 Borough High Street,,London,,England                       ,SE1 1GZ,Central Government,NDPB,False
+10025274,Elliott Durham Community School,,Ransom Drive,,Mapperley,Nottingham,Nottinghamshire               ,England                       ,NG3 5LR,Wider Public Sector,Secondary Schools,False
+10025199,Buckholme Towers School,,"18 Commercial Road,",,,Poole,Dorset                        ,England                       ,BH14 0JW,Wider Public Sector,School Other,False
+10025187,Learning and Skills Network,LSN,120 Holborn,,,London,,England                       ,EC1N 2AD,Wider Public Sector,,False
+10025178,Improvement Foundation,,Gateway House,Piccadilly South,,Manchester,Greater Manchester            ,England                       ,M60 7LP,Wider Public Sector,Private Sector Enabler,False
+10025143,Citizens Advice North Region,,Suite 193,India Building,Water Street,Liverpool,Merseyside                    ,England                       ,L2 0XQ,Wider Public Sector,Charity,False
+10025130,Consumer Focus,,4th Floor Artillery House Artillery Row,London,Greater London,London,Greater London,England,SW1P 1RT,Central Government,NDPB,False
+10024959,Children's Hospice South West,,North Devon Head Office,Redlands Road,,Barnstaple,Devon                         ,England                       ,EX31 2PZ,Wider Public Sector,GP Practice,False
+10024931,Beckett Primary School,,Monk Street,Derby,Derbyshire,Derby,Derbyshire,England,DE22 3FS,Wider Public Sector,Local Authority Maintained School (All Types),False
+10024830,East of England Regional Assembly,EERA,Flempton House,Bury Road,Flempton,Bury St. Edmunds,Suffolk                       ,England                       ,IP28 6EG,Wider Public Sector,,False
+10024820,Wandle Housing Association,,15 Abbeville Road,,,London,,England                       ,SW4 9LA,Wider Public Sector,,False
+10024800,Citizens Advice Bureau Inverness,,103 Academy Street,,,Inverness,Highland                      ,Scotland                      ,IV1 1LX,Wider Public Sector,Charity,False
+10024798,Affinity Sutton,,6 More London Place,London,Greater London,London,Greater London,England,SE1 2DA,Wider Public Sector,Housing Associations,False
+10024735,A Smith Consistuency Officer,,Unit 1,Newtec Place,Magdalen Road,Oxford,Oxfordshire                   ,England                       ,OX4 1RE,Wider Public Sector,,False
+10024733,City and County of Swansea,,Civic Centre,Oystermouth Road,,Swansea,,Wales                         ,SA1 3SN,Wider Public Sector,Local Government,False
+10024701,Castle Rushen High School,,Castle Rushen High School,Arbory Road,Castletown,Isle of Man,,England                       ,IM9 1RE,Wider Public Sector,Secondary Schools,False
+10024666,Independent Safeguarding Authority,,Stephenson House,Alderman Best Way,,Darlington,,England                       ,DL1 4WB,Central Government,NDPB,False
+10024661,Shireland Collegiate Academy,,Waterloo Road,,,Smethwick,West Midlands                 ,England                       ,B66 4ND,Wider Public Sector,Academy (All Types),False
+10024636,University of Wales Newport,,Lodge Road,Caerleon,,Newport,,Wales                         ,NP18 3QT,Wider Public Sector,Education,False
+10024570,South East Water,,The Lodge,Arlington Reservoir,,Berwick,East Sussex                   ,England                       ,BN26 6TF,Wider Public Sector,Water,False
+10024416,Defence Electronic & Component Agency (Formerly Known as Defence Support Group),,Building 203 Monxton Road,Andover,Hampshire,Andover,Hampshire,England,SP11 8HT,Central Government,Executive Agency,False
+10024387,Renaissance Southend,,19 Clifftown Road,,,Southend on Sea,Essex                         ,England                       ,SS1 1AB,Wider Public Sector,,False
+10024329,NPS Property Consultants Limited,,16 Central Avenue St. Andrews Business Park,Norwich,Norfolk,Norwich,Norfolk,England,NR7 0HR,Wider Public Sector,TBA,False
+10024279,UK Commission for Employment and Skills,,"Unit 3 Callflex Business Park Golden Smithies Lane, Wath-upon-Dearne",Rotherham,South Yorkshire,Rotherham,South Yorkshire,England,S63 7ER,Central Government,TBA,False
+10024265,Sir Oswald Stoll Foundation,,446 Fulham Road,,,London,,England                       ,SW6 1DS,Wider Public Sector,,False
+10024262,CCS Lambeth Council,,Children's community services,Upper Tulse Hill,132A Valens House,London,,England                       ,SW2 2RX,Wider Public Sector,,False
+10024253,Jersey Airport,,The Stores,,,St Peter,Jersey                        ,Channel Islands               ,JE1 1BY,Wider Public Sector,,False
+10024250,Abbeyfield Amersham and Chesham Society Limited The,,Pratt House,Quill Hall Lane,,Amersham,Buckinghamshire               ,England                       ,HP6 6LU,Wider Public Sector,Housing Associations,False
+10024243,St Georges Prepartory School,,La Magre Manor,La Rue de la Hague,,St Peter,Guernsey                      ,Channel Islands               ,JE3 7DB,Wider Public Sector,School Other,False
+10024166,Surrey and Sussex Strategic Health Authority,,Q19 Payables 4075 Phoenix House,Topcliffe Lane,Tingley,Wakefield,West Yorkshire                ,England                       ,WF3 1WE,Wider Public Sector,Acute Trust,False
+10024041,Highlands Council,,3 Ardross Terrace,,,Inverness,Highland                      ,Scotland                      ,IV3 5NQ,Wider Public Sector,Local Government,False
+10024018,FareShare,,Unit H04 Block H Tower Bridge Business Complex 100 Clements Rd,London,Greater London,London,Greater London,England,SE16 4DG,Wider Public Sector,Charity,False
+10023822,Joint Nature Conservation Committee,,Monkstone House City Road,Peterborough,Cambridgeshire,Peterborough,Cambridgeshire,England,PE1 1JY,Central Government,NDPB,False
+10023651,UCE Birmingham,,Technology Innovation Centre,Millennium Point,Curzon Street,Birmingham,,England                       ,B4 7XG,Wider Public Sector,,False
+10023650,Local Better Regulation Office,,4th Floor 5 St. Philips Place,Birmingham,West Midlands,Birmingham,West Midlands,England,B3 2PW,Central Government,TBA,False
+10023609,Teachers TV,,c/o Secretariat,Caxton House,6-12 Tothill Street,London,,England                       ,SW1H 9NA,Central Government,NDPB,False
+10023604,Teenage Pregnancy Independent Advisory Group The,,C/O Teenage Pregnancy Unit,Caxton House,6-12 Tothill Street,London,,England                       ,SW1H 9NA,Central Government,,False
+10023599,Diplomatic Service Appeal Board,DSAB,Old Admiralty Building,Whitehall,,London,,England                       ,SW1A 2PA,Central Government,,False
+10023385,Citizens Advice Bureau Esher,,Harry Fletcher House,High Street,,Esher,Surrey                        ,England                       ,KT10 9RN,Wider Public Sector,Charity,False
+10023361,South West Water,,Peninsula House,Rydon Lane,,Exeter,Devon                         ,England                       ,EX2 7HR,Wider Public Sector,,False
+10023293,RAF Stanbridge,,Stanbridge Road,Leighton Buzzard,Bedfordshire,Leighton Buzzard,Bedfordshire,England,LU7 4QT,Central Government,MoD - RAF,False
+10023263,NHS Yorkshire and the Humber Commercial Procurement Collaborative,NHS YHCPC,Don Valley House,Savile Street East,,Sheffield,South Yorkshire               ,England                       ,S4 7UQ,Wider Public Sector,Support,False
+10023220,Defra Investigation Services,,Block 5,Government Buildings,,Bristol,Somerset                      ,England                       ,BS10 6NJ,Central Government,,False
+10023132,Financial Supervision Commission,,Finch Hill House,Bucks Road,,Douglas Isle of Man,,England                       ,IM99 1DT,Wider Public Sector,,False
+10023080,Department for Innovation Universities and Skills,DIUS,Sanctuary Buildings,Great Smith Street,,London,,England                       ,SW1P 3BT,Central Government,,False
+10023053,Helepayne Gardens,,East Wing,Trustford House,Harberton,Totnes,Devon                         ,England                       ,TQ9 7RZ,Wider Public Sector,,False
+10022992,Jersey College for Girls,,Le Mont Millais,,St Saviour,Chanel Islands,,England                       ,JE2 7YB,Wider Public Sector,,False
+10022851,Scottish Police Services Authority Glasgow,SPSA,P O box 26895,,,Glasgow,,Scotland                      ,G2 9BY,Wider Public Sector,,False
+10022817,Merton Chamber of Commerce Limited,,2nd Floor,Tuition House,27-37 St Georges Road,Wimbledon,,England                       ,SW19 4EU,Wider Public Sector,,False
+10022635,Grainville School,,St Saviour Road,St Saviour,,Jersey,,"Jersey, C.I.                  ",JE2 7XB,Wider Public Sector,School Other,False
+10022608,Queen Elizabeth II High School,,Douglas Road,,,Peel,,Isle of Man                   ,IM5 1RD,Wider Public Sector,Education,False
+10022580,NHS London LPP,,180 Strand,,,London,,England                       ,WC2R 1BL,Wider Public Sector,,False
+10022560,GMB,,369 Burnt Oak Broadway,,,Edgeware,,England                       ,HA8 5AW,Wider Public Sector,Private Sector Enabler,False
+10022492,Ramsey Spinning Infant School,,High Street Ramsey,HUNTINGDON,Cambridgeshire,HUNTINGDON,Cambridgeshire,England,PE26 1AE,Wider Public Sector,Local Authority Maintained School (All Types),False
+10022242,University of the West of England Bristol,,UWE,640 Bristol Business Park,Bristol,Somerset,,England                       ,BS16 1EJ,Wider Public Sector,Universities,False
+10022228,Sandwell Primary Care Trust,,Kingston House,438-450 High Street ,,West Bromwich ,,England                       ,B70 9LD,Wider Public Sector,PCT - Commissioning,False
+10022223,NHS North Staffordshire Primary Care Trust,,Bradwell Hospital,Talke Road,Chesterton,Newcastle,,England                       ,ST5 7NJ,Wider Public Sector,PCT - Commissioning,False
+10022220,NHS Manchester ,,Gateway House,Piccadilly South,,Manchester ,,England                       ,M60 7LP,Wider Public Sector,PCT - Commissioning,False
+10022219,Liverpool Primary Care Trust,,1 Arthouse Square ,67-69 Seel Street,,Liverpool ,,England                       ,L1 4AZ,Wider Public Sector,PCT - Commissioning,False
+10022216,NHS Kirklees,,St. Lukes House Blackmoorfoot Road Crossland Moor,Huddersfield,,Huddersfield,,England,HD4 5RH,Wider Public Sector,PCT - Commissioning,False
+10022208,East Sussex Downs and Weald PCT,,36-38 Friars Walk,,,Lewes,,England                       ,BN7 2PB,Wider Public Sector,PCT - Commissioning,False
+10022200,Bradford and Airedale Teaching Primary Care Trust,BDCT,Douglas Mill,Bowling Old Lane,,Bradford,,England                       ,BD5 7JR,Wider Public Sector,PCT - Commissioning,False
+10022194,Government Office for the East,,Eastbrook - 2nd Floor,Shaftesbury Road,,Cambridge,,England                       ,CB2 8DF,Central Government,,False
+10022012,Walsall Academy,,Lichfield Road,Walsall,West Midlands,Walsall,West Midlands,England,WS3 3LX,Wider Public Sector,Academy (All Types),False
+10021972,Paragon Housing Association Limited,,Invergrange House Station Road,Grangemouth,Stirlingshire,Grangemouth,Stirlingshire,Scotland,FK3 8DG,Wider Public Sector,Housing Associations,False
+10021948,Leicester Housing Association,,19 DeMontfort Street,,,Leicester,Leicestershire                ,England                       ,LE1 7GE,Wider Public Sector,Housing Associations,False
+10021888,Skillsmart Retail Limited,,40 Duke Street,London,Greater London,London,Greater London,England,W1A 1AB,Wider Public Sector,,False
+10021887,(closed) Skillset,,Prospect House 80-110 New Oxford Street,London,Greater London,London,Greater London,England,WC1A 1HB,Wider Public Sector,,False
+10021882,Skillfast UK Limited,,Richmond House Lawnswood Business Park Redvers Close,Leeds,West Yorkshire,Leeds,West Yorkshire,England,LS16 6RD,Wider Public Sector,,False
+10021881,Scottish Social Services Council,,c/o Care Commission HQ Compass House 11 Riverside Drive,Dundee,Angus,Dundee,Angus,Scotland,DD1 4NY,Wider Public Sector,TBA,False
+10021846,National Biological Standards Board UK,,Blanche Lane,South Mimms,,POTTERS BAR,Hertfordshire                 ,England                       ,EN6 3QG,Wider Public Sector,,False
+10021842,Ministry of Defence Police,,Weathersfield,,,BRAINTREE,,England                       ,CM7 4AZ,Central Government,,False
+10021840,Metal Industry Skills and Performance Ltd,,5 & 6 Meadowcourt Amos Road,Sheffield,South Yorkshire,Sheffield,South Yorkshire,England,S9 1BX,Wider Public Sector,Other Education,False
+10021832,Healthcare Commission,,Finsbury Tower,103-105 Bunhill Row,,LONDON,,England                       ,EC1Y 8TG,Central Government,NDPB,False
+10021804,Commission for Rural Communities,,John Dower House,Crescent Place,,CHELTENHAM,,England                       ,GL50 3RA,Central Government,,False
+10021803,COI Communications,,Hercules House,Hercules Road,,LONDON,,England                       ,SE1 7DU,Central Government,,False
+10021694,Fareham Citizens Advice Bureau,,Fareham Citizens Advice Bureau,Library Building,Osborn Road,Fareham,Hampshire                     ,England                       ,PO16 7EN,Wider Public Sector,Charity,False
+10021670,Victoria Community Technical School,,West Street,,,Crewe,Cheshire                      ,England                       ,SW1 2PZ,Wider Public Sector,School Other,False
+10021557,Kingston and District NHS,,50 Braemar Road,,,Middlesex,,England                       ,TW8 ONS,Wider Public Sector,Acute Trust,False
+10021553,Cheshire and Merseyside Health Authority,,Quayside,,Wilderspool Park,Warrington,Cheshire                      ,England                       ,WA4 6HL,Wider Public Sector,GP Practice,False
+10021550,Prospect Medical Practice,,Cantley Farm Cantley Lane,Norwich,Norfolk,Norwich,Norfolk,England,NR4 6TF,Wider Public Sector,GP Practice,False
+10021326,Churchill Community College,,Churchill Street,Wallsend,Tyne and Wear,Wallsend,Tyne and Wear,England,NE28 7TN,Wider Public Sector,Local Authority Maintained School (All Types),False
+10021286,CITIZENS ADVICE SHROPSHIRE,,CITIZENS ADVICE SHROPSHIRE,ROY FLETCHER CENTRE,12-17 CROSS HILL,SHREWSBURY,,England                       ,SY1 1JE,Wider Public Sector,Charity,False
+10021273,Labour Party The,,Eldon House,Regent Centre,,Gosforth,Tyne and Wear                 ,England                       ,NE3 3PW,Central Government,,False
+10021240,Centre for Ecology and Hydrology,,Lancaster Environment Centre Library Avenue Bailrigg,Lancaster,Lancashire,Lancaster,Lancashire,England,LA1 4AP,Central Government,TBA,False
+10021174,Homestead School,,School Lane,,Langham,Colchester,Essex                         ,England                       ,CO4 5PA,Wider Public Sector,School Other,False
+10021129,Memorial University of Newfoundland,,The Maltings,St Johns Walk,,Harlow,Essex                         ,England                       ,CM17 OAJ,Wider Public Sector,,False
+10021126,Burnley District Citizens Advice Service,,144-148 St James Street,,,Burnley,,England                       ,BB11 1NR,Wider Public Sector,Charity,False
+10020986,A2 Housing Group,,A2 Housing Group Spelthorne House Thames Street,Staines,Middlesex,Staines,Middlesex,England,TW18 4TA,Wider Public Sector,Housing Associations,False
+10020985,New Zealand High Commission,,New Zealand High Commission,New Zealand House,80 Haymarket,London,,England                       ,SW1Y 4TQ,Central Government,,False
+10020981,Chesterfield Citizens Advice Bureau,,6-8 Broad Pavement,,,Chesterfield,,England                       ,S40 1RP,Wider Public Sector,Charity,False
+10020809,Chartered Institute of Management Accountants,CIMA,26 Chapter Street,,,London,,England                       ,SW1P 4NP,Wider Public Sector,Charity,False
+10020763,Citizens Advice Bureau Lincoln,,Beaumont Lodge,Beaumont Fee,,Lincoln,Lincolnshire                  ,England                       ,LN1 1UL,Wider Public Sector,Charity,False
+10020653,University of Oxford,,ICT Support Team Osney One Building Osney Mead,Oxford,Oxfordshire,Oxford,Oxfordshire,England,OX2 OEW,Wider Public Sector,Universities,False
+10020617,Ashford Civic Centre,,Tannery Lane,,,Ashford,Kent                          ,England                       ,TN23 1PL,Wider Public Sector,,False
+10020568,Victoria College,,Mont Millais,St Helier,,Jersey,,England                       ,JE1 4HT,Wider Public Sector,Colleges other,False
+10020473,Hertfordshire Primary Care Trust,,Parkway,,,Welwyn Garden City,Hertfordshire                 ,England                       ,AL8 6JL,Wider Public Sector,Support,False
+10020452,Confidential Enquiry Into Maternal and Child Health,,Chiltern Court,188 Baker Street,,London,,England                       ,NW1 5SD,Wider Public Sector,Support,False
+10020428,Bristol Water Plc,,Bridgewater Road,,,Bristol,Avon                          ,England                       ,BS99 7AU,Wider Public Sector,,False
+10020425,Bournemouth and West Hants Water,,George Jessell House,Francis Avenue,,Bournemouth,Dorset                        ,England                       ,BH11 8NB,Wider Public Sector,,False
+10020378,United Utilities,,"Thirlmere House, Lingley Mere",Lingley Green Avenue,Great Sankey,WARRINGTON,Cheshire                      ,England                       ,WA5 3LP,Wider Public Sector,,False
+10020278,Stranton Primary School,,Southburn Terrace,,,Hartlepool,Cleveland                     ,England                       ,TS25 1SQ,Wider Public Sector,Primary Schools,False
+10020275,King Williams College,,King Williams College Grounds,,,Cstletown,Isle of Man                   ,England                       ,IM9 1TP,Wider Public Sector,Colleges other,False
+10020222,Solent Middle School,,Baring Road,,,Cowes,Isle of Wight                 ,England                       ,PO31 8DS,Wider Public Sector,Secondary Schools,False
+10020181,RAF News,,"Room S91, Building 255",HQ PTC,RAF Innsworth,Gloucester,,England                       ,GL3 1EZ,Central Government,,False
+10020174,Peterborough Citizens Advice Bureau,,41a Park Road,,,Peterborough,Cambridgeshire                ,England                       ,PE1 2TH,Wider Public Sector,Charity,False
+10020152,Abingdon College,,Wootton Road,,,Abingdon,,England                       ,OX14 1GG,Wider Public Sector,Colleges other,False
+10020085,Northumbrian Water,,Abbey Road,,,Durham,County Durham                 ,England                       ,DH1 5FJ,Wider Public Sector,,False
+10020071,Little Sisters of The Poor,,Jeanne Jugan Residence,New St Johns Road,,St Helier,,Channel Islands               ,JE2 4XZ,Wider Public Sector,,False
+10020058,Loughton and District Citizens Advice Bureau,,St Mary's Parish Centre,,,Loughton,,England                       ,IG10 1BB,Wider Public Sector,Charity,False
+10020055,Firebuy,,St. David's House,70 Wray Park Road,,Reigate,Surrey                        ,England                       ,RH2 0EJ,Wider Public Sector,,False
+10020011,National Employment Panel,NEP,Level 5A,Caxton House,6-12 Tothill Street,London,,England                       ,SW1H 9NA,Central Government,NDPB,False
+10019992,London Development Agency,LDA,Devon House,58-60 St Katharine's Way,,London,,England                       ,E1W 1JX,Central Government,NDPB,False
+10019990,Hearing Aid Council,HAC,70 St Mary Axe,,,London,,England                       ,EC3A 8BD,Central Government,NDPB,False
+10019970,CENTREX,,Bramshill,,,Hook,Hampshire                     ,England                       ,RG27 0JW,Central Government,NDPB,False
+10019945,Food From Britain,FFB,4th Floor,Manning House,22 Carlisle Place,London,,England                       ,SW1P 1JA,Central Government,NDPB,False
+10019942,Animal Health,SVS,C11 Government Buildings,Whittington Road,,Worcester,Worcestershire                ,England                       ,WR5 2LQ,Central Government,Executive Agency,False
+10019935,Inland Waterways Advisory Council,,City Road Lock 38 Graham Street,London,Greater London,London,Greater London,England,N1 8JX,Central Government,NDPB,False
+10019933,Committee on the Medical Effects of Air Pollutants,COMEAP,Health Protection Agency,"Centre for Radiation, Chemicals and Environmental Hazards",Chilton,Oxon,,England                       ,OX11 0RQ,Central Government,NDPB,False
+10019909,Farnham Heath End School,,Hale Reeds,Farnham,Surrey,Farnham,Surrey,England,GU9 9BN,Wider Public Sector,Academy (All Types),False
+10019869,UNISON Malvern Hills,,8 Alton Road,,,Worcester,Worcestershire                ,England                       ,WR5 3RL,Wider Public Sector,,False
+10019868,(Closed) Office of HM Paymaster General,,Room 3/30 1 Horse Guards Road,London,Greater London,London,Greater London,England,SW1A 2HQ,Central Government,TBA,False
+10019800,Main Street Surgery,,Main Street,,,Leiston,,England                       ,IP16 4ES,Wider Public Sector,,False
+10019770,St Davids School,,Church Road,,,Ashford,Middlesex                     ,England                       ,TW15 3DZ,Wider Public Sector,School Other,False
+10019638,Office for Civil Nuclear Security,,Building 418.15,Harwell International Business Centre,,Didcot,Oxfordshire                   ,England                       ,OX11 0QA,Central Government,,False
+10019516,National Association of Citizens Advice Bureau Newcastle upon Tyne,,Portland House,New Bridge Street West,,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE1 8AN,Wider Public Sector,Charity,False
+10019483,St Teilos CIW High School,,Llanedeyrn Road,Pen-y-lan,,Pen-y-lan,,Wales,CF23 9DT,Wider Public Sector,Education,False
+10019349,Kings Norton Boys School,,Northfield Road Kings Norton,Birmingham,West Midlands,Birmingham,West Midlands,England,B30 1DY,Wider Public Sector,Local Authority Maintained School (All Types),False
+10019347,St Peters High School,,Stroud Road,,,Tuffley,Gloucestershire               ,England                       ,GL4 0DE,Wider Public Sector,Academy (All Types),False
+10019307,Capacitybuilders,,77 Paradise Circus Queensferry,,,Birmingham,West Midlands                 ,England                       ,SW1A 2AS,Central Government,,False
+10019300,Newbridge School,,258 Barley Lane  Goodmayes,Ilford,Essex,Ilford,Essex,England,IG3 8XS,Wider Public Sector,Local Authority Maintained School (All Types),False
+10019291,Newham University Hospitals NHS Trust,,Glen Road,,Plaistow,London,,England                       ,E13 8SL,Wider Public Sector,Acute Trust,False
+10019163,Pinehurst Infants School,,Beech Avenue,,,Swindon,Wiltshire                     ,England                       ,SN2 1JT,Wider Public Sector,State Infant Schools,False
+10019084,Victim Support West Midlands,,Select House,Popes Lane,,Oldbury,West Midlands                 ,England                       ,B69 4PA,Wider Public Sector,Charity,False
+10019064,RSA Academy,,Bilston Road,Tipton,West Midlands,Tipton,West Midlands,England,DY4 0BZ,Wider Public Sector,Academy (All Types),False
+10019028,Citizens Advice Stockton,,Stockton Information & Advice Centre,Bath Lane,,Stockton-on-Tees,Cleveland                     ,England                       ,TS18 2DS,Wider Public Sector,Charity,False
+10018963,Government Decontamination Service,,"D, 3-8 Whitehall Place",,,London,,England                       ,SW1A 2HH,Central Government,,False
+10018934,London Centre of Excellence,,Association of London Government,59 Southwark Street,,London,,England                       ,SE1 0AL,Wider Public Sector,,False
+10018850,Business Link Surrey,,Hollywood House Church Street East,Woking,Surrey,Woking,Surrey,England,GU21 6HJ,Central Government,TBA,False
+10018701,South West Trains,,Wimbledon Traincare,Durnsford Road,,Wimbledon,,England                       ,SW19 8EG,Wider Public Sector,Transport,False
+10018609,Wessex Trains Limited,,Hertford House,1 Cranwood Street,,London,,England                       ,EV1V 9QS,Wider Public Sector,Transport,False
+10018599,Human Tissue Authority,,Finlaison House,15-17 Furnival Street,,London,,England                       ,EC4A 1AB,Central Government,Central Bodies,False
+10018555,Thames Water Utilities,,Reading Bridge,,,Reading,Berkshire                     ,England                       ,RG1 8PR,Wider Public Sector,,False
+10018529,Severn Trent Water,,Aseriti Unit 2800,The Crescent,Birmingham Business Park,Birmingham,West Midlands                 ,England                       ,B37 7YL,Wider Public Sector,,False
+10018378,Data Protection Act,,Address 1,Town/City,,Town/City,,England,XXXX,Wider Public Sector,TBA,False
+10018286,Royal Opera House Foundation,,Royal Opera House,Covent Garden,,London,,England                       ,WC2E 9DD,Wider Public Sector,Charity,False
+10018280,Royal Masonic Benevolent Institution,,20 Great Queen Street,London,Greater London,London,Greater London,England,WC2B 5BG,Wider Public Sector,Charity,False
+10018140,Donkey Sanctuary,,Slade House Farm,Sidmouth,Devon,Sidmouth,Devon,England,EX10 0NU,Wider Public Sector,Charity,False
+10017979,National Treatment Agency For Substance Misuse,NTA,Skipton House 6th Floor,80 London Road,,London,,England                       ,SE1 6LH,Central Government,Support,False
+10017931,Jersey Fire and Rescue Service,,Fire Service Headquarters,PO Box 509,Rouge Bouillon,St Helier,,England                       ,JE2 3ZA,Wider Public Sector,Fire and Rescue Services,False
+10017930,Isle of Man Fire and Rescue Service,,Fire Service Headquarters,Elm Tree House,Elm Tree Road,Onchan,Isle of Man                   ,England                       ,IM3 4EF,Wider Public Sector,Fire and Rescue Services,False
+10017682,Abbeyfield East London Extra Care Society Limited The,,George Brooker House 100 Dagenham Avenue,Dagenham,Essex,Dagenham,Essex,England,RM9 6LH,Wider Public Sector,Housing Associations,False
+10017264,Longhurst Housing Association Limited,,Friars House,Quaker Lane,,Boston,Lincolnshire                  ,England                       ,PE21 6DZ,Wider Public Sector,Housing Associations,False
+10016882,First Wessex,,Gordon House Gordon Road,Aldershot,Hampshire,Aldershot,Hampshire,England,GU11 1LD,Wider Public Sector,Housing Associations,False
+10016570,Papworth Trust The,,Head Office Papworth Everard,Cambridge,Cambridgeshire,Cambridge,Cambridgeshire,England,CB3 8RG,Wider Public Sector,Housing Associations,False
+10016536,ASRA Greater London Housing Association Limited,,Asra House,No 1 Long Lane,,London,,England                       ,SE1 4PG,Wider Public Sector,Housing Associations,False
+10016331,Central Manchester Primary Care Trust (NHS Manchester ),,Mauldeth House,Mauldeth Road West,Chorlton Cum Hardy,Manchester,Greater Manchester            ,England                       ,M21 7RL,Wider Public Sector,PCT - Commissioning,False
+10016329,Central Eastern Cheshire PCT Crewe Health Management,,Trust Headquarters,Barony Road,,Nantwich,Cheshire                      ,England                       ,CW5 5QU,Wider Public Sector,PCT - Commissioning,False
+10016313,South Staffordshire Primary Care Trust,,Mellor House,Corporation Street,,Stafford,Staffordshire                 ,England                       ,ST16 3SR,Wider Public Sector,PCT - Commissioning,False
+10016299,Lewisham and Greenwich Healthcare NHS Trust,,University Hospital Lewisham High Street Lewisham,London,Greater London,London,Greater London,England,SE13 6LH,Wider Public Sector,PCT - Commissioning,False
+10016292,NHS Birmingham East and North,,Suite 20,Waterlinks House,Richard Street,Birmingham,West Midlands                 ,England                       ,B7 4AA,Wider Public Sector,PCT - Commissioning,False
+10016274,Victim Support Croydon,,250 Brighton Road,,,South Croydon,Surrey                        ,England                       ,CR2 6AH,Wider Public Sector,Charity,False
+10016239,St Ninians High School,,St Ninians,,,Douglas,Isle of Man                   ,England                       ,IM2 5RA,Wider Public Sector,Secondary Schools,False
+10016229,UNISON,,1 Mableton Place,,,London,,England                       ,WC1H 9AJ,Wider Public Sector,,False
+10016226,NHS North of Tyne Newcastle Primary Care Trust,,Benfield Road,,,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE6 4PF,Wider Public Sector,PCT - Commissioning,False
+10016203,Gateshead Primary Care Trust,,5th Avenue Business Park,Team Valley Trading Estate,,Gateshead,Tyne and Wear                 ,England                       ,NE11 0NB,Wider Public Sector,PCT - Commissioning,False
+10016162,Calderdale PCT,,School House,56 Hopwood Lane,,Halifax,West Yorkshire                ,England                       ,HX1 5ER,Wider Public Sector,PCT - Commissioning,False
+10016153,Barnet PCT,,Hyde House,The Hyde,,London,,England                       ,NW9 6QQ,Wider Public Sector,PCT - Commissioning,False
+10016147,Manchester Mental Health and Social Care Trust,,Chorlton House 70 Manchester Road Chorlton Cum Hardy,Manchester,Greater Manchester,Manchester,Greater Manchester,England,M21 9UN,Wider Public Sector,Mental Health Trust,False
+10016102,Birmingham Womens NHS Foundation Trust,,Birmingham Womens Hospital Metchley Park Road,Birmingham,West Midlands,Birmingham,West Midlands,England,B15 2TG,Wider Public Sector,Acute Trust,False
+10016062,NHS Sefton,,Burlington House,Crosby Road North,,Liverpool,Merseyside                    ,England                       ,L22 0QB,Wider Public Sector,PCT - Commissioning,False
+10016060,South Manchester Primary Care Trust (NHS Manchester ),,Withington Hospital,Nell Lane,,Manchester,Greater Manchester            ,England                       ,M20 2LR,Wider Public Sector,PCT - Commissioning,False
+10016044,Rotherham Primary Care Trust,,Bevan House,Oakwood Hall Drive,,Rotherham,South Yorkshire               ,England                       ,S60 3AQ,Wider Public Sector,PCT - Commissioning,False
+10016033,North Manchester Primary Care Trust (NHS Manchester ),,"2nd Floor, Newton Silk Mill",Holyoak Street,Newton Heath,Manchester,Greater Manchester            ,England                       ,M40 1HA,Wider Public Sector,PCT - Commissioning,False
+10016019,Rosemary Nelson Inquiry (Closed),,PO Box 50157,London,,London,,England,SW1E 6WW,Central Government,TBA,False
+10016018,Defence Training Review Rationalisation IPT,,"Ministry of Defence: 7-A-18, Main Building",Horse Guards Avenue,Whitehall,London,,England                       ,SW1A 2HB,Central Government,,False
+10015967,Pensions Commission,,"4th floor, Adelphi",1-11 John Adam Street,,London,,England                       ,WC2N 6HT,Central Government,,False
+10015965,Office Of The Leader Of The House Of Commons And Lord Privy Seal,,26 Whitehall,,,London,,England                       ,SW1A 2WH,Central Government,,False
+10015960,Womens National Commission,,1 Victoria Street,,,London,,England                       ,SW1H 0ET,Wider Public Sector,NDPB,False
+10015959,Women and Equality Unit,,35 Great Smith Street,,,London,,England                       ,SW1P 3BQ,Wider Public Sector,,False
+10015957,Government Communications Network,,67 Tufton Street,,,London,,England                       ,SW1P 3QS,Central Government,,False
+10015950,Visas UK,,,London,Greater London,London,Greater London,England,XXXX,Central Government,TBA,False
+10015940,British National Space Centre,BNSC,151 Buckingham Palace Road,,,London,,England                       ,SW1W 9SS,Central Government,,False
+10015936,Boundary Commission for England,,1 Drummond Gate,,,London,,England                       ,SW1V 2QQ,Central Government,NDPB,False
+10015935,(Closed) Benefit Fraud Inspectorate,,"BFI Customer Liaison 2nd Floor, Berkeley House 12a North Park Road",Harrogate,North Yorkshire,Harrogate,North Yorkshire,England,HG1 5QA,Central Government,TBA,False
+10015898,Alfred Barrow School The,,Duke Street,,,Barrow-in-Furness,Cumbria                       ,England                       ,LA14 2LB,Wider Public Sector,Secondary Schools,False
+10015890,Heart of Birmingham Teaching Primary Care Trust,,Bartholomew House,142 Hagley Road,Edgbaston,Birmingham,West Midlands                 ,England                       ,B16 9PA,Wider Public Sector,PCT - Commissioning,False
+10015855,Scottish and Southern Energy,,55 Vastern Road,,,Reading,Berkshire                     ,England                       ,RG1 8BU,Wider Public Sector,Energy,False
+10015841,Cumbria Police Authority,,Carleton Hall,,,Penrith,Cumbria,England,CA10 2AU,Wider Public Sector,Police Authority,False
+10015650,Park College Eastbourne,,King's Drive,,,Eastbourne,East Sussex                   ,England                       ,BN21 2UN,Wider Public Sector,,False
+10015649,Lews Castle College,,Lews,,,Stornoway,Isle of Lewis                 ,Scotland                      ,HS2 0XR,Wider Public Sector,Education,False
+10015620,Bohunt School,,longmoor Road,Liphook,Hampshire,Liphook,Hampshire,England,GU30 7NY,Wider Public Sector,Academy (All Types),False
+10015606,London Connects,,59 South Bank Street,,,London,,England                       ,SE1 OAL,Wider Public Sector,,False
+10015552,Groundwork East London,,6 Lower Clapton Road,Hackney,,London,,England                       ,E5 0PD,Wider Public Sector,Charity,False
+10015511,Shropshire Chamber of Commerce,,Trevithick House,Stafford Park 4,,TELFORD,,England                       ,TF3 3BA,Wider Public Sector,Other,False
+10015495,States of Jersey Police,,Police Headquarters,Rouge Bouillon,,St Helier,Jersey                        ,Channel Islands               ,JE2 3ZA,Wider Public Sector,Police Service,False
+10015494,Isle of Man Constabulary,,Police Headquarters,Glencrutchery Road,,DOUGLAS,,Isle of Man                   ,IM2 4RG,Wider Public Sector,Police Service,False
+10015493,Guernsey Police,,Police Headquarters,Hospital Lane,,St Peter Port,Guernsey                      ,Channel Islands               ,GY1 2QN,Wider Public Sector,Police Service,False
+10015490,Douglas Corporation,,Town Hall,Ridgeway Street,,DOUGLAS,,Wales                         ,IM99 1AD,Wider Public Sector,,False
+10015486,Swansea Local Health Board,,Raglan House,Charter Court,Phoenix Way,SWANSEA,,Wales                         ,SA7 9DD,Wider Public Sector,Health,False
+10015480,Newport Local Health Board,,St Cadoc's Hospital,Caerleon,,NEWPORT,,Wales                         ,NP18 3XQ,Wider Public Sector,Health,False
+10015471,Anglesey Local Health Board,,17 High Street,,,LLANGEFNI,,Wales                         ,LL77 7LT,Wider Public Sector,Health,False
+10015433,Isle of Man College,,Homefield Road,,,Douglas,,Isle of Man                   ,IM2 6RB,Wider Public Sector,Education,False
+10015426,Guernsey College of Further Education,,La Route De Coutanchez,,,St Peter Port,Guernsey                      ,Channel Islands               ,GY1 2TT,Wider Public Sector,Education,False
+10015421,Duchy College,,Stoke Climsland,,,CALLINGTON,,England                       ,PL17 8PB,Wider Public Sector,Colleges other,False
+10015417,Dartington College of Arts,,Dartington,,,TOTNES,,England                       ,TQ9 6EJ,Wider Public Sector,,False
+10015404,Beverley College of Further Education,,Gallows Lane,,,Beverley,,England                       ,HU17 7DT,Wider Public Sector,Colleges of Further Education,False
+10015384,General Consumer Council for NI,,Elizabeth House,116 Holywood Road,,BELFAST,,Northern Ireland              ,BT4 1NY,Wider Public Sector,,False
+10015379,Veterans Agency,,Tomlinson House,Norcross,,THORNTON-CLEVELEYS,,England                       ,FY5 3WP,Central Government,,False
+10015376,Radiocommunications Agency,,Wyndham House,189 Marsh Wall,,LONDON,,England                       ,E14 9SX,Central Government,,False
+10015373,National Consumer Council,,20 Grosvenor Gardens,,,London,,England                       ,SW1W 0DH,Central Government,,False
+10015351,Citizens Advice Swindon,,Holbrook House,Station Road,,Swindon,,England                       ,SN1 1HH,Wider Public Sector,Charity,False
+10015334,Devon Partnership Trust,,Rainbow House,Avenue Road,,Torbay,Devon                         ,England                       ,TQ2 5LS,Wider Public Sector,Care Trust,False
+10015323,ITsafe,,6th Floor Stockley House 130 Wilton Road,London,Greater London,London,Greater London,England,SW1V 1LQ,Wider Public Sector,Private Sector Enabler,False
+10015295,New Milton and District Citizens Advice Bureau,,2 Ashley Road,,,New Milton,,England                       ,BH25 6AS,Wider Public Sector,Charity,False
+10015246,.ict Support Service,,Floor 1 Riverside House,Riverside Way,,Northampton,Northamptonshire              ,England                       ,NN1 5NX,Wider Public Sector,,False
+10015227,Eastern Health and Social Services Board,,12-22 Linenhall Street,,,Belfast,County Antrim                 ,Northern Ireland              ,BT2 8BS,Wider Public Sector,Health,False
+10015226,St Peter's School,,Clifton,,,York,North Yorkshire               ,England                       ,Y030 6AB,Wider Public Sector,School Other,False
+10015212,Barnardos North West,,7 Lineside Close,,,Liverpool,Merseyside                    ,England                       ,L25 2UD,Wider Public Sector,Charity,False
+10015201,Isle of Man Department of Education,,St Georges Court,,,Douglas,Isle of Man                   ,England                       ,IM1 2SG,Central Government,,False
+10015129,WaterVoice,,Centre City Tower 7 Hill Street,Birmingham,West Midlands,Birmingham,West Midlands,England,B5  4UA,Central Government,Executive Agency,False
+10015104,Learning and Skills Development Agency,LSDA,Regent Arcade House,19-25 Argyll Street,,London,,England                       ,W1F 7LS,Central Government,,False
+10015045,Computacenter UK,,Customer Focus,Hatfield Business Park,Hatfield Avenue,Hatfield,Hertfordshire                 ,England                       ,AL10 9TW,Wider Public Sector,Private Sector Enabler,False
+10015018,Lifelong Learning UK,,5th Floor,St Andrews House,18-20 St Andrew Street,London,,England                       ,EC4A 3AY,Wider Public Sector,,False
+10014979,Boston University,,43 Harrington Gardens,,,London,,England                       ,SW7 4JU,Wider Public Sector,Universities,False
+10014707,Pinewood School,,Hoe Lane,Ware,Hertfordshire,Ware,Hertfordshire,England,SG12 9PB,Wider Public Sector,Specialist Schools,False
+10014681,Pinehurst Junior School,,Beech Avenue,,,Swindon,Wiltshire                     ,England                       ,SN2 1JR,Wider Public Sector,Primary Schools,False
+10014522,Pallion Primary School,,Waverley Terrace,,,Sunderland,,England                       ,SR4 6TA,Wider Public Sector,Primary Schools,False
+10014445,Childrens Workforce Development Council,CWDC,5 Albion Place,,,Leeds,West Yorkshire                ,England                       ,LS1 6JL,Wider Public Sector,NDPB,False
+10014433,Greater Merseyside Enterprise,,Greater Merseyside enterprise Ltd,Egerton House,2 Tower Road,Birkenhead,Merseyside                    ,England                       ,CH41 1FN,Wider Public Sector,,False
+10014423,Department for Productivity Energy and Industry,,1 Victoria Street,,,London,,England                       ,SW1H OET,Central Government,,False
+10014419,British Nuclear Group,,"BNFL,",St Bees Suite. innovation Centre,Westlakes Science & Technology park,Moor Row,Cumbria                       ,England                       ,CA24 3TP,Wider Public Sector,Magnox Family,False
+10014365,Virgin Trains,,Virgin Trains,SBQ1,29 Smallbrook Queensway,Birmingham,West Midlands                 ,England                       ,B5 4HG,Wider Public Sector,,False
+10014264,Caterham High School,,Caterham High School Caterham Avenue,Ilford,Essex,Ilford,Essex,England,IG5 0QW,Wider Public Sector,Local Authority Maintained School (All Types),False
+10014246,Brunel Design Group,,Brunel Design Group,21-23 East Street,,Fareham,Hampshire                     ,England                       ,PO16 0BZ,Central Government,,False
+10014211,Affinity Homes Group,,37-39 Perrymount Road,,,Haywards Heath,West Sussex                   ,England                       ,RH16 3BN,Wider Public Sector,Charity,False
+10014168,Pennine Care NHS Trust,,Trust Headquarters,225 Old Street,,Ashton-Under-Lyne,,England                       ,OL6 7SR,Wider Public Sector,Mental Health Trust,False
+10014143,Darnhill County Primary School,,15 Sutherland Road,,,Heywood,,England                       ,OL10 3PY,Wider Public Sector,Primary Schools,False
+10014134,NHS South of Tyne South Tyneside Primary Care Trust,,Claronden House,Viking Industrial Estate,Wagonway Road,Hebburn,Tyne and Wear                 ,England                       ,NE31 1SP,Wider Public Sector,PCT - Commissioning,False
+10014132,St Sampson Infant School,,Rue Des Monts,Vale,,Guernsey,Guernsey                      ,Channel Islands               ,GY2 4HS,Wider Public Sector,State Infant Schools,False
+10014091,Environment Agency Wales,,Cambria House,29 Newport Road,,Cardiff,South Glamorgan               ,Wales                         ,CF24 0TP,Wider Public Sector,,False
+10014083,10 Downing Street,,10 Downing Street,,,London,,England                       ,SW1A 2AA,Central Government,,False
+10014081,NCS Facilities,,PO Box 10301,,,Birmingham,West Midlands                 ,England                       ,B3 2XR,Central Government,NDPB,False
+10014054,Health Professions Wales,,"2nd Floor, Golate House",101 St Mary Street,,Cardiff,,England                       ,CF10 1DX,Wider Public Sector,Health Trust,False

--- a/db/data_migrate/20181001100230_import_inactive_customers.rb
+++ b/db/data_migrate/20181001100230_import_inactive_customers.rb
@@ -1,0 +1,24 @@
+# Execute with:
+#
+#   rails runner db/data_migrate/20181001100230_import_inactive_customers.rb
+#
+require 'csv'
+require 'progress_bar'
+
+puts 'Reading CSV file...'
+customers_csv_path = Rails.root.join('db', 'data_migrate', '20181001100230_import_inactive_customers.csv')
+csv = CSV.read(customers_csv_path, headers: true, header_converters: :symbol)
+
+puts 'Importing customers...'
+bar = ProgressBar.new(csv.count)
+csv.each do |customer_row|
+  postcode = customer_row[:postcode] == 'XXXX' ? nil : customer_row[:postcode].strip
+
+  customer = Customer.find_or_initialize_by(urn: customer_row[:urn])
+  customer.postcode = postcode
+  customer.sector = customer_row[:sector].strip.parameterize.underscore
+  customer.name = customer_row[:customername].strip
+  customer.save!
+
+  bar.increment!
+end

--- a/db/data_migrate/filter_customers.rb
+++ b/db/data_migrate/filter_customers.rb
@@ -11,14 +11,11 @@ csv = CSV.read(customers_csv_path, headers: true, header_converters: :symbol)
 warn 'Filtering customers...'
 bar = ProgressBar.new(csv.count)
 
-INTERNAL_CCS_SUPPLIER = /99[0-9]{2}00/
-
 def needs_importing?(customer_row)
-  # We're only interested in customers that are active that we don't have
-  # that aren't internal CCS suppliers
-  customer_row[:active] == 'True' &&
-    !Customer.exists?(urn: customer_row[:urn]) &&
-    customer_row[:urn] !~ INTERNAL_CCS_SUPPLIER
+  # We're only interested in customers that don't already exist and that have
+  # non-internal URN numbers (real URN numbers appear to start at 10000000, with
+  # URNs below that being used for testing purposes)
+  !Customer.exists?(urn: customer_row[:urn]) && customer_row[:urn].to_i > 10000000
 end
 
 def customers_header(customers_csv_path)


### PR DESCRIPTION
We need to include inative customers in the system because suppliers may
make a submission including invoicing against customers that are no
longer active, but were at the time of invoicing. This updates the
filter utility to import both active and inactive customers.

This change also necessitated the broadening of the filtering of
"internal" customers as the existing regular expression was not enough
to filter out the inactive ones.