### PR TITLE
Report dates in the expected date format during export

### DIFF
--- a/app/models/export/contracts/row.rb
+++ b/app/models/export/contracts/row.rb
@@ -22,8 +22,8 @@ module Export
           value_for('CustomerContactName', default: nil),
           value_for('CustomerContactNumber', default: nil),
           value_for('CustomerContactEmail', default: nil),
-          value_for('ContractStartDate'),
-          value_for('ContractEndDate'),
+          value_for('ContractStartDate', default: nil),
+          value_for('ContractEndDate', default: nil),
           value_for('ContractValue'),
           value_for('ContractAwardChannel'),
           *values_for_additional

--- a/app/models/export/contracts/row.rb
+++ b/app/models/export/contracts/row.rb
@@ -22,14 +22,24 @@ module Export
           value_for('CustomerContactName', default: nil),
           value_for('CustomerContactNumber', default: nil),
           value_for('CustomerContactEmail', default: nil),
-          value_for('ContractStartDate', default: nil),
-          value_for('ContractEndDate', default: nil),
+          contract_start_date,
+          contract_end_date,
           value_for('ContractValue'),
           value_for('ContractAwardChannel'),
           *values_for_additional
         ]
       end
       # rubocop:enable Metrics/AbcSize
+
+      private
+
+      def contract_start_date
+        formatted_date value_for('ContractStartDate', default: nil)
+      end
+
+      def contract_end_date
+        formatted_date value_for('ContractEndDate', default: nil)
+      end
     end
   end
 end

--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -10,7 +10,7 @@ module Export
           value_for('CustomerURN'),
           value_for('CustomerName'),
           value_for('CustomerPostCode'),
-          value_for('InvoiceDate'),
+          invoice_date,
           value_for('InvoiceNumber'),
           value_for('SupplierReferenceNumber', default: nil),
           value_for('CustomerReferenceNumber', default: nil),
@@ -31,6 +31,12 @@ module Export
         ]
       end
       # rubocop:enable Metrics/AbcSize
+
+      private
+
+      def invoice_date
+        formatted_date value_for('InvoiceDate')
+      end
     end
   end
 end

--- a/app/models/export/submission_entry_row.rb
+++ b/app/models/export/submission_entry_row.rb
@@ -6,6 +6,9 @@ module Export
   #
   # These rows also define 8 additional ++AdditionalN++ fields.
   class SubmissionEntryRow < CsvRow
+    US_DATE_FORMAT = %r(^(\d{1,2})\/(\d{1,2})\/(\d{2})$)
+    UK_DATE_FORMAT = %r(^(\d{1,2})\/(\d{1,2})\/(\d{4})$)
+
     def value_for(destination_field, default: NOT_IN_DATA)
       source_field = source_field_for(destination_field)
       model.data.fetch(source_field, default)
@@ -15,6 +18,18 @@ module Export
       (1..8).map do |n|
         value_for("Additional#{n}", default: nil)
       end
+    end
+
+    def formatted_date(date_string)
+      if date_string&.match UK_DATE_FORMAT
+        Date.strptime(date_string, '%d/%m/%Y').iso8601
+      elsif date_string&.match US_DATE_FORMAT
+        Date.strptime(date_string, '%m/%d/%y').iso8601
+      else
+        date_string
+      end
+    rescue ArgumentError
+      date_string
     end
 
     private

--- a/spec/lib/tasks/export/contracts_spec.rb
+++ b/spec/lib/tasks/export/contracts_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe 'rake export:contracts', type: :task do
     it 'writes #NOTINDATA for fields it cannot map' do
       expect(output_lines[2]).to eql(
         "#{contract2.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA," \
-        ',,,,,,,,,' \
-        '#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,,,,,,,'
+        ',,,,,,,,,,,' \
+        '#NOTINDATA,#NOTINDATA,,,,,,,,'
       )
     end
 

--- a/spec/lib/tasks/export/contracts_spec.rb
+++ b/spec/lib/tasks/export/contracts_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'rake export:contracts', type: :task do
       expect(output_lines[1]).to eql(
         "#{contract.submission_id},10010915,Government Legal Department,WC1B 4ZZ,471600.00001,"\
         'DWP - Claim by Mr I Dontexist,1,Contentious Employment,,,,,,,,,'\
-        '6/27/18,6/27/20,5000.00,Further Competition,N/A,N,Central Government Department,N,0.00,15,,'
+        '2018-06-27,2020-06-27,5000.00,Further Competition,N/A,N,Central Government Department,N,0.00,15,,'
       )
     end
 

--- a/spec/lib/tasks/export/invoices_spec.rb
+++ b/spec/lib/tasks/export/invoices_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'rake export:invoices', type: :task do
     it 'writes each invoice to that output' do
       expect(output_lines.length).to eql(3)
       expect(output_lines[1]).to eql(
-        "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,5/31/18,3307957,DEP/0008.00032,"\
+        "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,2018-05-31,3307957,DEP/0008.00032,"\
         'GITIS Terms and Conditions,1,Contracts,Core,,Legal Director/Senior Solicitor,,Hourly,151.09,-0.9,-135.98,,'\
         '-27.20,,0.00,0.00,0.00,N/A,Time and Material,,,'
       )

--- a/spec/models/export/submission_entry_row_spec.rb
+++ b/spec/models/export/submission_entry_row_spec.rb
@@ -51,4 +51,31 @@ RSpec.describe Export::SubmissionEntryRow do
       end
     end
   end
+
+  describe '#format_date returning dates as ISO8601' do
+    let(:row) { Export::SubmissionEntryRow.new(entry) }
+    let(:entry) { double 'SubmissionEntry' }
+
+    it 'handles DD/MM/YYYY date strings' do
+      expect(row.formatted_date('12/10/2018')).to eq '2018-10-12'
+      expect(row.formatted_date('1/1/2018')).to eq '2018-01-01'
+      expect(row.formatted_date('21/9/2017')).to eq '2017-09-21'
+    end
+
+    it 'handles US-formatted MM/DD/YY date strings' do
+      expect(row.formatted_date('9/10/18')).to eq '2018-09-10'
+      expect(row.formatted_date('8/1/18')).to eq '2018-08-01'
+      expect(row.formatted_date('2/28/17')).to eq '2017-02-28'
+      expect(row.formatted_date('3/28/19')).to eq '2019-03-28'
+    end
+
+    it 'returns the input value for non-matching dates' do
+      expect(row.formatted_date(nil)).to be_nil
+      expect(row.formatted_date('')).to eq ''
+    end
+
+    it 'returns the input value for invalid dates' do
+      expect(row.formatted_date('13/28/19')).to eq '13/28/19'
+    end
+  end
 end


### PR DESCRIPTION
At the moment, dates are being ingested by the lambda-based ingest
process as strings in consistently inconsistent way: they either appear
as "MM/DD/YY" or "DD/MM/YYYY"*. The export needs to report them in
ISO8601 format. This makes that the case for the date fields we have
known sheet mappings for.

Note that this does not cover all cases where we have ingested a date as
there are other date fields that sometimes map to the additional fields.
For example RM3710 maps 'Lease Start Date' to 'Additional8' in the
export. To handle these cases we'll need a more sophisticated solution
that introspects on the field definitions in the framework definitions
to determine when the value should be formatted as a date, but
that's a more involved piece of work that we don't have time for right
now (there is a pressure to deliver the export asap so business/finance
can perform the necessary checks and invoicing). Once we started the
work to perform validations in Ruby (leaning on ActiveModel), we'll have
the necessary plumbing in place to determine if a given field is a date
and at that point can encapsulate the formatting so it happens
automatically inside `Export::SubmissionEntryRow#value_for` based on
each framework's definition instead of explicitly in
`Export::Invoices::Row` and `Export::Contracts::Row`.

Additionally/alternatively we expect to fix/replace ingest such that
dates are ingested and validated in a consistent format that may make
this redundant.

*: mostly. turns out there are actually a couple of instances in the production data that don't, hence the rescuing for invalid dates.