### PR TITLE
Only backfill total_value on validated entries

### DIFF
--- a/db/data_migrate/20181009114237_backfill_submission_entry_total_value.rb
+++ b/db/data_migrate/20181009114237_backfill_submission_entry_total_value.rb
@@ -53,6 +53,7 @@ ActiveRecord::Base.connection.execute(
               ELSE data ->> 'Expected Total Order Value'
             END)
         ), '£ ,', ''
-      ) :: decimal;
+      ) :: decimal
+    WHERE submission_entries.aasm_state = 'validated';
 POSTGRESQL
 )


### PR DESCRIPTION
When this data migration was run on production it failed because their
are entries in the production data that do not match the expected format
for the totals fields, for example: "(17.60)" and "$£48.46". The safest
way to ensure this backfill will always work is to only perform the
backfill on entries that have been validated, thus ensuring they will
match the expected format.