### PR TITLE
Escape framework:definition single quotes

### DIFF
--- a/lib/generators/framework/definition_generator.rb
+++ b/lib/generators/framework/definition_generator.rb
@@ -41,6 +41,10 @@ class Framework
       @miso_fields ||= Framework::MisoFields.new(framework_short_name)
     end
 
+    def quote(field_name)
+      field_name.match?(/'/) ? %("#{field_name}") : "'#{field_name}'"
+    end
+
     def exports_to(field)
       value = field['ExportsTo']
       should_export = value.present? && !value&.match(/[!?]/)

--- a/lib/generators/framework/templates/framework_definition.rb.erb
+++ b/lib/generators/framework/templates/framework_definition.rb.erb
@@ -8,7 +8,7 @@ class Framework
         <%= invoice_total_value_field %>
 
         <%- invoice_fields.each do |field| -%>
-        field '<%= field['DisplayName'] %>', <%= activemodel_data_type field['SystemDataType'] %><%= exports_to(field) %>
+        field <%= quote(field['DisplayName']) %>, <%= activemodel_data_type field['SystemDataType'] %><%= exports_to(field) %>
         <%- end -%>
       end
       <%- if order_fields.any? -%>
@@ -17,7 +17,7 @@ class Framework
         <%= order_total_value_field %>
 
         <%- order_fields.each do |field| -%>
-        field '<%= field['DisplayName'] %>', <%= activemodel_data_type field['SystemDataType'] %><%= exports_to(field) %>
+        field '<%= quote(field['DisplayName']) %>, <%= activemodel_data_type field['SystemDataType'] %><%= exports_to(field) %>
         <%- end -%>
       end
       <%- end -%>

--- a/spec/lib/generators/framework/definition_generator_spec.rb
+++ b/spec/lib/generators/framework/definition_generator_spec.rb
@@ -72,4 +72,13 @@ RSpec.describe Framework::DefinitionGenerator, type: :generator do
       expect(definition).to match "field 'Cost Centre', :string"
     end
   end
+
+  context 'Single quotes in fields – RM3797' do
+    let(:generator_arguments)      { %w[RM3797] }
+    let(:expected_definition_file) { 'RM3797.rb' }
+
+    it %(escapes the "Publisher's Name" field) do
+      expect(definition).to include(%(field "Publisher's Name"))
+    end
+  end
 end


### PR DESCRIPTION
Switch to double-quotes for "Publisher's Name"