### PR TITLE
Wait for ingest & validation before transition

### DIFF
--- a/app/models/submission_status_update.rb
+++ b/app/models/submission_status_update.rb
@@ -8,10 +8,14 @@ class SubmissionStatusUpdate
   def perform!
     return unless submission.entries.any?
 
-    submission.ready_for_review! if no_entries_pending?
+    submission.ready_for_review! if all_entries_ingested? && no_entries_pending?
   end
 
   private
+
+  def all_entries_ingested?
+    submission.files.sum(&:rows) == submission.entries.count
+  end
 
   def no_entries_pending?
     submission.entries.pending.none?

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -28,6 +28,9 @@ FactoryBot.define do
       after(:create) do |submission, _evaluator|
         create_list(:invoice_entry, 2, :valid, submission: submission)
         create_list(:order_entry, 1, :valid, submission: submission)
+        if submission.files.empty?
+          create_list(:submission_file, 1, submission: submission, rows: submission.entries.count)
+        end
       end
     end
 
@@ -37,6 +40,9 @@ FactoryBot.define do
       after(:create) do |submission, _evaluator|
         create_list(:invoice_entry, 2, :valid, submission: submission)
         create_list(:invoice_entry, 1, :errored, submission: submission)
+        if submission.files.empty?
+          create_list(:submission_file, 1, submission: submission, rows: submission.entries.count)
+        end
       end
     end
 
@@ -46,6 +52,9 @@ FactoryBot.define do
       after(:create) do |submission, _evaluator|
         create_list(:invoice_entry, 2, :valid, submission: submission)
         create_list(:invoice_entry, 1, submission: submission)
+        if submission.files.empty?
+          create_list(:submission_file, 1, submission: submission, rows: submission.entries.count)
+        end
       end
     end
   end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Submission do
   it { is_expected.to have_many(:files) }
   it { is_expected.to have_many(:entries) }
 
-  describe 'state machine' do
+  describe '#ready_for_review state machine event' do
     it 'transitions from processing to in_review, with a valid submission' do
       submission = FactoryBot.create(:submission_with_validated_entries, aasm_state: :processing)
       submission.ready_for_review

--- a/spec/models/submission_status_update_spec.rb
+++ b/spec/models/submission_status_update_spec.rb
@@ -67,6 +67,25 @@ RSpec.describe SubmissionStatusUpdate do
           submission_status_check.perform!
         end
       end
+
+      context 'with ingest still in progress (i.e. entries count doesn’t match files#rows)' do
+        let(:submission) do
+          FactoryBot.create(
+            :submission_with_validated_entries,
+            files: [FactoryBot.build(:submission_file)],
+            aasm_state: :processing
+          ).tap do |submission|
+            entries_count = submission.entries.count
+            submission.files.last.update!(rows: (entries_count + 1))
+          end
+        end
+
+        it 'leaves the submission in a "processing"' do
+          submission_status_check.perform!
+
+          expect(submission).to be_processing
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Because both ingest and validation are parallelised, we can end up in a
situation where all the ingested rows have finished validation whilst
ingest is still ongoing. This can result in a submission transitioning
out of "processing" before all the rows have actually been ingested and
validated. This guards against that, by ensuring the transition is only
fired once the entries count matches the rows reported by the file, and
there are no pending entries remaining.