### PR TITLE
Add management charge rates to framework definitions

### DIFF
--- a/app/models/export/coda_finance_report/row.rb
+++ b/app/models/export/coda_finance_report/row.rb
@@ -66,7 +66,7 @@ module Export
       end
 
       def commission_percent
-        format_percentage(management_charge_rate)
+        percentage_as_decimal(management_charge_rate)
       end
 
       def end_user
@@ -118,7 +118,7 @@ module Export
         format '%.2f', amount.truncate(2)
       end
 
-      def format_percentage(percentage)
+      def percentage_as_decimal(percentage)
         (percentage / 100).to_s
       end
 

--- a/app/models/export/coda_finance_report/row.rb
+++ b/app/models/export/coda_finance_report/row.rb
@@ -107,7 +107,7 @@ module Export
       end
 
       def management_charge_rate
-        Framework::TMP_FIXED_CHARGE_RATE
+        framework.management_charge_rate
       end
 
       def numeric_string_to_number(numeric_string)

--- a/app/models/export/submissions/extract.rb
+++ b/app/models/export/submissions/extract.rb
@@ -7,6 +7,7 @@ module Export
         Submission.select(
           <<~POSTGRESQL
             submissions.*,
+            frameworks.short_name             AS _framework_short_name,
             orders.total_value                AS _total_order_value,
             COALESCE(orders.entry_count, 0)   AS _order_entry_count,
             invoices.total_value              AS _total_invoice_value,
@@ -15,6 +16,7 @@ module Export
           POSTGRESQL
         ).joins(
           <<~POSTGRESQL
+            LEFT JOIN frameworks ON frameworks.id = submissions.framework_id
             LEFT JOIN (SELECT
                          submission_id,
                          SUM(total_value) AS total_value,
@@ -37,7 +39,7 @@ module Export
         ).where(
           aasm_state: RELEVANT_STATUSES
         ).group(
-          'submissions.id, orders.total_value, invoices.total_value,'\
+          'submissions.id, frameworks.short_name, orders.total_value, invoices.total_value,'\
           'orders.entry_count, invoices.entry_count'
         )
       end

--- a/app/models/export/submissions/row.rb
+++ b/app/models/export/submissions/row.rb
@@ -45,7 +45,7 @@ module Export
       end
 
       def management_charge_rate
-        (Framework::TMP_FIXED_CHARGE_RATE / 100).to_s
+        (framework_definition.management_charge_rate / 100).to_s
       end
 
       def created_date
@@ -74,6 +74,10 @@ module Export
       end
 
       private
+
+      def framework_definition
+        @framework_definition ||= Framework::Definition[submission._framework_short_name]
+      end
 
       def contract_entry_count
         submission._order_entry_count

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -12,4 +12,10 @@ class Framework < ApplicationRecord
     with: /\A40\d{4}\z/,
     message: 'must start with “40” and have four additional numbers, for example: “401234”'
   }
+
+  delegate :management_charge_rate, to: :definition
+
+  def definition
+    @definition ||= Definition[short_name]
+  end
 end

--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -33,6 +33,12 @@ class Framework
         def framework_short_name(value = nil)
           @framework_short_name ||= value
         end
+
+        ##
+        # E.g. BigDecimal.new('1.5')
+        def management_charge_rate(charge_rate = nil)
+          @management_charge_rate ||= charge_rate
+        end
       end
     end
 

--- a/app/models/framework/definition/CM_OSG_05_3565.rb
+++ b/app/models/framework/definition/CM_OSG_05_3565.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'CM/OSG/05/3565'
       framework_name       'Laundry Services - Wave 2'
 
+      management_charge_rate BigDecimal('0')
+
       class Invoice < Sheet
         total_value_field 'Total Spend'
 

--- a/app/models/framework/definition/RM1031.rb
+++ b/app/models/framework/definition/RM1031.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM1031'
       framework_name       'Laundry and Linen Services (RM1031)'
 
+      management_charge_rate BigDecimal('0.5')
+
       class Invoice < Sheet
         total_value_field 'Total Charge (Ex VAT)'
 

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM1070'
       framework_name       'Vehicle Purchase (RM1070)'
 
+      management_charge_rate BigDecimal('0.5')
+
       class Invoice < Sheet
         total_value_field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT'
 

--- a/app/models/framework/definition/RM3710.rb
+++ b/app/models/framework/definition/RM3710.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM3710'
       framework_name       'Vehicle Lease and Fleet Management'
 
+      management_charge_rate BigDecimal('0.5')
+
       class Invoice < Sheet
         total_value_field 'Total Charge (Ex VAT)'
 

--- a/app/models/framework/definition/RM3754.rb
+++ b/app/models/framework/definition/RM3754.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM3754'
       framework_name       'Vehicle Telematics'
 
+      management_charge_rate BigDecimal('0.5')
+
       class Invoice < Sheet
         total_value_field 'Total Charge (ex VAT)'
 

--- a/app/models/framework/definition/RM3756.rb
+++ b/app/models/framework/definition/RM3756.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM3756'
       framework_name       'Rail Legal Services'
 
+      management_charge_rate BigDecimal('1.5')
+
       class Invoice < Sheet
         total_value_field 'Total Cost (ex VAT)'
 

--- a/app/models/framework/definition/RM3767.rb
+++ b/app/models/framework/definition/RM3767.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM3767'
       framework_name       'Supply and Fit of Tyres (RM3767)'
 
+      management_charge_rate BigDecimal('1')
+
       class Invoice < Sheet
         total_value_field 'Total Cost (Ex VAT)'
 

--- a/app/models/framework/definition/RM3772.rb
+++ b/app/models/framework/definition/RM3772.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM3772'
       framework_name       'Specialist Laundry Services (for Surgical Gowns, D'
 
+      management_charge_rate BigDecimal('0.5')
+
       class Invoice < Sheet
         total_value_field 'Total Charge (Ex VAT)'
 

--- a/app/models/framework/definition/RM3786.rb
+++ b/app/models/framework/definition/RM3786.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM3786'
       framework_name       'General Legal Advice Services'
 
+      management_charge_rate BigDecimal('1.5')
+
       class Invoice < Sheet
         total_value_field 'Total Cost (ex VAT)'
 

--- a/app/models/framework/definition/RM3787.rb
+++ b/app/models/framework/definition/RM3787.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM3787'
       framework_name       'Finance & Complex Legal Services'
 
+      management_charge_rate BigDecimal('1.5')
+
       class Invoice < Sheet
         total_value_field 'Total Cost (ex VAT)'
 

--- a/app/models/framework/definition/RM3797.rb
+++ b/app/models/framework/definition/RM3797.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM3797'
       framework_name       'Journal Subscriptions'
 
+      management_charge_rate BigDecimal('1')
+
       class Invoice < Sheet
         total_value_field 'Total Charge (Ex VAT)'
 

--- a/app/models/framework/definition/RM807.rb
+++ b/app/models/framework/definition/RM807.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM807'
       framework_name       'Vehicle Hire (RM807)'
 
+      management_charge_rate BigDecimal('0.5')
+
       class Invoice < Sheet
         total_value_field 'Total Charges (ex VAT)'
 

--- a/app/models/framework/definition/RM849.rb
+++ b/app/models/framework/definition/RM849.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM849'
       framework_name       'Laundry & Linen Services Framework'
 
+      management_charge_rate BigDecimal('0.5')
+
       class Invoice < Sheet
         total_value_field 'Invoice Line Total Value ex VAT and Expenses'
 

--- a/app/models/framework/definition/RM858.rb
+++ b/app/models/framework/definition/RM858.rb
@@ -4,6 +4,8 @@ class Framework
       framework_short_name 'RM858'
       framework_name       'Pan Govt Vehicle Leasing & Fleet Outsource Solutio'
 
+      management_charge_rate BigDecimal('0.5')
+
       class Invoice < Sheet
         total_value_field 'Invoice Line Total Value ex VAT'
 

--- a/spec/lib/tasks/export/submissions_spec.rb
+++ b/spec/lib/tasks/export/submissions_spec.rb
@@ -9,12 +9,13 @@ RSpec.describe 'rake export:submissions', type: :task do
     let(:args) { {} }
 
     let!(:no_business_submission) do
-      create(:no_business_submission)
+      create(:no_business_submission, framework: create(:framework, short_name: 'RM3756'))
     end
 
     let!(:submission) do
       create(
         :submission,
+        framework: create(:framework, short_name: 'RM3767'),
         aasm_state: 'completed',
         created_at: Time.zone.local(2018, 9, 18, 14, 20, 35),
         management_charge: 45000,
@@ -53,7 +54,7 @@ RSpec.describe 'rake export:submissions', type: :task do
       expect(output_lines.length).to eql(3)
       expect(output_lines.find { |line| line.match('PO1234') }).to eql(
         "#{submission.task.id},#{submission.id},supplier_accepted,file,xls,1,804.00,1,179.00,450.00," \
-        '0.015,2018-09-18T14:20:35Z,,,,,PO1234'
+        '0.01,2018-09-18T14:20:35Z,,,,,PO1234'
       )
     end
 

--- a/spec/models/export/coda_finance_report/row_spec.rb
+++ b/spec/models/export/coda_finance_report/row_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Export::CodaFinanceReport::Row do
   let(:task) { FactoryBot.create(:task, framework: framework, supplier: supplier, period_month: 8, period_year: 2018) }
-  let(:framework) { FactoryBot.create(:framework, coda_reference: 401234) }
+  let(:framework) { FactoryBot.create(:framework, short_name: 'RM1070', coda_reference: 401234) }
   let(:supplier) { FactoryBot.create(:supplier, coda_reference: 'C012345') }
   let(:submission) do
     FactoryBot.create(
@@ -53,7 +53,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
   end
 
   it 'reports the management charge rate as ‘Commission %’' do
-    expect(cg_report_row.commission_percent).to eq '0.015'
+    expect(cg_report_row.commission_percent).to eq '0.005'
   end
 
   it 'reports the sector as ‘End User’' do
@@ -113,8 +113,8 @@ RSpec.describe Export::CodaFinanceReport::Row do
     end
 
     it 'reports the total management charge, scoped to the sector, as ‘Commission’' do
-      expect(cg_report_row.commission).to eq '18.45'
-      expect(wps_report_row.commission).to eq '-6.43'
+      expect(cg_report_row.commission).to eq '6.15'
+      expect(wps_report_row.commission).to eq '-2.14'
     end
 
     it 'handles sales amounts written as a human-readable number' do
@@ -125,11 +125,11 @@ RSpec.describe Export::CodaFinanceReport::Row do
         data: { 'Total Cost (ex VAT)' => ' 2,428.95 ', 'Customer URN' => health_dept.urn }
       )
       expect(cg_report_row.inf_sales).to eq '3659.40'
-      expect(cg_report_row.commission).to eq '54.89'
+      expect(cg_report_row.commission).to eq '18.29'
     end
 
     it 'handles no business submissions, reporting them as zero sales and commission' do
-      no_business_submission = FactoryBot.create(:no_business_submission)
+      no_business_submission = FactoryBot.create(:no_business_submission, framework: framework)
       row = Export::CodaFinanceReport::Row.new(no_business_submission, Customer.sectors[:central_government])
 
       expect(row.inf_sales).to eq '0.00'

--- a/spec/models/export/submissions/extract_spec.rb
+++ b/spec/models/export/submissions/extract_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe Export::Submissions::Extract do
           it { is_expected.to be_nil }
         end
       end
+
+      describe '#_framework_short_name as a projection on the Submission model' do
+        it 'returns the submission’s framework short_name' do
+          expect(extract_file_submission._framework_short_name).to eq(file_submission.framework.short_name)
+          expect(extract_no_business_submission._framework_short_name)
+            .to eq(extract_no_business_submission.framework.short_name)
+        end
+      end
     end
   end
 end

--- a/spec/models/export/submissions/row_spec.rb
+++ b/spec/models/export/submissions/row_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe Export::Submissions::Row do
   end
 
   describe '#management_charge_rate' do
-    subject { row.management_charge_value }
-    it 'is fixed to a constant at present, expected to change Oct 2018' do
-      expect(row.management_charge_rate).to eql('0.015')
+    let(:submission) { double 'Submission', _framework_short_name: 'RM1031' }
+    it 'returns the rate for the framework identified by _framework_short_name as a decimal' do
+      expect(row.management_charge_rate).to eql('0.005')
     end
   end
 

--- a/spec/models/framework/definition_spec.rb
+++ b/spec/models/framework/definition_spec.rb
@@ -10,12 +10,20 @@ RSpec.describe Framework::Definition do
         it 'returns that framework' do
           expect(definition.framework_short_name).to eql(framework_short_name)
         end
+
+        it 'reports the management charge' do
+          expect(definition.management_charge_rate).to eq(BigDecimal('1.5'))
+        end
       end
 
       context 'and it has slashes in it' do
         let(:framework_short_name) { 'CM/OSG/05/3565' }
         it 'returns that framework' do
           expect(definition.framework_short_name).to eql(framework_short_name)
+        end
+
+        it 'reports the management charge' do
+          expect(definition.management_charge_rate).to eq(BigDecimal('0'))
         end
       end
     end

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe Framework do
   it { is_expected.to have_many(:suppliers).through(:agreements) }
   it { is_expected.to have_many(:submissions) }
 
+  describe '#management_charge_rate' do
+    let(:rm3756) { Framework.new(short_name: 'RM3756') }
+
+    it 'reports the rate of the framework definition' do
+      expect(rm3756.management_charge_rate).to eq BigDecimal('1.5')
+    end
+  end
+
   describe 'validations' do
     subject { Framework.create(short_name: 'test') }
     it { is_expected.to validate_presence_of(:short_name) }


### PR DESCRIPTION
Updates the framework definitions to include their management charge rates and wires them into the coda finance report and the data warehouse export for submissions.