### PR TITLE
Rails Console helpers to help with debug/reporting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,6 +65,7 @@ Metrics/AbcSize:
     Max: 21
     Exclude:
         - 'spec/**/*'
+        - 'lib/console_helpers.rb'
 
 Metrics/LineLength:
     Max: 120

--- a/README.md
+++ b/README.md
@@ -47,3 +47,9 @@ A [full list of the API endpoints](endpoints.md) is available in a separate docu
 ## Importing users
 
 See [this guide](importing.md) to see how to import users and suppliers.
+
+## Console helpers
+
+There are some handy methods available in the Rails console for debugging
+submissions and reporting on the state of the monthly tasks. See
+[lib/console_helpers.rb](lib/console_helpers.rb) for more details.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ A [full list of the API endpoints](endpoints.md) is available in a separate docu
 
 See [this guide](importing.md) to see how to import users and suppliers.
 
+## Reporting rake tasks
+
+There are Rake tasks to report the status of the month's tasks:
+
+```
+  # Report the status of the month's tasks
+  $ bundle exec rake report:submission_stats
+```
+
 ## Console helpers
 
 There are some handy methods available in the Rails console for debugging

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,14 @@ module DataSubmissionServiceApi
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
     end
+
+    console do
+      require './lib/console_helpers'
+      if defined?(Pry)
+        TOPLEVEL_BINDING.eval('self').extend ConsoleHelpers
+      else
+        Rails::ConsoleMethods.include ConsoleHelpers
+      end
+    end
   end
 end

--- a/lib/console_helpers.rb
+++ b/lib/console_helpers.rb
@@ -1,0 +1,20 @@
+# Helper methods that are automatically included in the rails console to aid in
+# debugging and reporting whilst we are without an administrative interface.
+module ConsoleHelpers
+  # Outputs some useful information on a given submission. Helpful to get an
+  # overview of the state of the submission when debugging one that might be stuck.
+  def inspect_submission(submission)
+    Rails.logger.silence do
+      submission.reload
+      STDERR.puts "\n"
+      STDERR.puts "URL: /tasks/#{submission.task_id}/submissions/#{submission.id}"
+      STDERR.puts "Created #{submission.created_at}"
+      STDERR.puts "Submission (#{submission.aasm_state}) #{submission.id}"
+      STDERR.puts "Task (#{submission.task.status}) #{submission.task_id}"
+      STDERR.puts "File rows: #{submission.files.first.rows}"
+      STDERR.puts "Entries:   #{submission.entries.count}"
+      STDERR.puts submission.entries.group(:aasm_state).count(:aasm_state)
+      STDERR.puts "\n"
+    end
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,0 +1,33 @@
+namespace :report do
+  desc 'Reports monthly task statistics. Defaults to the current month’s tasks. Override with [MM,YYYY]'
+  task :submission_stats, %i[month year] => :environment do |_task, args|
+    month = args[:month] || (Time.zone.today - 1.month).month
+    year = args[:year] || Time.zone.today.year
+
+    reporting_period = Date.new(year.to_i, month.to_i)
+
+    task_period_scope = Task.where(period_year: reporting_period.year, period_month: reporting_period.month)
+
+    puts "\nStats for #{reporting_period.strftime('%B %Y')} tasks"
+    puts "Unstarted:\t#{task_period_scope.unstarted.count}"
+    puts "Completed:\t#{task_period_scope.completed.count} (#{business_no_business_state(task_period_scope)})"
+    puts "In Progress:\t#{task_period_scope.in_progress.count} (#{latest_submission_state(task_period_scope)})"
+  end
+
+  private
+
+  def latest_submission_state(task_scope)
+    submission_states = task_scope.in_progress.includes(:latest_submission).map { |t| t.latest_submission.aasm_state }
+    stats = submission_states.each_with_object(Hash.new(0)) { |state, counts| counts[state] += 1 }
+
+    stats.map { |state, count| "#{state} #{count}" }.join(' / ')
+  end
+
+  def business_no_business_state(task_scope)
+    file_counts = task_scope.completed.includes(:latest_submission).map { |task| task.latest_submission.files.count }
+    no_business_count = file_counts.count(0)
+    business_count = file_counts.count(&:positive?)
+
+    "#{business_count} Business / #{no_business_count} No Business"
+  end
+end


### PR DESCRIPTION
Helper methods made available in the Rails console to aid us with
debugging and reporting whilst we are without an administrative
interface that reports this sort of stuff for us.

Note that the helpers have to be included in a different way depending
on whether Pry is active or not as Pry overrides the defualt Rails
console.