### PR TITLE
Update finance report to report total spend across all frameworks

### DIFF
--- a/app/models/export/coda_finance_report/row.rb
+++ b/app/models/export/coda_finance_report/row.rb
@@ -96,10 +96,7 @@ module Export
       end
 
       def total_sales
-        submission.entries
-                  .invoices
-                  .sector(sector)
-                  .sum { |entry| numeric_string_to_number(entry.data['Total Cost (ex VAT)']) }
+        submission.entries.invoices.sector(sector).sum(:total_value)
       end
 
       def management_charge

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -22,4 +22,11 @@ namespace :export do
   task :contracts, [:output] => [:environment] do |_task, args|
     Export::Anything.new(Export::Contracts::Extract.all_relevant, args[:output]).run
   end
+
+  desc 'Export coda finance report to CSV'
+  task coda_finance_report: :environment do
+    export_path = "/tmp/coda_finance_report_#{Time.zone.today}.csv"
+    puts "Exporting to #{export_path}"
+    Export::CodaFinanceReport.new(Submission.completed, File.open(export_path, 'w')).run
+  end
 end

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     end
 
     trait :legal_framework_invoice_data do
+      total_value(-135.98)
       data do
         {
           'UNSPSC' => '80120000',
@@ -61,6 +62,7 @@ FactoryBot.define do
     end
 
     trait :legal_framework_contract_data do
+      total_value 5000
       data do
         {
           'Matter Name' => 'DWP - Claim by Mr I Dontexist',

--- a/spec/models/export/coda_finance_report/row_spec.rb
+++ b/spec/models/export/coda_finance_report/row_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :invoice_entry,
         :valid,
         submission: submission,
+        total_value: 801.50,
         data: { 'Total Cost (ex VAT)' => '801.50', 'Customer URN' => home_office.urn }
       )
     end
@@ -79,6 +80,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :invoice_entry,
         :valid,
         submission: submission,
+        total_value: 428.95,
         data: { 'Total Cost (ex VAT)' => '428.95', 'Customer URN' => health_dept.urn }
       )
     end
@@ -87,6 +89,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :invoice_entry,
         :valid,
         submission: submission,
+        total_value: -428.95,
         data: { 'Total Cost (ex VAT)' => '-428.95', 'Customer URN' => bobs_charity.urn }
       )
     end
@@ -95,6 +98,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :order_entry,
         :valid,
         submission: submission,
+        total_value: 1000,
         data: { 'Total Cost (ex VAT)' => '1000.00', 'Customer URN' => home_office.urn }
       )
     end
@@ -103,6 +107,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :order_entry,
         :valid,
         submission: submission,
+        total_value: 1200,
         data: { 'Total Cost (ex VAT)' => '1200.00', 'Customer URN' => bobs_charity.urn }
       )
     end
@@ -115,17 +120,6 @@ RSpec.describe Export::CodaFinanceReport::Row do
     it 'reports the total management charge, scoped to the sector, as ‘Commission’' do
       expect(cg_report_row.commission).to eq '6.15'
       expect(wps_report_row.commission).to eq '-2.14'
-    end
-
-    it 'handles sales amounts written as a human-readable number' do
-      FactoryBot.create(
-        :invoice_entry,
-        :valid,
-        submission: submission,
-        data: { 'Total Cost (ex VAT)' => ' 2,428.95 ', 'Customer URN' => health_dept.urn }
-      )
-      expect(cg_report_row.inf_sales).to eq '3659.40'
-      expect(cg_report_row.commission).to eq '18.29'
     end
 
     it 'handles no business submissions, reporting them as zero sales and commission' do

--- a/spec/models/export/coda_finance_report_spec.rb
+++ b/spec/models/export/coda_finance_report_spec.rb
@@ -27,12 +27,18 @@ RSpec.describe Export::CodaFinanceReport do
   end
   let(:submission_entry_1) do
     FactoryBot.build(
-      :invoice_entry, :valid, data: { 'Total Cost (ex VAT)' => '678.55', 'Customer URN' => home_office.urn }
+      :invoice_entry,
+      :valid,
+      total_value: 678.55,
+      data: { 'Total Cost (ex VAT)' => '678.55', 'Customer URN' => home_office.urn }
     )
   end
   let(:submission_entry_2) do
     FactoryBot.build(
-      :invoice_entry, :valid, data: { 'Total Cost (ex VAT)' => '123.45', 'Customer URN' => home_office.urn },
+      :invoice_entry,
+      :valid,
+      total_value: 123.45,
+      data: { 'Total Cost (ex VAT)' => '123.45', 'Customer URN' => home_office.urn },
     )
   end
 


### PR DESCRIPTION
A couple of the parts required for https://trello.com/b/A1vk6EAn/ccs-rmi-beta-sprints:

- Updates the coda finance report so it makes use of the new `submission_entries#total_value` column to report across all October frameworks
- Adds a Rake task to generate the report