### PR TITLE
Remove spaces from Customer Reference Number field

### DIFF
--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -13,7 +13,7 @@ module Export
           value_for('InvoiceDate'),
           value_for('InvoiceNumber'),
           value_for('SupplierReferenceNumber'),
-          value_for('Customer Reference Number', default: nil),
+          value_for('CustomerReferenceNumber', default: nil),
           value_for('LotNumber'),
           value_for('ProductDescription', default: nil),
           value_for('ProductGroup', default: nil),


### PR DESCRIPTION
We don't have it for legal frameworks so there's no test that would
fail to look it up yet, but correct it now so it matches the export
documentation.