### PR TITLE
Generate framework definitions for october

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,8 @@ Metrics/AbcSize:
 
 Metrics/LineLength:
     Max: 120
+    Exclude:
+        - 'app/models/framework/definition/**/*'
 
 Metrics/BlockLength:
     Max: 40

--- a/app/models/framework/definition/RM1031.rb
+++ b/app/models/framework/definition/RM1031.rb
@@ -1,0 +1,43 @@
+class Framework
+  module Definition
+    class RM1031 < Base
+      framework_short_name 'RM1031'
+      framework_name       'Laundry and Linen Services (RM1031)'
+
+      class Invoice < Sheet
+        total_value_field 'Total Charge (Ex VAT)'
+
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber'
+        field 'Service Type', :string, exports_to: 'ProductGroup'
+        field 'Category', :string, exports_to: 'ProductClass'
+        field 'Item Code', :string, exports_to: 'ProductCode'
+        field 'UNSPSC', :integer, exports_to: 'UNSPSC'
+        field 'Unit of Purchase', :string, exports_to: 'UnitType'
+        field 'Price per Unit', :decimal, exports_to: 'UnitPrice'
+        field 'Quantity', :decimal, exports_to: 'UnitQuantity'
+        field 'Total Charge (Ex VAT)', :decimal, exports_to: 'InvoiceValue'
+        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'Cost Centre ', :string
+        field 'Contract Number', :string
+        field 'Baseline Price', :decimal, exports_to: 'Additional1'
+        field 'Subcontractor Supplier Name', :string, exports_to: 'Additional2'
+        field 'Item', :string, exports_to: 'ProductDescription'
+      end
+
+      class Order < Sheet
+        total_value_field 'Customer Order/Contract Value'
+
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Number of items', :decimal
+        field 'Customer Order/Contract Value', :decimal, exports_to: 'ContractValue'
+        field 'Project Name', :string, exports_to: 'ProductDescription'
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -1,0 +1,45 @@
+class Framework
+  module Definition
+    class RM1070 < Base
+      framework_short_name 'RM1070'
+      framework_name       'Vehicle Purchase (RM1070)'
+
+      class Invoice < Sheet
+        total_value_field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT'
+
+        field 'Lot Number', :string, exports_to: 'LotNumber'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Invoice Number', :string, exports_to: 'InvoiceNumber'
+        field 'Invoice Line Number', :string
+        field 'Vehicle Model', :string, exports_to: 'ProductSubClass'
+        field 'Vehicle Make', :string, exports_to: 'ProductClass'
+        field 'Vehicle Segment', :string, exports_to: 'ProductGroup'
+        field 'UNSPSC', :integer, exports_to: 'UNSPSC'
+        field 'Unit of Purchase', :string, exports_to: 'UnitType'
+        field 'Invoice Price Per Vehicle', :decimal, exports_to: 'UnitPrice'
+        field 'Quantity', :integer, exports_to: 'UnitQuantity'
+        field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', :decimal, exports_to: 'InvoiceValue'
+        field 'Additional Expenditure to provide goods', :decimal, exports_to: 'Expenses'
+        field 'VAT Applicable?', :boolean, exports_to: 'VATIncluded'
+        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'Vehicle CAP Code', :string, exports_to: 'ProductCode'
+        field 'Vehicle Trim/Derivative', :string, exports_to: 'ProductDescription'
+        field 'Cost Centre', :string
+        field 'Contract Number', :string
+        field 'Vehicle Registration Number', :string, exports_to: 'Additional1'
+        field 'All Conversion and third party conversion costs excluding factory fit options', :decimal, exports_to: 'Additional2'
+        field 'CO2 Emissions', :decimal, exports_to: 'Additional3'
+        field 'Fuel Type', :string, exports_to: 'Additional4'
+        field 'Customer Support Terms', :decimal, exports_to: 'Additional5'
+        field 'Leasing Company', :string, exports_to: 'Additional6'
+        field 'Additional support terms given to Lease companies', :decimal, exports_to: 'Additional7'
+        field 'Invoice Price Excluding Options', :decimal, exports_to: 'Additional8'
+        field 'List Price Excluding Options', :decimal
+        field 'eAuction Contract No', :string
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/RM3710.rb
+++ b/app/models/framework/definition/RM3710.rb
@@ -1,0 +1,51 @@
+class Framework
+  module Definition
+    class RM3710 < Base
+      framework_short_name 'RM3710'
+      framework_name       'Vehicle Lease and Fleet Management'
+
+      class Invoice < Sheet
+        total_value_field 'Total Charge (Ex VAT)'
+
+        field 'Lot Number', :string, exports_to: 'LotNumber'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber'
+        field 'Unit of Purchase', :string, exports_to: 'UnitType'
+        field 'Price per Unit (Ex VAT)', :decimal, exports_to: 'UnitPrice'
+        field 'Quantity', :decimal, exports_to: 'UnitQuantity'
+        field 'Total Charge (Ex VAT)', :decimal, exports_to: 'InvoiceValue'
+        field 'VAT Applicable', :string, exports_to: 'VATIncluded'
+        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'CAP Code', :string, exports_to: 'ProductCode'
+        field 'Vehicle Make', :string, exports_to: 'ProductClass'
+        field 'Vehicle Model', :string, exports_to: 'ProductSubClass'
+        field 'Product Description - Vehicle Derivative / Fleet Management Services', :string, exports_to: 'ProductDescription'
+        field 'Product Classification', :string, exports_to: 'ProductGroup'
+        field 'UNSPSC', :integer, exports_to: 'UNSPSC'
+        field 'Cost Centre', :string
+        field 'Contract Number', :string
+        field 'Subcontractor Supplier Name', :string, exports_to: 'Additional2'
+        field 'Vehicle Registration', :string, exports_to: 'Additional1'
+        field 'Fuel Type', :string, exports_to: 'Additional4'
+        field 'CO2 Emission Levels', :decimal, exports_to: 'Additional3'
+        field 'Vehicle Convertors Name', :string, exports_to: 'Additional5'
+        field 'Vehicle Conversion Type', :string, exports_to: 'Additional6'
+        field 'Vehicle Type', :string, exports_to: 'Additional7'
+        field 'Lease Start Date', :date, exports_to: 'Additional8'
+        field 'Lease End Date', :date
+        field 'Lease Period (Months)', :integer
+        field 'Payment Profile', :string
+        field 'Annual Lease Mileage', :decimal
+        field 'Base Vehicle Price ex VAT', :decimal
+        field 'Lease Finance Charge ex VAT', :decimal
+        field 'Annual Service Maintenance & Repair Costs ex VAT', :decimal
+        field 'Residual Value', :decimal
+        field 'Total Manufacturer Discount (%)', :decimal
+        field 'Spend Code', :string, exports_to: 'PromotionCode'
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/RM3754.rb
+++ b/app/models/framework/definition/RM3754.rb
@@ -1,0 +1,30 @@
+class Framework
+  module Definition
+    class RM3754 < Base
+      framework_short_name 'RM3754'
+      framework_name       'Vehicle Telematics'
+
+      class Invoice < Sheet
+        total_value_field 'Total Charge (ex VAT)'
+
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber'
+        field 'Product Description', :string, exports_to: 'ProductDescription'
+        field 'UNSPSC', :integer, exports_to: 'UNSPSC'
+        field 'Unit of Purchase', :string, exports_to: 'UnitType'
+        field 'Price per Unit', :decimal, exports_to: 'UnitPrice'
+        field 'Total Number of Units', :decimal, exports_to: 'UnitQuantity'
+        field 'Total Charge (ex VAT)', :decimal, exports_to: 'InvoiceValue'
+        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'Cost Centre', :string
+        field 'Contract Number', :string
+        field 'Vehicle Registration No', :string, exports_to: 'Additional1'
+        field 'Payment Profile', :string, exports_to: 'Additional2'
+        field 'Subcontractor Supplier Name', :string, exports_to: 'Additional3'
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/RM3767.rb
+++ b/app/models/framework/definition/RM3767.rb
@@ -1,0 +1,46 @@
+class Framework
+  module Definition
+    class RM3767 < Base
+      framework_short_name 'RM3767'
+      framework_name       'Supply and Fit of Tyres (RM3767)'
+
+      class Invoice < Sheet
+        total_value_field 'Total Cost (Ex VAT)'
+
+        field 'Lot Number', :string, exports_to: 'LotNumber'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Tyre Specification ', :string, exports_to: 'ProductCode'
+        field 'Vehicle Category', :string, exports_to: 'ProductSubClass'
+        field 'Associated Service', :string, exports_to: 'ProductDescription'
+        field 'Tyre Width', :decimal
+        field 'Aspect Ratio', :integer
+        field 'Rim Diameter', :decimal
+        field 'Load Capacity', :integer
+        field 'Speed Index', :string
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer Organisation Name', :string, exports_to: 'CustomerName'
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber'
+        field 'Customer Invoice Line Number', :string
+        field 'Product Type', :string, exports_to: 'ProductGroup'
+        field 'Tyre Brand', :string, exports_to: 'ProductClass'
+        field 'UNSPSC', :integer, exports_to: 'UNSPSC'
+        field 'Unit of Purchase', :string, exports_to: 'UnitType'
+        field 'Price per Unit', :decimal, exports_to: 'UnitPrice'
+        field 'Total Cost (Ex VAT)', :decimal, exports_to: 'InvoiceValue'
+        field 'Quantity', :decimal, exports_to: 'UnitQuantity'
+        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'Cost Centre', :string
+        field 'Contract Number', :string
+        field 'Tyre Grade', :string, exports_to: 'Additional1'
+        field 'Run Flats (Y/N)', :string, exports_to: 'Additional2'
+        field 'Core Tyre Price', :decimal, exports_to: 'Additional3'
+        field 'Valve Cost', :decimal, exports_to: 'Additional4'
+        field 'Fitment Cost', :decimal, exports_to: 'Additional5'
+        field 'Balance Cost', :decimal, exports_to: 'Additional6'
+        field 'Disposal Cost', :decimal, exports_to: 'Additional7'
+        field 'Subcontractor Name', :string, exports_to: 'Additional8'
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/RM3772.rb
+++ b/app/models/framework/definition/RM3772.rb
@@ -1,0 +1,43 @@
+class Framework
+  module Definition
+    class RM3772 < Base
+      framework_short_name 'RM3772'
+      framework_name       'Specialist Laundry Services (for Surgical Gowns, D'
+
+      class Invoice < Sheet
+        total_value_field 'Total Charge (Ex VAT)'
+
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Category', :string, exports_to: 'ProductClass'
+        field 'Item', :string, exports_to: 'ProductDescription'
+        field 'Item Code', :string, exports_to: 'ProductCode'
+        field 'UNSPSC', :integer, exports_to: 'UNSPSC'
+        field 'Unit of Purchase', :string, exports_to: 'UnitType'
+        field 'Price per Unit', :decimal, exports_to: 'UnitCost'
+        field 'Quantity', :decimal, exports_to: 'UnitQuantity'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber'
+        field 'Service Type', :string, exports_to: 'ProductGroup'
+        field 'Total Charge (Ex VAT)', :decimal, exports_to: 'InvoiceValue'
+        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'Cost Centre ', :string
+        field 'Contract Number', :string
+        field 'Baseline Price', :decimal, exports_to: 'Additional1'
+        field 'Subcontractor Supplier Name', :string, exports_to: 'Additional2'
+      end
+
+      class Order < Sheet
+        total_value_field 'Customer Order/Contract Value'
+
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Number of items', :decimal
+        field 'Customer Order/Contract Value', :decimal, exports_to: 'ContractValue'
+        field 'Project Name', :string, exports_to: 'ProductDescription'
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/RM3797.rb
+++ b/app/models/framework/definition/RM3797.rb
@@ -1,0 +1,31 @@
+class Framework
+  module Definition
+    class RM3797 < Base
+      framework_short_name 'RM3797'
+      framework_name       'Journal Subscriptions'
+
+      class Invoice < Sheet
+        total_value_field 'Total Charge (Ex VAT)'
+
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber'
+        field 'Product Group', :string, exports_to: 'ProductGroup'
+        field "Publisher's Name", :string, exports_to: 'ProductClass'
+        field 'Product Description', :string, exports_to: 'ProductDescription'
+        field 'Crown Commercial Service Unique Product Codes', :string, exports_to: 'ProductCode'
+        field 'UNSPSC', :integer, exports_to: 'UNSPSC'
+        field 'Unit of Measure', :string, exports_to: 'UnitType'
+        field 'Price per Unit', :decimal, exports_to: 'UnitPrice'
+        field 'Quantity', :decimal, exports_to: 'UnitQuantity'
+        field 'Total Charge (Ex VAT)', :decimal, exports_to: 'InvoiceValue'
+        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'Cost Centre', :string
+        field 'Contract Number', :string
+        field 'Publisher List Price', :decimal, exports_to: 'Additional2'
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/RM807.rb
+++ b/app/models/framework/definition/RM807.rb
@@ -1,0 +1,45 @@
+class Framework
+  module Definition
+    class RM807 < Base
+      framework_short_name 'RM807'
+      framework_name       'Vehicle Hire (RM807)'
+
+      class Invoice < Sheet
+        total_value_field 'Total Charges (ex VAT)'
+
+        field 'Contract Number', :string
+        field 'Cost Centre', :string
+        field 'Miles Travelled', :decimal, exports_to: 'Additional6'
+        field 'Refuelling Charges inc fuel ex VAT', :decimal, exports_to: 'Additional7'
+        field 'Rental Company', :string, exports_to: 'Additional8'
+        field 'Booking Method', :string
+        field 'On line booking discount', :decimal
+        field 'Lot Number', :string, exports_to: 'LotNumber'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Customer Agreement Number/Reference', :string, exports_to: 'CustomerReferenceNumber'
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber'
+        field 'Customer Invoice Line Number', :string
+        field 'Invoice Line Product/Service Description', :string, exports_to: 'ProductDescription'
+        field 'UNSPSC', :integer, exports_to: 'UNSPSC'
+        field 'Unit of Purchase', :string, exports_to: 'UnitType'
+        field 'Price per Unit', :decimal, exports_to: 'UnitPrice'
+        field 'Invoice Line Quantity', :decimal, exports_to: 'UnitQuantity'
+        field 'Total Charges (ex VAT)', :decimal, exports_to: 'InvoiceValue'
+        field 'VAT Applicable', :boolean, exports_to: 'VATIncluded'
+        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'Promotion Code', :string, exports_to: 'PromotionCode'
+        field 'Invoice Line Product/Service Grouping', :string, exports_to: 'ProductGroup'
+        field 'Rental Period', :string, exports_to: 'Additional1'
+        field 'Vehicle Group Booked', :string, exports_to: 'Additional2'
+        field 'Vehicle Group Supplied', :string, exports_to: 'Additional3'
+        field 'Vehicle Make', :string, exports_to: 'ProductClass'
+        field 'Vehicle Derivative', :string, exports_to: 'ProductSubClass'
+        field 'Fuel Type', :string, exports_to: 'Additional4'
+        field 'CO2 Emission Level', :string, exports_to: 'Additional5'
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/RM849.rb
+++ b/app/models/framework/definition/RM849.rb
@@ -1,0 +1,53 @@
+class Framework
+  module Definition
+    class RM849 < Base
+      framework_short_name 'RM849'
+      framework_name       'Laundry & Linen Services Framework'
+
+      class Invoice < Sheet
+        total_value_field 'Invoice Line Total Value ex VAT and Expenses'
+
+        field 'Lot Number', :string, exports_to: 'LotNumber'
+        field 'Supplier Order Number', :string, exports_to: 'SupplierReferenceNumber'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Customer Order Number', :string, exports_to: 'CustomerReferenceNumber'
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber'
+        field 'Customer Invoice Line Number', :string, exports_to: 'Additional1'
+        field 'Invoice Line Product / Service Description', :string, exports_to: 'ProductDescription'
+        field 'Invoice Line Service Grouping', :string, exports_to: 'ProductGroup'
+        field 'UNSPSC', :string, exports_to: 'UNSPSC'
+        field 'Product Code', :string, exports_to: 'ProductCode'
+        field 'Unit of Purchase', :string, exports_to: 'UnitType'
+        field 'Price per Unit', :decimal, exports_to: 'UnitPrice'
+        field 'Invoice Line Quantity', :decimal, exports_to: 'UnitQuantity'
+        field 'Invoice Line Total Value ex VAT and Expenses', :decimal, exports_to: 'InvoiceValue'
+        field 'VAT Applicable', :boolean, exports_to: 'VATIncluded'
+        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'Contract Number', :string
+        field 'Cost Centre', :string
+      end
+
+      class Order < Sheet
+        total_value_field 'Customer Order/Contract Value'
+
+        field 'Lot Number', :string, exports_to: 'LotNumber'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Customer Order Number', :string, exports_to: 'CustomerReferenceNumber'
+        field 'Customer Order Date', :date
+        field 'Customer Contract Start Date', :date, exports_to: 'ContractStartDate'
+        field 'Customer Contract End Date', :date, exports_to: 'ContractEndDate'
+        field 'Project Name', :string, exports_to: 'ProductDescription'
+        field 'UNSPSC', :integer, exports_to: 'UNSPSC'
+        field 'Number of items', :integer
+        field 'Customer Order/Contract Value', :decimal, exports_to: 'ContractValue'
+        field 'Invoice Line Service Grouping', :string, exports_to: 'ContractAwardChannel'
+        field 'Invoice Line Product / Service Description', :string, exports_to: 'Additional1'
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/RM858.rb
+++ b/app/models/framework/definition/RM858.rb
@@ -1,0 +1,57 @@
+class Framework
+  module Definition
+    class RM858 < Base
+      framework_short_name 'RM858'
+      framework_name       'Pan Govt Vehicle Leasing & Fleet Outsource Solutio'
+
+      class Invoice < Sheet
+        total_value_field 'Invoice Line Total Value ex VAT'
+
+        field 'Lot Number', :string, exports_to: 'LotNumber'
+        field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
+        field 'Customer Organisation', :string, exports_to: 'CustomerName'
+        field 'Customer URN', :integer, exports_to: 'CustomerURN'
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber'
+        field 'Customer Invoice Line Number', :string
+        field 'Invoice Line Product / Service Description', :string, exports_to: 'ProductDescription'
+        field 'Unit of Purchase', :string, exports_to: 'UnitType'
+        field 'Price per Unit ex VAT', :decimal, exports_to: 'UnitPrice'
+        field 'Invoice Line Quantity', :decimal, exports_to: 'UnitQuantity'
+        field 'Invoice Line Total Value ex VAT', :decimal, exports_to: 'InvoiceValue'
+        field 'VAT Applicable', :boolean, exports_to: 'VATIncluded'
+        field 'VAT Amount Charged', :decimal, exports_to: 'VATCharged'
+        field 'Spend Code', :string, exports_to: 'PromotionCode'
+        field 'Invoice Line Product / Service Grouping', :string, exports_to: 'ProductGroup'
+        field 'CAP Code', :string, exports_to: 'ProductCode'
+        field 'Vehicle Make', :string, exports_to: 'ProductClass'
+        field 'Vehicle Model', :string, exports_to: 'ProductSubClass'
+        field 'Vehicle Derivative', :string, exports_to: 'Additional1'
+        field 'Product Classification', :string, exports_to: 'Additional2'
+        field 'Vehicle Registration', :string, exports_to: 'Additional3'
+        field 'Vehicle Convertors Name', :string, exports_to: 'Additional4'
+        field 'Vehicle Conversion Type', :string, exports_to: 'Additional5'
+        field 'Vehicle Type', :string, exports_to: 'Additional6'
+        field 'Fuel Type', :string, exports_to: 'Additional7'
+        field 'CO2 Emission Levels', :string, exports_to: 'Additional8'
+        field 'Lease Period', :string
+        field 'Lease Start Date', :date
+        field 'Lease End Date', :date
+        field 'Payment Profile', :string
+        field 'Annual Lease Mileage', :decimal
+        field 'Base Vehicle Price ex VAT', :decimal
+        field 'Lease Cost excluding Optional Extras and Conversion ex VAT', :decimal
+        field 'Lease Finance Charge ex VAT', :decimal
+        field 'Lease Finance Margin ex VAT', :decimal
+        field 'Vehicle Purchase Terms', :string
+        field 'Standard Vehicle Discount (%)', :decimal
+        field 'Enhanced Vehicle Discount (%)', :decimal
+        field 'Annual Service Maintenance & Repair Costs ex VAT', :decimal
+        field 'Annual Breakdown & Recovery Costs ex VAT', :decimal
+        field 'Residual Value', :decimal
+        field 'Cost Centre', :string
+        field 'Contract Number', :string
+      end
+    end
+  end
+end

--- a/data/framework_miso_fields.csv
+++ b/data/framework_miso_fields.csv
@@ -125,7 +125,7 @@ ColumnId,TemplateId,FrameworkId,Name,SheetName,DestinationTable,FieldGroup,Short
 10170,427,485,Laundry & Linen Services Framework,OrdersReceived,Orders,Default,ProductDescription,ProductDescription,Project Name,ProductDescription,varchar,255,System.String,True,False,Workplace,RM849
 10171,427,485,Laundry & Linen Services Framework,OrdersReceived,Orders,Default,UNSPSC,UNSPSC,UNSPSC,UNSPSC,int,-1,System.Int32,False,False,Workplace,RM849
 10172,427,485,Laundry & Linen Services Framework,OrdersReceived,Orders,Default,Quantity,Quantity,Number of items,Orders needs field for this?,int,-1,System.Int32,False,False,Workplace,RM849
-10173,427,485,Laundry & Linen Services Framework,OrdersReceived,Orders,Default,Value,Value,Customer Order/Contract Value,ContactValue,"decimal(18,4)",-1,System.Decimal,True,False,Workplace,RM849
+10173,427,485,Laundry & Linen Services Framework,OrdersReceived,Orders,Default,Value,Value,Customer Order/Contract Value,ContractValue,"decimal(18,4)",-1,System.Decimal,True,False,Workplace,RM849
 10174,427,485,Laundry & Linen Services Framework,OrdersReceived,Orders,Default,OrderChannel,OrderChannel,Invoice Line Service Grouping,ContractAwardChannel,varchar,3,System.String,True,False,Workplace,RM849
 10175,427,485,Laundry & Linen Services Framework,OrdersReceived,Orders,User Defined,InvLineDesc,XCol1,Invoice Line Product / Service Description,Additional1,varchar,255,System.String,True,False,Workplace,RM849
 17434,758,644,Vehicle Purchase (RM1070),InvoicesRaised,Invoices,Default,LotNumber,LotNumber,Lot Number,LotNumber,varchar,20,System.String,True,False,Fleet,RM1070

--- a/lib/generators/framework/templates/framework_definition.rb.erb
+++ b/lib/generators/framework/templates/framework_definition.rb.erb
@@ -17,7 +17,7 @@ class Framework
         <%= order_total_value_field %>
 
         <%- order_fields.each do |field| -%>
-        field '<%= quote(field['DisplayName']) %>, <%= activemodel_data_type field['SystemDataType'] %><%= exports_to(field) %>
+        field <%= quote(field['DisplayName']) %>, <%= activemodel_data_type field['SystemDataType'] %><%= exports_to(field) %>
         <%- end -%>
       end
       <%- end -%>


### PR DESCRIPTION
This adds the missing definition files for October frameworks. These need to be present for the export to work with the current production data.