### PR TITLE
492 - rake export:tasks - use framework's short name

### DIFF
--- a/app/models/export/tasks/row.rb
+++ b/app/models/export/tasks/row.rb
@@ -16,7 +16,7 @@ module Export
           task.id,
           year_and_month,
           task.supplier_id,
-          task.framework_id,
+          task.framework.short_name,
           task.status,
           FIXED_TASK_TYPE,
           EMPTY_FOR_NOW,

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -5,7 +5,7 @@ namespace :export do
 
   desc 'Export task entities to CSV'
   task :tasks, [:output] => [:environment] do |_task, args|
-    Export::Anything.new(Task.all, args[:output]).run
+    Export::Anything.new(Task.includes(:framework), args[:output]).run
   end
 
   desc 'Export submission entities to CSV'

--- a/spec/lib/tasks/export/tasks_spec.rb
+++ b/spec/lib/tasks/export/tasks_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'rake export:tasks', type: :task do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
         <<~LINE.chomp
-          #{first_task.id},2018-08,#{first_task.supplier.id},#{first_task.framework.id},unstarted,1,,
+          #{first_task.id},2018-08,#{first_task.supplier.id},#{first_task.framework.short_name},unstarted,1,,
         LINE
       )
     end


### PR DESCRIPTION
This was exporting the framework ID to the FrameworkID field which is
of no use outside this API. Export the Framework#short_name to the
FrameworkID field.