### PR TITLE
Temporarily bypass management charge calculation

### DIFF
--- a/app/models/submission_status_update.rb
+++ b/app/models/submission_status_update.rb
@@ -8,29 +8,12 @@ class SubmissionStatusUpdate
   def perform!
     return unless submission.entries.any?
 
-    trigger_management_charge_calculation if all_entries_valid?
-    transition_to_in_review if no_entries_pending? && some_entries_errored?
+    submission.ready_for_review! if no_entries_pending?
   end
 
   private
 
-  def all_entries_valid?
-    submission.entries.validated.count == submission.entries.count
-  end
-
-  def transition_to_in_review
-    submission.ready_for_review!
-  end
-
   def no_entries_pending?
     submission.entries.pending.none?
-  end
-
-  def some_entries_errored?
-    submission.entries.errored.any?
-  end
-
-  def trigger_management_charge_calculation
-    AWSLambdaService.new(submission_id: submission.id).trigger
   end
 end

--- a/spec/models/submission_status_update_spec.rb
+++ b/spec/models/submission_status_update_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe SubmissionStatusUpdate do
     let(:aws_lambda_service_double) { double(trigger: true) }
     let(:submission_status_check) { SubmissionStatusUpdate.new(submission) }
 
-    before do
-      allow(AWSLambdaService).to receive(:new).and_return(aws_lambda_service_double)
-    end
-
     context 'given a "processing" submission' do
       context 'with "pending" entries' do
         let(:submission) { FactoryBot.create(:submission_with_pending_entries, aasm_state: :processing) }
@@ -29,16 +25,10 @@ RSpec.describe SubmissionStatusUpdate do
       context 'with all entries validated' do
         let(:submission) { FactoryBot.create(:submission_with_validated_entries, aasm_state: :processing) }
 
-        it 'leaves the submission in a "processing" state' do
+        it 'transitions the submission to "in_review"' do
           submission_status_check.perform!
 
-          expect(submission).to be_processing
-        end
-
-        it 'triggers a management charge calculation' do
-          expect(aws_lambda_service_double).to receive(:trigger)
-
-          submission_status_check.perform!
+          expect(submission).to be_in_review
         end
       end
 


### PR DESCRIPTION
We've realised that we [removed an endpoint the calculator relies] on to
perform the calculation, which has broken calculation! For now we're
going to skip calculation so that users are not blocked from completing
their submissions.

We will need to re-instate calculation and perform calculation against
October submissions before we can generate the finance and date
warehouse exports.

[removed the endpoint that the calculator relies](https://github.com/dxw/DataSubmissionServiceAPI/commit/bdd0a193e59e192f2710d90a494b7add09c82db5)