### PR TITLE
(473) Prevent duplicate SubmissionEntries from being created

### DIFF
--- a/app/controllers/v1/submission_entries_controller.rb
+++ b/app/controllers/v1/submission_entries_controller.rb
@@ -5,6 +5,8 @@ class V1::SubmissionEntriesController < ApplicationController
     entry = initialize_submission_entry
     entry.attributes = submission_entry_params
 
+    return head :no_content if SubmissionEntry.exists?(submission_id: entry.submission_id, source: entry.source)
+
     if entry.save
       render jsonapi: entry, status: :created
     else


### PR DESCRIPTION
When the ingest lambda fails, it automatically restarts which was generating duplicate entries for the same row/sheet in a given spreadsheet.

Now we check whether the `submission_id` and `source` already exist, and return an `HTTP 409 Conflict` status if this is the case.