### PR TITLE
Release 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [release-14] - 2018-10-01
+
+- Data migration to import non-Active customers to database
+- Temporary bypass of broken management charge calculation to avoid blocking
+  user submission
+- Fix bug that was resulting in submissions transitioning before ingest and
+  validation had completed.
+
 ## [release-13] - 2018-09-27
 
 - Updated Customer URN list for October
@@ -68,3 +76,6 @@
 ## [release-1] - 2018-07-31
 
 Initial release
+
+
+[release-14]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-13...release-14


### PR DESCRIPTION
- Data migration to import non-Active customers to database
- Temporary bypass of broken management charge calculation to avoid blocking
  user submission
- Fix bug that was resulting in submissions transitioning before ingest and
   validation had completed.

Note the following must be run on production to perform the data migration: 

```
   rails runner db/data_migrate/20181001100230_import_inactive_customers.rb
```

Changes: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-13...release-14