### PR TITLE
(476) Reduce logging in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem 'aws-sdk-s3', require: false
 # Exception tracking
 gem 'rollbar'
 
+# Logging
+gem 'lograge'
+
 gem 'rubocop'
 
 gem 'progress_bar', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.10.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -206,6 +211,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    request_store (1.4.1)
+      rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -290,6 +297,7 @@ DEPENDENCIES
   jsonapi-rails
   jsonapi-rspec
   listen (>= 3.0.5, < 3.2)
+  lograge
   pg (>= 0.18, < 2.0)
   progress_bar
   pry-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,6 +42,22 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
+  # Don't log SQL in production
+  config.active_record.logger = nil
+
+  # Use lograge for cleaner logging
+  config.lograge.enabled = true
+  config.lograge.ignore_actions = ['CheckController#index']
+  config.lograge.logger = ActiveSupport::Logger.new(STDOUT)
+
+  config.lograge.custom_options = lambda do |event|
+    exceptions = ['controller', 'action', 'format', 'id']
+
+    {
+      params: event.payload[:params].except(*exceptions)
+    }
+  end
+
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 


### PR DESCRIPTION
We're having to pay for an overly large Papertrail account as the API is
generating a large amount of logging, so let's reduce that!

 - Stop logging SQL queries
 - Use lograge so that one request = one log line (also making it easier
   to search!)
 - Don't log CheckController#index at all

----

### Before

```
Started GET "/v1/tasks?filter%5Buser_id%5D=4187322e-3fe3-492a-9a80-c3bffd39a889&include=framework%2Clatest_submission" for 172.20.0.1 at 2018-10-03 16:02:27 +0000
Processing by V1::TasksController#index as JSON
  Parameters: {"filter"=>{"user_id"=>"4187322e-3fe3-492a-9a80-c3bffd39a889"}, "include"=>"framework,latest_submission"}
   (3.8ms)  SELECT "memberships"."supplier_id" FROM "memberships" WHERE "memberships"."user_id" = $1  [["user_id", "4187322e-3fe3-492a-9a80-c3bffd39a889"]]
  ↳ app/models/task.rb:25
  Task Load (0.6ms)  SELECT "tasks".* FROM "tasks" WHERE 1=0
  ↳ app/controllers/v1/tasks_controller.rb:20
Completed 200 OK in 53ms (Views: 2.1ms | ActiveRecord: 7.0ms)
```

### After 
```
method=GET path=/v1/tasks format=json controller=V1::TasksController action=index status=200 duration=73.78 view=6.29 db=0.00 params={"filter"=>{"user_id"=>"4187322e-3fe3-492a-9a80-c3bffd39a889"}, "include"=>"framework,latest_submission"}
```