### PR TITLE
Add some temporary code for reporting spend/charge

### DIFF
--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -3,15 +3,23 @@ namespace :report do
   task :submission_stats, %i[month year] => :environment do |_task, args|
     month = args[:month] || (Time.zone.today - 1.month).month
     year = args[:year] || Time.zone.today.year
+    reporting_period_date = Date.new(year.to_i, month.to_i)
 
-    reporting_period = Date.new(year.to_i, month.to_i)
-
-    task_period_scope = Task.where(period_year: reporting_period.year, period_month: reporting_period.month)
-
-    puts "\nStats for #{reporting_period.strftime('%B %Y')} tasks"
+    task_period_scope = Task.where(period_year: reporting_period_date.year, period_month: reporting_period_date.month)
+    puts "\nStats for #{reporting_period_date.strftime('%B %Y')} tasks"
     puts "Unstarted:\t#{task_period_scope.unstarted.count}"
     puts "Completed:\t#{task_period_scope.completed.count} (#{business_no_business_state(task_period_scope)})"
     puts "In Progress:\t#{task_period_scope.in_progress.count} (#{latest_submission_state(task_period_scope)})"
+  end
+
+  desc 'Report spend and management charge. Defaults to the current month’s tasks. Override with [MM,YYYY]'
+  task :spend_and_management_charge, %i[month year] => :environment do |_task, args|
+    require 'temporary_totals_reporter'
+    month = args[:month] || (Time.zone.today - 1.month).month
+    year = args[:year] || Time.zone.today.year
+    reporting_period_date = Date.new(year.to_i, month.to_i)
+
+    TemporaryTotalsReporter.new(reporting_period_date).report
   end
 
   private

--- a/lib/temporary_totals_reporter.rb
+++ b/lib/temporary_totals_reporter.rb
@@ -1,0 +1,85 @@
+# A temporary class to report on the total spend and management charge for a
+# given submission window whilst we are without per-entry storage of the spend
+# and management charge.
+#
+# This class should become redundant once we are capturing the total  value and
+# management charge per-entry. At that point it should be removed and/or
+# replaced by something that leans on the data available.
+class TemporaryTotalsReporter
+  include ActionView::Helpers::NumberHelper
+
+  FRAMEWORK_LOOKUPS = {
+    'CM/OSG/05/3565' => ['0', 'Total Spend'],
+    'RM1031' => ['0.5', 'Total Charge (Ex VAT)'],
+    'RM1070' => [
+      '0.5',
+      'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT'
+    ],
+    'RM3710' => ['0.5', 'Total Charge (Ex VAT)'],
+    'RM3754' => ['0.5', 'Total Charge (ex VAT)'],
+    'RM3756' => ['1.5', 'Total Cost (ex VAT)'],
+    'RM3767' => ['1', 'Total Cost (ex VAT)'],
+    'RM3772' => ['0.5', 'Total Charge (Ex VAT)'],
+    'RM3786' => ['1.5', 'Total Cost (ex VAT)'],
+    'RM3787' => ['1.5', 'Total Cost (ex VAT)'],
+    'RM3797' => ['1', 'Total Charge (Ex VAT)'],
+    'RM807' => ['0.5', 'Total Charges (ex VAT)'],
+    'RM849' => ['0.5', 'Invoice Line Total Value ex VAT and Expenses'],
+    'RM858' => ['0.5', 'Invoice Line Total Value ex VAT']
+  }.freeze
+
+  attr_reader :reporting_period_date
+
+  def initialize(reporting_period_date)
+    @reporting_period_date = reporting_period_date
+  end
+
+  def report
+    STDERR.puts "Calculating spend and management charge for #{reporting_period_date.strftime('%B %Y')} tasks"
+
+    STDERR.puts "Total spend is approximately #{as_currency(total_spend)}"
+    STDERR.puts "Total management charge is approximately #{as_currency(management_charge)}"
+  end
+
+  def total_spend
+    completed_submissions.sum do |submission|
+      spend_column = FRAMEWORK_LOOKUPS.fetch(submission.framework.short_name).last
+
+      submission.entries.invoices.pluck(:data).sum { |data| coerce_amount_to_decimal(data[spend_column]) }
+    end
+  end
+
+  def management_charge
+    completed_submissions.sum do |submission|
+      spend_column = FRAMEWORK_LOOKUPS.fetch(submission.framework.short_name).last
+      percentage = FRAMEWORK_LOOKUPS.fetch(submission.framework.short_name).first
+      total = submission.entries.invoices.pluck(:data).sum { |data| coerce_amount_to_decimal(data[spend_column]) }
+      total * BigDecimal(percentage) / 100
+    end
+  end
+
+  private
+
+  def coerce_amount_to_decimal(currency_amount)
+    if currency_amount.is_a? String
+      BigDecimal(currency_amount.tr('£,', ''))
+    else
+      BigDecimal(currency_amount.to_s)
+    end
+  end
+
+  def as_currency(number)
+    number_to_currency(number, precision: 0, unit: '£')
+  end
+
+  def tasks_scope
+    @tasks_scope ||= Task.where(period_year: reporting_period_date.year, period_month: reporting_period_date.month)
+  end
+
+  def completed_submissions
+    @completed_submissions ||= tasks_scope
+                               .joins(latest_submission: :framework)
+                               .merge(Submission.completed)
+                               .map(&:latest_submission)
+  end
+end


### PR DESCRIPTION
We will use this rake task to report the monthly spend and management
charge in the interim until we have a proper administrative interface
that gives the figures.

Note that until we have both the total value and management charge
stored as database columns on submission_entries, calculating the total
spend and management charge is convoluted, inefficient and hacky. Things
get much simpler once the work to normalise the data and model the
framework definitions in the Ruby application is complete.