### PR TITLE
Fix RM3767 framework definition mismatches

### DIFF
--- a/app/models/framework/definition/RM3767.rb
+++ b/app/models/framework/definition/RM3767.rb
@@ -29,9 +29,9 @@ class Framework
         field 'UNSPSC', :integer, exports_to: 'UNSPSC'
         field 'Unit of Purchase', :string, exports_to: 'UnitType'
         field 'Price per Unit', :decimal, exports_to: 'UnitPrice'
-        field 'Total Cost (Ex VAT)', :decimal, exports_to: 'InvoiceValue'
+        field 'Total Cost (ex VAT)', :decimal, exports_to: 'InvoiceValue'
         field 'Quantity', :decimal, exports_to: 'UnitQuantity'
-        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'VAT Amount Charged', :decimal, exports_to: 'VATCharged'
         field 'Cost Centre', :string
         field 'Contract Number', :string
         field 'Tyre Grade', :string, exports_to: 'Additional1'

--- a/data/framework_miso_fields.csv
+++ b/data/framework_miso_fields.csv
@@ -285,9 +285,9 @@ ColumnId,TemplateId,FrameworkId,Name,SheetName,DestinationTable,FieldGroup,Short
 20663,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,Default,UNSPSC,UNSPSC,UNSPSC,UNSPSC,varchar,,System.Int32,True,False,Fleet,RM3767
 20664,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,Default,UnitOfPurchase,UnitOfPurchase,Unit of Purchase,UnitType,varchar,4,System.String,True,False,Fleet,RM3767
 20665,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,Default,UnitPrice,UnitPrice,Price per Unit,UnitPrice,varchar,,System.Decimal,True,False,Fleet,RM3767
-20666,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,Default,InvoiceLineTotal,InvoiceLineTotal,Total Cost (Ex VAT),InvoiceValue,varchar,,System.Decimal,True,False,Fleet,RM3767
+20666,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,Default,InvoiceLineTotal,InvoiceLineTotal,Total Cost (ex VAT),InvoiceValue,varchar,,System.Decimal,True,False,Fleet,RM3767
 20667,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,Default,UnitQuantity,UnitQuantity,Quantity,UnitQuantity,varchar,,System.Decimal,True,False,Fleet,RM3767
-20668,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,Default,VATCharged,VATCharged,VAT amount charged,VATCharged,varchar,,System.Decimal,True,False,Fleet,RM3767
+20668,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,Default,VATCharged,VATCharged,VAT Amount Charged,VATCharged,varchar,,System.Decimal,True,False,Fleet,RM3767
 20675,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,Default,CostCentre,CostCentre,Cost Centre,! do not export,varchar,255,System.String,True,,Fleet,RM3767
 20676,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,Default,ContractNumber,ContractNumber,Contract Number,! do not export,varchar,255,System.String,True,,Fleet,RM3767
 20660,915,683,Supply and Fit of Tyres (RM3767),InvoicesRaised,Invoices,User Defined,XCol1,XCol1,Tyre Grade,Additional1,varchar,9,System.String,True,,Fleet,RM3767


### PR DESCRIPTION
Both `'Total Cost (ex VAT)'` and `'VAT Amount Charged'` had case that didn't
match the case in the template file or the case used in the current
lambda-based ingest process, which was resulting in`'#NODATA'` being
reported in the data warehouse export.

It's also worth noting that although the definition contains a 'Customer
PostCode' field, the template doesn't have such a column. It appears
that at some point the column was removed from the template. We're
leaving it in place until some further investigation is carried out to
decide what's best to do.