### PR TITLE
Include submission PO number in finance export

### DIFF
--- a/app/models/export/coda_finance_report/row.rb
+++ b/app/models/export/coda_finance_report/row.rb
@@ -50,7 +50,7 @@ module Export
       end
 
       def order_number
-        BLANK_FOR_NOW
+        submission.purchase_order_number
       end
 
       def lot_description

--- a/spec/models/export/coda_finance_report/row_spec.rb
+++ b/spec/models/export/coda_finance_report/row_spec.rb
@@ -4,7 +4,15 @@ RSpec.describe Export::CodaFinanceReport::Row do
   let(:task) { FactoryBot.create(:task, framework: framework, supplier: supplier, period_month: 8, period_year: 2018) }
   let(:framework) { FactoryBot.create(:framework, coda_reference: 401234) }
   let(:supplier) { FactoryBot.create(:supplier, coda_reference: 'C012345') }
-  let(:submission) { FactoryBot.create(:submission, framework: framework, task: task, supplier: supplier) }
+  let(:submission) do
+    FactoryBot.create(
+      :submission,
+      framework: framework,
+      task: task,
+      supplier: supplier,
+      purchase_order_number: 'PO999'
+    )
+  end
   subject(:cg_report_row) { Export::CodaFinanceReport::Row.new(submission, Customer.sectors[:central_government]) }
   subject(:wps_report_row) { Export::CodaFinanceReport::Row.new(submission, Customer.sectors[:wider_public_sector]) }
 
@@ -18,6 +26,10 @@ RSpec.describe Export::CodaFinanceReport::Row do
 
   it 'reports the framework’ short_name as ‘Contract ID' do
     expect(cg_report_row.contract_id).to eq framework.short_name
+  end
+
+  it '#order_number returns the submission’s purchase_order_number' do
+    expect(cg_report_row.order_number).to eq 'PO999'
   end
 
   it 'reports the framework’ name as ‘Lot Description’' do

--- a/spec/models/export/coda_finance_report_spec.rb
+++ b/spec/models/export/coda_finance_report_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Export::CodaFinanceReport do
       entries: [submission_entry_1, submission_entry_2],
       supplier: supplier_2,
       framework: framework,
-      task: task_1
+      task: task_1,
+      purchase_order_number: 'PO-123'
     )
   end
   let(:submission_entry_1) do
@@ -43,8 +44,8 @@ RSpec.describe Export::CodaFinanceReport do
   let(:expected_csv) do
     <<~CSV
       RunID,Nominal,Customer Code,Customer Name,Contract ID,Order Number,Lot Description,Inf Sales,Commission,Commission %,End User,Submitter,Month,M_Q
-      #{submission.id},409999,C011111,Mary,RM3787,,G CLOUD,802.00,12.03,0.015,UCGV,Mary,August 2018,M
-      #{submission.id},409999,C011111,Mary,RM3787,,G CLOUD,0.00,0.00,0.015,UWPS,Mary,August 2018,M
+      #{submission.id},409999,C011111,Mary,RM3787,PO-123,G CLOUD,802.00,12.03,0.015,UCGV,Mary,August 2018,M
+      #{submission.id},409999,C011111,Mary,RM3787,PO-123,G CLOUD,0.00,0.00,0.015,UWPS,Mary,August 2018,M
       #{no_business_submission.id},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,0.015,UCGV,Bob,August 2018,M
       #{no_business_submission.id},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,0.015,UWPS,Bob,August 2018,M
     CSV


### PR DESCRIPTION
The purchase order number is now captured during the submission process
meaning it can be included in the finance export.