### PR TITLE
Add missing inactive customers

### DIFF
--- a/db/data_migrate/20181015134534_import_missing_customers.csv
+++ b/db/data_migrate/20181015134534_import_missing_customers.csv
@@ -1,0 +1,2902 @@
+URN,CustomerName,Acronym,Address1,Address2,Address3,Town,County,Country,PostCode,Sector,Subsector,Active
+10013975,Fulford School,,Fulford Gate Heslington Lane,York,North Yorkshire,York,North Yorkshire,England,YO10 4FY,Wider Public Sector,Local Authority Maintained School (All Types),False
+10013908,Rural Development Service,,17 Smith Square,,,London,,England                       ,SW1P 3JR,Central Government,,False
+10013875,University Hospital of North Staffordshire NHS Trust,,Trust Headquarters,Prices Road,Hartshill,Stoke-on-Trent,Staffordshire,England,ST4 7LN,Wider Public Sector,Acute Trust,False
+10013849,Bath and District Citizens Advice Bureau,,2 Edgar Buildings,,,Bath,,England                       ,BA1 2EE,Wider Public Sector,Charity,False
+10013845,The Royal Parks,RPA,The Old Police House,Hyde Park,,London,,England                       ,W2 2UH,Central Government,Executive Agency,False
+10013703,West Yorkshire NHS Shared Services,,Phoenix House,Topcliffe Lane,Tingley,Wakefield,West Yorkshire                ,England                       ,WF3 1WE,Wider Public Sector,Support,False
+10013697,Central Police Training and Development Authority,,PO Box 208,,,Bedford,Bedfordshire                  ,England                       ,MK44 3WA,Central Government,,False
+10013566,North Tyneside Citizens Advice Bureau,,1 Roxburgh Terrace,,,Whitley Bay,Tyne and Wear                 ,England                       ,NE26 1DR,Wider Public Sector,Other,False
+10013556,Test,,Test,,,Test,,England                       ,Test,Wider Public Sector,,False
+10013554,Burton Hill School,,Burton Hill,,,Malmesbury,Wiltshire                     ,England                       ,SN16 0EG,Wider Public Sector,Specialist Schools,False
+10013553,Chiltern Cheshire Home,,Headquarters,Packhorse Road,,Gerrards Cross,Buckinghamshire               ,England                       ,SL9 8JT,Wider Public Sector,,False
+10013552,Sport England,,Bisham Abbey,,,Bisham,Buckinghamshire               ,England                       ,SL7 XXX,Central Government,NDPB,False
+10013477,Public Net,,PO Box 7003,,,Westcliffe on Sea,,England                       ,SS0 0TH,Wider Public Sector,Private Sector Enabler,False
+10013443,National Institute for Mental Health in England,NIMHE,"West Yorkshire Strategic Health Authority, Blenhei",Duncombe Street,,Leeds,West Yorkshire                ,England                       ,LS1 4PL,Central Government,Central Bodies,False
+10013442,Victim Support West Yorkshire,,Area Office,7 Parkview Court,St. Pauls Road,Shipley,West Yorkshire                ,England                       ,BD18 3DZ,Wider Public Sector,Charity,False
+10013433,International Oil Pollution Compensation Funds,,23 Portland House,Stag Place,,London,,England                       ,SW1E 5BH,Central Government,,False
+10013416,St Peter's School,,St. Peters School,Clifton,,York,North Yorkshire               ,England                       ,YO30 6AB,Wider Public Sector,School Other,False
+10013380,National Aggregation Body LLP,,Gainsborough House,2 Sheen Road,,Richmond,Surrey                        ,England                       ,TW9 1AE,Wider Public Sector,,False
+10013344,NHS North of Tyne North Tyneside Primary Care Trust,,"Northern Cancer Network, Equinox House",Silver Fox Way,Cobalt Business Park,Newcastle upon Tyne,Tyne and Wear                 ,England                       ,NE27 0QJ,Wider Public Sector,PCT - Commissioning,False
+10013302,NHS,,"N H S Clinical Governance Support Team, Second Flo",East Street,,Leicester,Leicestershire                ,England                       ,LE1 6NB,Wider Public Sector,Acute Trust,False
+10013271,States of Guernsey Health and Social Services Dept,,The Duchess ofKEN House,Le Vauquiedor,St. Andrew,Guernsey,Guernsey                      ,Channel Islands               ,GY6 8TW,Wider Public Sector,,False
+10013264,St Francis Westborough Primary School,,Southway,,,Guildford,Surrey                        ,England                       ,GU2 8DA,Wider Public Sector,Primary Schools,False
+10013259,Armed Forces Personnel Administration Agency,AFPAA,"Central Office, Building 182",Royal Air Force,Innsworth,Gloucester,Gloucestershire               ,England                       ,GL3 1HW,Central Government,Cross Service,False
+10013254,East End Partnership Ltd,,East End Partnership Ltd,78-80 Tollcross Road,,Glasgow,,Scotland                      ,G31 4XA,Wider Public Sector,Not for Profit,False
+10013221,HM Prison The Weare,,H M Prison Weare,,Castletown,Portland,Dorset                        ,England                       ,DT5 1PZ,Central Government,,False
+10013216,Atkins defence asset management,,Atkins Defence asset management,Kitchener Road,,Catterick Garrison,North Yorkshire               ,England                       ,DL9 4HE,Central Government,,False
+10013215,AFE Serviceline,,"AFE Serviceline, Building 6",Peronne Lines,Kitchener Road,Catterick Garrison,North Yorkshire               ,England                       ,DL9 4HE,Central Government,,False
+10013188,Ellesmere Port and Neston Borough Council,,Council Offices,4 Civic Way,,Ellesmere Port,Cheshire                      ,England                       ,CH65 0BE,Wider Public Sector,District Council,False
+10013170,Directorate of Information Systems,DIS,"Centre House,",79 Chichester Street,,Belfast,Antrim                        ,Northern Ireland              ,BT1 4JR,Wider Public Sector,NDPB,False
+10013167,Camborne Science and Community College,,Cranberry Road,Camborne,Cornwall,Camborne,Cornwall,England,TR14 7PP,Wider Public Sector,Local Authority Maintained School (All Types),False
+10013142,Her Majesty's Magistrates Courts Service Inspectorate,,8th Floor,Millbank,,London,,England                       ,SW1P 4QP,Central Government,,False
+10013138,Strategic Rail Authority,SRA,55 Victoria Street,,,London,,England                       ,SW1H 0EU,Central Government,,False
+10013116,Defence Procurement Reform,,"D L O, Building 400, North Site Monxton Road",Andover,Hampshire,Andover,Hampshire,England,SP11 8HJ,Central Government,TBA,False
+10013090,South Eastern Trains,,"South Eastern Trains Ltd, 41-45",Blackfriars Road,,London,,England                       ,SE1 8PG,Wider Public Sector,,False
+10013070,South Yorkshire NHS Supply Management Confederation,,"N H S Supplies, Millennium House, 30",Junction Road,,Sheffield,South Yorkshire               ,England                       ,S11 8XB,Wider Public Sector,GP Practice,False
+10013050,Portsmouth City Teaching PCT,,Personnel Dept,Locksway Road,,Southsea,Hampshire                     ,England                       ,PO4 8LD,Wider Public Sector,PCT - Commissioning,False
+10013005,Citizens Advice,,Citizens Advice Bureau,Wellington Place,Eastwood,Nottingham,Nottinghamshire               ,England                       ,NG16 3GB,Wider Public Sector,Charity,False
+10012528,W S Atkins Defence Services,,Building 30,"WSM Office, RAF High Wycombe",New Road,Walters Ash,Buckinghamshire               ,England                       ,HP14 4XU,Central Government,,False
+10012526,Freedom Of Information,,Address 1,Town/City,,Town/City,,England,XXXX,Wider Public Sector,TBA,False
+10012513,testing nav bar,,tghfgh,,,dhdf,,England                       ,dfhdfh,Central Government,,False
+10012506,Business Link Gloucestershire,,Main Road Shurdington,Cheltenham,Gloucestershire,Cheltenham,Gloucestershire,England,GL51 4GA,Central Government,TBA,False
+10012503,Statistics Commission,,Artillery House,11 - 19 Artillery Row,,London,,England                       ,SW1P 1RT,Central Government,NDPB,False
+10012501,Unisys,,Test on live system to be deleted,,,London,,England                       ,ZZ1 1ZZ,Wider Public Sector,Private Sector Enabler,False
+10012500,Onyx Software UK Ltd,,Test for live system to be deleted,,,Bracknell,,England                       ,ZZ1 1ZZ,Wider Public Sector,Private Sector Enabler,False
+10012495,Special Health Board,,Main Office,,, ,,England                       ,OO,Wider Public Sector,Private Sector Enabler,False
+10012484,RAF Museum,,Main Office,,,Shifnal,Shropshire                    ,England                       ,TF11 8UP,Central Government,RAF,False
+10012475,Northampton Tax Office,,Main Office,,, ,,England                       ,OO,Wider Public Sector,Private Sector Enabler,False
+10012473,North West Division NHS Supplies Authority,,Main Office,,, ,,England                       ,OO,Wider Public Sector,GP Practice,False
+10012471,Normalair Garrett Ltd,,Main Office,,, ,,England                       ,OO,Wider Public Sector,Private Sector Enabler,False
+10012470,NHS Telecommunications Branch,,19 Calthorpe Road,Edgbaston,,Birmingham,West Midlands                 ,England                       ,B15 1RP,Wider Public Sector,Acute Trust,False
+10012464,Manorbier Youth Hostel,,Main Office,,, ,,England                       ,OO,Wider Public Sector,Private Sector Enabler,False
+10012463,Manor Cheshire Home,,Main Office,,, ,,England                       ,OO,Wider Public Sector,Private Sector Enabler,False
+10012450,HMNB Gibralter,,Gibralter Logistics Unit,Room 13 Building 70,HMNB Gibraltar, ,,Gibraltar                     ,BFPO 52,Wider Public Sector,Private Sector Enabler,False
+10012442,DSTL,,Main Office,,, ,,England                       ,OO,Wider Public Sector,Private Sector Enabler,False
+10012423,Chester-Le-Street District Council,,Newcastle Road,,,Chester-le-Street,County Durham                 ,England                       ,DH3 3UT,Wider Public Sector,District Council,False
+10012410,Lygon Almshouses The,,Lygon House,313 Fulham Palace Road,,London,,England                       ,SW6 6TH,Wider Public Sector,Private Sector Enabler,False
+10012403,Treasury Solicitors Department,,Queen Annes Chambers,28 Broadway,,LONDON,,England                       ,SW1H 9JS,Central Government,,False
+10012402,Training and Development Agency for Schools,,"13th Floor, Portland House",Bressenden Place,,LONDON,,England                       ,SW1E 5TT,Central Government,NDPB,False
+10012399,RSI,,Wyndham House,189 Marsh Wall,,LONDON,,England                       ,E14 9SX,Wider Public Sector,Private Sector Enabler,False
+10012394,Office of the Parliamentary Counsel,,36 Whitehall,,,LONDON,,England                       ,SW1A 2AY,Central Government,,False
+10012392,OGCbuying.solutions,,5th Floor Royal Liver Building,Pier Head,,LIVERPOOL,,England                       ,L3 1PE,Central Government,,False
+10012373,Joint Entrance Clearance,,Ist Floor 89 Albert Embankment,,,LONDON,,England                       ,SE1 7TP,Wider Public Sector,Private Sector Enabler,False
+10012360,Emergency Planning College,,The Hawkshill,Easingwold,,YORK,North Yorkshire               ,England                       ,YO61 3EG,Central Government,,False
+10012358,EAT,,1st Floor Audit House,58 Victoria Street,,LONDON,,England                       ,EC4Y 0DS,Wider Public Sector,Private Sector Enabler,False
+10012351,(Closed) Competition Commission,,7th Floor Victoria House,London,Greater London,London,Greater London,England,WC1B 4AD,Central Government,TBA,False
+10012340,Her Majestys Treasury,,Allington Towers,19 Allington St,,London,,England                       ,SW16 5EB,Central Government,,False
+10012333,THORNTON DJ,,Queensview Medical Centre,Thornton Road,,Northampton,,England                       ,NN2 6LS,Wider Public Sector,Private Sector Enabler,False
+10012331,Newlink Project Ltd The,,Unit 3 Lenton Business Centre,Lenton Boulevard,,Nottingham,,England                       ,NG7 2BY,Wider Public Sector,Private Sector Enabler,False
+10012326,Map Squad The,,Wessex Centre,Hadleigh Street,,London,,England                       ,E2 0LB,Wider Public Sector,Private Sector Enabler,False
+10012289,Luton Citizens Advice Bureau,CAB,24-26 King Street,,,Luton,Bedfordshire                  ,England                       ,LU1 2DP,Wider Public Sector,Charity,False
+10012273,Citizens Advice Bureau Swindon,CAB,Faringdon House,1 Faringdon Road,,Swindon,Wiltshire                     ,England                       ,SN1 5AR,Wider Public Sector,Charity,False
+10012271,Southern Crimestoppers,,107 Preston Drove,,,Brighton,,England                       ,BN1 6EW,Wider Public Sector,Private Sector Enabler,False
+10012270,Castlemilk Youth Complex,,39 Ardencraig Road,Castlemilk,,Glasgow,,Scotland                      ,G45 0EQ,Wider Public Sector,Private Sector Enabler,False
+10012266,Race Equality Team,,Northamptonshire County Council,Spencer Centre,Lewis Road,Northampton,,England                       ,NN5 7BJ,Wider Public Sector,Private Sector Enabler,False
+10012263,Moorlands Day Service,,Buxton Road,,,Leek,,England                       ,ST13 6NF,Wider Public Sector,Private Sector Enabler,False
+10012260,MLA,,17 Main Street,,,Crumlin,,Northern Ireland              ,BT29 4UR,Wider Public Sector,Private Sector Enabler,False
+10012254,New Milton and District CAB,,2 Ashley Road,,,New Milton,,England                       ,BH25 6AS,Wider Public Sector,Private Sector Enabler,False
+10012238,Provost Technical Support Unit,,Roussillon Barracks,Broyle Road,,Chichester,West Sussex                   ,England                       ,PO19 6BL,Wider Public Sector,Private Sector Enabler,False
+10012235,Prison Fellowship NI,,39 University Street,,,Belfast,,Northern Ireland              ,BT7 1FY,Wider Public Sector,Private Sector Enabler,False
+10012233,Devon Youth Service - Exeter,,Centre Exe,The Old School House,Exwick Road,Exeter,,England                       ,EX4 2AT,Wider Public Sector,Private Sector Enabler,False
+10012232,J6 CIS3 HQ BFC,,Headquarters British Forces Cyprus,J6 CIS3,HQ BFC, ,,Cyprus                        ,BFPO53,Wider Public Sector,Private Sector Enabler,False
+10012228,Shopmobility Stockport,,Level 2,Merseyway Car Park,,Stockport,,England                       ,SK1 1PD,Wider Public Sector,Private Sector Enabler,False
+10012227,Lytham St Annes High Tech,,Worsley Road,,,Lytham St Annes,,England                       ,FY8 4DG,Wider Public Sector,Private Sector Enabler,False
+10012226,Adswood Youth Centre,,Neston Grove,Adswood,,Stockport,,England                       ,SK3 8PH,Wider Public Sector,Private Sector Enabler,False
+10012224,Plymouth City Centre,,Chief Executives Department,"Floor 1,",Civic Centre,Plymouth,,England                       ,PL1 2EW,Wider Public Sector,Private Sector Enabler,False
+10012221,Riversides School - Worcester,,Thorneloe Road,,,Worcester,,England                       ,WR1 3HZ,Wider Public Sector,Private Sector Enabler,False
+10012217,Rochdale and District Citizens Advice Bureau,CAB,Middleton CAB,Milton Street,Middleton,Manchester,Greater Manchester            ,England                       ,M24 5TU,Wider Public Sector,Charity,False
+10012207,C2k,,c/o Ashfield Boys School,Holywood Road,,Belfast,,Northern Ireland              ,BT4 2LY,Wider Public Sector,Private Sector Enabler,False
+10012200,Downham and Bellingham EAZ,,Elfrida Primary School,Elfrida Crescent,Bellingham,London,,England                       ,SE6 3EN,Wider Public Sector,Private Sector Enabler,False
+10012198,Keeper of Privy Purse The,,Information Systems Management,Buckingham Palace,,London,,England                       ,SW1A 1AA,Wider Public Sector,Private Sector Enabler,False
+10012183,Stockton on Tees Area Child Protection Committee,,Review and Development Unit,Parkside,Melrose Avenue,Billingham,,England                       ,TS23 2JH,Wider Public Sector,Private Sector Enabler,False
+10012166,Derwent Community Team,,Beaufort Street Business Centre,Beaufort Street,,Derby,,England                       ,DE21 6AX,Wider Public Sector,Private Sector Enabler,False
+10012151,Office of the Scottish Charity Regulator,,Argyle House,Marketgait,,Dundee,,Scotland                      ,DD1 1QP,Wider Public Sector,Private Sector Enabler,False
+10012149,Mosborough Townships Under Fives Service,,Station Road,,,Sheffield,,England                       ,S20 3GU,Wider Public Sector,Private Sector Enabler,False
+10012145,1st Regiment RHA,,Welfare Centre,Assaye Barracks,,Tidworth,Wiltshire                     ,England                       ,SP9 7AB,Central Government,,False
+10012139,North Tyneside Challenge,,Howard House,Saville Street,,North Shields,,England                       ,NE30 1NT,Wider Public Sector,Private Sector Enabler,False
+10012120,Dame Elizabeth Cadbury TC,,Woodgrove Road,Bourneville,,Birmingham,West Midlands                 ,England                       ,B30 1UL,Wider Public Sector,Private Sector Enabler,False
+10012110,St Katherines School - Canvey,,Hilton Road,,,Canvey Island,,England                       ,SS8 9QA,Wider Public Sector,Private Sector Enabler,False
+10012104,Ridgeway Primary Nursery Unit,,Off Park Avenue,,,South Shields,,England                       ,NE34 8QL,Wider Public Sector,Private Sector Enabler,False
+10012089,Pensby High School for Boys,,Irby Road,,,Heswall,,England                       ,CH61 6XN,Wider Public Sector,Private Sector Enabler,False
+10012086,St Annes School - Chelmsford,,154 New London Road,,,Chelmsford,,England                       ,CM2 0AW,Wider Public Sector,Private Sector Enabler,False
+10012080,Milford Towers Community Association,,Flat 529 Milford Towers,Thomas Lane,Catford,London,,England                       ,SE6 4SA,Wider Public Sector,Private Sector Enabler,False
+10012078,School of Dental Science,,Dept of Restorative Dentistry,Framlington Place,,Newcastle upon Tyne,,England                       ,NE2 4BW,Wider Public Sector,Private Sector Enabler,False
+10012075,High Greave Infants,,High Greave Road,East Herringthorpe,,Rotherham,,England                       ,S65 3LZ,Wider Public Sector,Private Sector Enabler,False
+10012066,St Davids RC School - Swansea,,West Cross Avenue,West Cross,,Swansea,,Wales                         ,SA3 5TS,Wider Public Sector,Private Sector Enabler,False
+10012065,Highcrest Community School,,Hatters Lane,,,High Wycombe,,England                       ,HP13 7NQ,Wider Public Sector,Private Sector Enabler,False
+10012056,Ronald Openshaw Nursery Education Centre,,Henniker Road,Stratford,,London,,England                       ,E15 1JP,Wider Public Sector,Private Sector Enabler,False
+10012045,Glenburn Health Centre,,Fairway Avenue,,,Paisley,,Scotland                      ,PA2 8DX,Wider Public Sector,Private Sector Enabler,False
+10012040,Mardon Associates,,Mardon Group Learning Centre,1 Sussex Road,,Southport,,England                       ,PR9 0SS,Wider Public Sector,Private Sector Enabler,False
+10012013,Heathfield High School,,Belle Vue Road,Earl Shilton,Nottinghamshire,Earl Shilton,Nottinghamshire,England,LE9 8AA,Wider Public Sector,Local Authority Maintained School (All Types),False
+10012011,Oakdin Montessori Kindergarten Ltd,,67 Perry Street,,,Billericay,,England                       ,CM12 0NA,Wider Public Sector,Private Sector Enabler,False
+10011989,Priory School - Bury St Edmunds,,Mount Road,,,Bury St Edmunds,,England                       ,IP32 7BH,Wider Public Sector,Private Sector Enabler,False
+10011987,St Josephs CP - Dorking,,Norfolk Road,,,Dorking,,England                       ,RM4 3JA,Wider Public Sector,Private Sector Enabler,False
+10011985,Newtown Medical Practice,,Park Street,,,Newtown,,Wales                         ,SY16 1ZF,Wider Public Sector,Private Sector Enabler,False
+10011978,Wodensborough CTC,,Hyde Road,,,Wednesbury,,England                       ,WS10 0DR,Wider Public Sector,Private Sector Enabler,False
+10011973,Ysgol Caer Felin,,Pencader,,,Pencader,,Wales                         ,SA39 9AA,Wider Public Sector,Education,False
+10011966,Central College - London,,1-3 Rivington Street,,,London,,England                       ,EC2A 3DT,Wider Public Sector,,False
+10011965,Neovenator Community Org,,The Peckham Settlement,Goldsmith Road,Peckham,London,,England                       ,SE15 5TF,Wider Public Sector,Private Sector Enabler,False
+10011961,St James School - Malvern,,Croft Bank,,,Malvern,,England                       ,WR14 4DF,Wider Public Sector,Private Sector Enabler,False
+10011958,Women and Equality Unit,,10 Great George Street,,,London,,England                       ,SW1P 3AE,Wider Public Sector,Private Sector Enabler,False
+10011957,Coventry Sohihull and Warwickshire Partnership Lt,,Tower Court,Courtauds Way,,Coventry,,England                       ,CV6 5QT,Wider Public Sector,Private Sector Enabler,False
+10011940,NHS South of Tyne Sunderland Teaching Primary Care Trust,,Pemberton House,Colima Avenue,Sunderland Enterprise Park,Sunderland,Tyne and Wear                 ,England                       ,SR5 3XB,Wider Public Sector,PCT - Commissioning,False
+10011926,Isle of Wight Council - AV Technology,,c/o AV Technology,60 Dodnor Lane,Newport,Isle of Wight,,England                       ,PO30 5XD,Wider Public Sector,Private Sector Enabler,False
+10011923,NCALT,,Peel Centre,Aerodrome Road,,Hendon,,England                       ,NW9 5JE,Wider Public Sector,Private Sector Enabler,False
+10011919,West Cheshire Community Learning Partnership,,Project Office,Eaton Road,Handbridge,Chester,,England                       ,CH4 7ER,Wider Public Sector,Private Sector Enabler,False
+10011916,CASA,,University College London,1-19 Torrington Place,,London,,England                       ,WC1E 6BT,Wider Public Sector,Private Sector Enabler,False
+10011911,Healthy Living Centre Citywide Coordinator,,City of Sunderland,Civic Centre,,Sunderland,,England                       ,SR2 7DN,Wider Public Sector,Private Sector Enabler,False
+10011906,Senet Enterprise Centre,,Green Lane,Ashington,,Northumberland,,England                       ,NE63 0EF,Wider Public Sector,Private Sector Enabler,False
+10011903,St Edwards C of E,,London Road,,,Romford ,,England                       ,RM7 9NX,Wider Public Sector,Private Sector Enabler,False
+10011897,West Midlands Police (Bloxwich),,Station Street,,,Bloxwich,,England                       ,WS3 2PD,Wider Public Sector,Private Sector Enabler,False
+10011894,RFCA for Yorkshire and The Humber,,20 St Georges Place,,,York,,England                       ,YO24 1DS,Wider Public Sector,Private Sector Enabler,False
+10011888,South Yorkshire Police - Mossway,,Mossway Police Station,Mossway,,Sheffield,,England                       ,S20 7XX,Wider Public Sector,Private Sector Enabler,False
+10011875,Hammersmith and Fulham Education Department,,Cambridge House,Cambridge Grove,,London,,England                       ,W6 0LE,Wider Public Sector,Private Sector Enabler,False
+10011859,Royal School for the Blind Liverpool,,Church Road North,Wavertree,,Liverpool,,England                       ,L15 6TQ,Wider Public Sector,Private Sector Enabler,False
+10011858,Albion Surgery The,,6 Pincott Road,,,Bexleyheath,,England                       ,DA6 7LP,Wider Public Sector,Private Sector Enabler,False
+10011852,NACRO ISSP,,29 Welbeck Road,Byker Village,,Newcastle upon Tyne,,England                       ,NE6 2HU,Wider Public Sector,Private Sector Enabler,False
+10011850,Manchester Refugee Support Network,,St James Centre,95A Princess Road,Moss Side,Manchester,,England                       ,M14 4TH,Wider Public Sector,Private Sector Enabler,False
+10011849,Ysgol Llangelynnin,,Henryd,,,Conwy,,Wales                         ,LL32 8YB,Wider Public Sector,Education,False
+10011844,NSLEC (National Specialist Law Enforcement Centre),,PO Box 208,,,Bedford,,England                       ,MK44 3WA,Wider Public Sector,Private Sector Enabler,False
+10011843,WILLOWS RIR,,Delapre Medical Centre,Gloucester Avenue,,Northampton,,England                       ,NN4 9PT,Wider Public Sector,Private Sector Enabler,False
+10011833,Countryside Agency - North West Region The,,North West Regional Office,Floor 7 Bridgewater House,Whitworth Street,Manchester,,England                       ,M1 6LT,Wider Public Sector,Private Sector Enabler,False
+10011830,TD/TGDA - AVTE Co-ord,,HQ PTC,RAF Innsworth,,Gloucester,,England                       ,GL3 1EZ,Wider Public Sector,Private Sector Enabler,False
+10011820,TEARE CML,,Church Street Practice,The Health Centre,Garston Lane,Wantage,,England                       ,OX12 7AY,Wider Public Sector,Private Sector Enabler,False
+10011797,Monmouthshire Directorate of Learning- Education,,County Hall,Floor 5,,Cumbran,,Wales                         ,NP44 2XH,Wider Public Sector,Private Sector Enabler,False
+10011794,Cultural Services - Bury,,Resource Services,Bury Library,Textile Hall,Bury,,England                       ,BL9 0DG,Wider Public Sector,Private Sector Enabler,False
+10011777,WILLIS AW,,King Edward Road Surgery,Christchurch Medical Centre,,Northampton,,England                       ,NN1 5LY,Wider Public Sector,Private Sector Enabler,False
+10011774,Bolton Metro,,Commercial Services,Wellington House,Wellington Street,Bolton,,England                       ,BL3 5DX,Wider Public Sector,Private Sector Enabler,False
+10011772,Camphill Village Trust Ltd The,,29 Middlecave Road,,,Malton,,England                       ,YO17 7NE,Wider Public Sector,Private Sector Enabler,False
+10011769,Sure Start Crewe,,3rd Floot Wellington House,38-44 Delamere Street,,Crewe,,England                       ,CW1 2LW,Wider Public Sector,Private Sector Enabler,False
+10011761,Training Exchange The,,Bank House,86-90 Laughton Road,Dinnington,Sheffield,,England                       ,S25 2PS,Wider Public Sector,Private Sector Enabler,False
+10011759,WYCSA,,Brunswick Court,Bridge Street,,Leeds,West Yorkshire                ,England                       ,LS2  7RJ,Wider Public Sector,Private Sector Enabler,False
+10011755,Emergency Planning Unit,,Oxfordshire County Council,Woodeaton Manor,Woodeaton,Oxford,,England                       ,OX3 9GU,Wider Public Sector,Private Sector Enabler,False
+10011754,CICA,,Tay House,300 Bath Street,,Glasgow,,Scotland                      ,G2 4JR,Wider Public Sector,Private Sector Enabler,False
+10011752,PRIO (Promoting Regeneration in Oldham),,Hollingwood Business Centre,Albert Street,Hollingwood,Oldham,,England                       ,OL8 3QL,Wider Public Sector,Private Sector Enabler,False
+10011751,Newport County Borough Council - Sports,,Sports Development Unit,Newport Tennis Centre,Traston Lane,Newport,Gwent                         ,Wales                         ,NP19 4RR,Wider Public Sector,Local Government,False
+10011748,NACRO NCT,,247 Felixstowe Road,,,Ipswich,,England                       ,IP3 9BN,Wider Public Sector,Private Sector Enabler,False
+10011747,Place2Be The,,Wapping Telephone Exchange,Royal Mint Street,,London,,England                       ,E1 8LQ,Wider Public Sector,Private Sector Enabler,False
+10011744,Terence Higgins Trust,,52-54 Grays Inn Road,,,London,,England                       ,WC1X 8JV,Wider Public Sector,Private Sector Enabler,False
+10011722,UNCM Medical Biochemistry,,1st Floor,Tenours Building,Heath Park,Cardiff,,Wales                         ,CF14 4XN,Wider Public Sector,Private Sector Enabler,False
+10011721,Tenterden Infants,,Recreation Ground Road,,,Tenterden,,England                       ,TN30 6RA,Wider Public Sector,Private Sector Enabler,False
+10011700,St Michael with St John,,Swallow Drive,,,Blackburn,,England                       ,BB1 6LE,Wider Public Sector,Private Sector Enabler,False
+10011696,Meat Hygiene Service,,Kings Pool,1-2 Peasholme Green,,York,Yorkshire                     ,England                       ,YO1 7PR,Central Government,Executive Agency,False
+10011692,Legal Services Commission - North East,,Eagle Star House,Fenkle Street,,Newcastle upon Tyne,,England                       ,NE1 5RU,Wider Public Sector,Private Sector Enabler,False
+10011691,St Georges Medical School,,Dept Obs & Gynae,Tooting,,London,,England                       ,SW17 0RE,Wider Public Sector,Private Sector Enabler,False
+10011683,Treasury Solicitors Department,,Queen Annes Chambers,28 Broadway,,London,,England                       ,SW1H 9JS,Wider Public Sector,Private Sector Enabler,False
+10011681,Water Customer Consultation Panels,,Ochil House,,,Stirling,,Scotland                      ,FK7 7XE,Wider Public Sector,Private Sector Enabler,False
+10011674,Superintendent Registrar,,Worksop District,Queens Building,Potter Street,Worksop,,England                       ,S80 2AM,Wider Public Sector,Private Sector Enabler,False
+10011670,Victim Support Newham,,Durning Hall,Earlham Grove,,London,,England                       ,E7 9AB,Wider Public Sector,Charity,False
+10011667,NCH Cotswold Community,,Ashton Keynes,,,Swindon,,England                       ,SN6 6QU,Wider Public Sector,Private Sector Enabler,False
+10011665,Mackworth Business Supplies,,Mackworth College,Prince Charles Avenue,,Derby,,England                       ,DE22 4LR,Wider Public Sector,Private Sector Enabler,False
+10011664,Martin Centre,,University of Cambridge,6 Chaucer Road,,Cambridge,,England                       ,CB2 2ED,Wider Public Sector,Private Sector Enabler,False
+10011654,Lowestoft and Waveney Education Services Ltd,,St Peter Street,,,Lowestoft,,England                       ,NR32 2NB,Wider Public Sector,Private Sector Enabler,False
+10011638,Centre for Educational Leadership,,The Faculty of Education,UNW of Manchester,,Manchester,,England                       ,M13 9PL,Wider Public Sector,Private Sector Enabler,False
+10011637,Logistic Applications IPT,,Arncott,,,Bicester,,England                       ,OX25 1LP,Wider Public Sector,Private Sector Enabler,False
+10011623,Legal Services Commission East Midlands,,Regional Office,Fothergill House,16 King Street,Nottingham,,England                       ,NG1 2AS,Wider Public Sector,Private Sector Enabler,False
+10011613,Nat environ Research Council (Southampton),,Research Ship Unit,Southamptoms Oceanography Centre,European Way,Southampton,,England                       ,SO14 3ZH,Wider Public Sector,Private Sector Enabler,False
+10011612,Nat Environ Research Council (West Hoe),,Plymouth Marine Laboratory,Prospect Place,West Hoe,Plymouth,,England                       ,PL1 3DH,Wider Public Sector,Private Sector Enabler,False
+10011611,Nat Environ Research Council (Huntingdon),,CEH Monks Wood,Abbots Ripton,Huntingdon,Cambs,,England                       ,PE28 2LS,Wider Public Sector,Private Sector Enabler,False
+10011610,Nat Environ Research Council (Oban),,The Scottish Association for Marine Sciences,Dunstaffnage Marine Laboratory,Oban,Argyll,,Scotland                      ,PA34 4AD,Wider Public Sector,Private Sector Enabler,False
+10011609,Nat Environ Rsearch Council (Keyworth),,British Geological Survey,Kingsley Dunham Centre,Keyworth,Nottingham,,England                       ,NG12 5GG,Wider Public Sector,Private Sector Enabler,False
+10011607,Nat Environ Research Council (Cambridge),,British Antartic Survey,High Cross,Madingley Road,Cambridge,,England                       ,CB3 0ET,Wider Public Sector,Private Sector Enabler,False
+10011606,STEPHEN AA,,Linden Avenue Medical Centre,Linden Avenue,,Kettering,,England                       ,NN15 7NX,Wider Public Sector,Private Sector Enabler,False
+10011603,Dept of Arts Heritage Leisure Bradford Council,,Policy & Executive Support,4th Floor Jacobs Well,,Bradford,West Yorkshire                ,England                       ,BD1 5RW,Wider Public Sector,Private Sector Enabler,False
+10011600,USPG,,Partnership House,157 Waterloo Road,,London,,England                       ,SE1 8XA,Wider Public Sector,Private Sector Enabler,False
+10011589,St James Unit,,Beauchamp Lane,Conley,,Oxford,,England                       ,OX43CF,Wider Public Sector,Private Sector Enabler,False
+10011571,Unity House Day Centre,,Stanley Road,,,Worcester,,England                       ,WR5 1BE,Wider Public Sector,Private Sector Enabler,False
+10011563,Stockley Academy,,Appletree Avenue,,,West Drayton,,England                       ,UB7 8DA,Wider Public Sector,Private Sector Enabler,False
+10011547,Lord Chancellors Department,,105 Victoria Street,,,London,,England                       ,SW1E 6QT,Wider Public Sector,Private Sector Enabler,False
+10011546,National Investments and Loans Office,,1 King Charles Street,,,London,,England                       ,SW1A 2AP,Wider Public Sector,Private Sector Enabler,False
+10011542,Kings School - Macclesfield The,,Cumberland Street,,,Macclesfield,,England                       ,SK10 1DA,Wider Public Sector,Private Sector Enabler,False
+10011539,Ysgol Gynradd Mynyddcerrig,,Mynyddcerrig,Pontyberem,Llanelli,Carms,,Wales                         ,SA15 5BG,Wider Public Sector,Education,False
+10011529,GILES MB,,The Windsor Road Surgery,Windsor Road,Garstang,Preston,,England                       ,PR3 1ED,Wider Public Sector,Private Sector Enabler,False
+10011528,St Marys Mortuary Department,,St Mary's Hospital,Milton Road,,Portsmouth,,England                       ,PO3 6AD,Wider Public Sector,Private Sector Enabler,False
+10011523,SMITH TM,,Parliament Hill Surgery,113-117 Highgate Road,,London,,England                       ,NW5 1TR,Wider Public Sector,Private Sector Enabler,False
+10011522,Royal Free Hampstead NHS Trust,,Supplies Department,Pond Street,,London,,England                       ,NW3 2QG,Wider Public Sector,Acute Trust,False
+10011520,Trevethin Community School,,Penygarn Road,Pontypool,,Torfaen,,Wales                         ,NP4 8BG,Wider Public Sector,Private Sector Enabler,False
+10011504,Nearis,,Swan Buildings,20 Swan Street,,Manchester,,England                       ,M4 5JW,Wider Public Sector,Private Sector Enabler,False
+10011498,Queen Elizabeths Foundation,,Woodlands Road,,,Leatherhead,,England                       ,KT22 OLN,Wider Public Sector,Private Sector Enabler,False
+10011496,State of Jersey - Computer Services,,Cyril Le Marquand House,The Parade,St Helier,Jersey,,Channel Islands               ,JE4 8YA,Wider Public Sector,Private Sector Enabler,False
+10011495,Wycombe Grange (PRU) The,,56 Amersham Hill,,,High Wycombe,,England                       ,HP13 6PQ,Wider Public Sector,Private Sector Enabler,False
+10011489,Sussex Learning and Skills Council,,Princes House,53 Queens Road,Brighton,East Sussex,,England                       ,BN3 1AB,Wider Public Sector,Private Sector Enabler,False
+10011483,Youth Council for Northern Ireland,,Forestview,Purdys Lane,,Belfast,,Northern Ireland              ,BT8 7AR,Wider Public Sector,Private Sector Enabler,False
+10011482,Training and Development Services,,11-13 Bloomfield Avenue,,,Belfast,,Northern Ireland              ,BT5 5HD,Wider Public Sector,Private Sector Enabler,False
+10011462,Mayor and Commonality and Citizens of City of London The,,PO Box 270,Guildhall,,London,,England                       ,EC2P 2EJ,Wider Public Sector,Private Sector Enabler,False
+10011457,Greater Merseyside Enterprise Ltd,,Egerton House,2 Tower Road,,Birkenhead,,England                       ,CH41 1FN,Wider Public Sector,Private Sector Enabler,False
+10011452,East of England Broadband Network (E2BN),,Russell House,14 Dunstable Street,Ampthill,Bedford,,England                       ,MK45 2JT,Wider Public Sector,Private Sector Enabler,False
+10011447,Integration Authority,,MOD - Larch 3a 2308,,Abbey Wood,Bristol,,England                       ,BS34 8JH,Central Government,,False
+10011434,Comm for Patient and Public Involvement in Health,,9th Floor,Ladywood House,45 Stephenson Street,Birmingham,West Midlands                 ,England                       ,B2 4BY,Wider Public Sector,Private Sector Enabler,False
+10011429,MoD Directorate General Information,,Room 816,St Giles Court,1-13 St Giles High Street,London,,England                       ,WC2H 8LD,Central Government,,False
+10011427,FCO Language Group,,Foreign and Commonwealth Office,Old Admiralty Building,,London,,England                       ,SW1A 2PA,Central Government,Executive Agency,False
+10011426,Information Systems,,London Borough of Barnet,Town Hall,The Burroughs,London,,England                       ,NW4 4BG,Wider Public Sector,Private Sector Enabler,False
+10011425,Local Government Information House,,76-86 Turnmill St,,,London,,England                       ,SW1E 6SW,Wider Public Sector,Private Sector Enabler,False
+10011419,DCDS (EC)  MoD,,Directorate of Equipment Capability Combat Service,Room 343 Northumberland House,Northumberland Avenue,London,,England                       ,WC2N 58P,Wider Public Sector,Private Sector Enabler,False
+10011409,National Association of Citizens Advice Bureaux,,Myddelton House,115-123 Pentonville Road,,London,,England                       ,N1 9LZ,Wider Public Sector,Charity,False
+10011405,Royal Comm on Ancient and Hist Monuments of Wales,,Plas Crug,,,Aberystwyth,,Wales                         ,SY23 1NJ,Wider Public Sector,Private Sector Enabler,False
+10011402,Disabilities Rights Commission,,2nd Floor,Arndale House,,Manchester,,England                       ,M4 3AQ,Wider Public Sector,Private Sector Enabler,False
+10011398,NHS Executive South West,NHS,Westward House,Lime Kiln Close,Stoke Gifford,Bristol,,England                       ,BS34 8SR,Wider Public Sector,Acute Trust,False
+10011396,Norfolk and Norwich Millennium Company Ltd,,2nd Floor,Blackburn House,1 Theatre Street,NORWICH,,England                       ,NR2 1RG,Wider Public Sector,Private Sector Enabler,False
+10011395,Department for Social Development (Social Security Agency) The,,Service Delivery Project,Room 329 Castle Court,Royal Avenue,Belfast,,Northern Ireland              ,BT1 1DF,Wider Public Sector,Private Sector Enabler,False
+10011391,Dept of Health (Drugs Misuse Team),,Wellington House,,,London,,England                       ,SE1 8UG,Wider Public Sector,Private Sector Enabler,False
+10011390,Information Policy Unit,,NHS Executive Headquarters,Department of Health,Room 1N 35A Quarry House,Leeds,West Yorkshire                ,England                       ,LS2 7UE,Wider Public Sector,Private Sector Enabler,False
+10011383,Police Authority fo NI (PANI),,Technology Group,Lislea Drive,Lisburn Road,Belfast,County Antrim                 ,Northern Ireland              ,BT9 7JG,Wider Public Sector,Emergency,False
+10011379,Treasury's Solicitor's Department The,,Queen Anne's Chambers,28 Broadway,,London,,England                       ,SW1H 9JS,Wider Public Sector,Private Sector Enabler,False
+10011377,ITSG,,Peel Park Blackpool Industrial Estate Brunel Way,Blackpool,Tyne and Wear,Blackpool,Tyne and Wear,England,FY4 5ES,Central Government,NDPB,False
+10011374,Registry of Friendly Societies,,25 The North Colonnade,Canary Wharf,,London,,England                       ,E14 5HS,Wider Public Sector,Private Sector Enabler,False
+10011369,NCH,,Turner House,22 Lucerne Road,,London,,England                       ,N5 1TZ,Wider Public Sector,Private Sector Enabler,False
+10011362,National Blood Service (NHS Blood and Transplant),,NEWCASTLE BLOOD CENTRE,HOLLAND DRIVE,BARRACK ROAD,NEWCASTLE UPON TYNE,Tyne and Wear                 ,England                       ,NE2 4NQ,Central Government,Special Health Authority,False
+10011350,Medical Devices Agency,,Room 1206,Hannibal House,Elephant and Castle,London,,England                       ,SE1 6TQ,Wider Public Sector,GP Practice,False
+10011346,Commission for Social Care Inspection,CSCI,Kierran Cross,11 Strand,,London,,England                       ,WC2N 5HR,Central Government,NDPB,False
+10011341,Treasury Solicitors,,Queen Anne's Chambers,28 Broadway,,London,,England                       ,SW1H 9JS,Wider Public Sector,Private Sector Enabler,False
+10011338,Yorkshire and Humber Regional Aggregation Board,,Round Foundry Media Centre,Foundry Street,,Leeds,West Yorkshire                ,England                       ,LS11 5QP,Wider Public Sector,Private Sector Enabler,False
+10011337,Northern Ireland Procurement Service,,Room 247,Rosepark house,,Belfast,,Northern Ireland              ,BT4 3NR,Wider Public Sector,Private Sector Enabler,False
+10011335,Partnerships for Schools,P4S,Fifth Floor,8-10 Great George Street,,London,,England                       ,SW1P 3AE,Central Government,NDPB,False
+10011309,Merseyside Police,,Police HQ,PO Box 59,,Liverpool,Merseyside                    ,England                       ,L69 1JD,Wider Public Sector,Police Service,False
+10011294,Ysgor Gymraeg Bro Ogwr,,Princess Way,Brackla,,Bridgend,,Wales                         ,CF31 2LN,Wider Public Sector,Private Sector Enabler,False
+10011292,Ysgol Twm or Nant,,Rhyl Road,Dinbych,,Denbigh,,Wales                         ,LL16 3DP,Wider Public Sector,Education,False
+10011290,Ysgol Maes Dyfan,,Gibbonsdown Rise,,,Barry,,Wales                         ,CF63 1DT,Wider Public Sector,Education,False
+10011289,Ysgol Gynradd Amlwch,,Pen y Bonc Road,Amlwch,,Anglesey,,Wales                         ,LL68 9DY,Wider Public Sector,Education,False
+10011288,Ysgol Gymraeg Trelyn,,Commercial Street,Pangam,,Blackwood,,Wales                         ,NP12 3ST,Wider Public Sector,Education,False
+10011287,Ysgol Gymraeg Melin Gruffydd,,Erw Las,Whitchurch,,Cardiff,,Wales                         ,CF14 1NL,Wider Public Sector,Education,False
+10011286,Ysgol Gyfun Ystalyfera,,Glan-yr-Afon,Ystaly Fera,,Swansea,,Wales                         ,SA9 2JJ,Wider Public Sector,Education,False
+10011284,Ysgol Eirias,,Eirias Road,,,Colwyn Bay,,Wales                         ,LL29 7SP,Wider Public Sector,Education,False
+10011283,Ysgol Cynfran,,Dolwen Road,Llysfaer,,Colwyn Bay,,Wales                         ,LL29 8SS,Wider Public Sector,Education,False
+10011280,Youth and Community Services,,Solar Campus,Leasowe Road,,Wallasey,,England                       ,CH45 8LW,Wider Public Sector,Private Sector Enabler,False
+10011276,Yorkshire Forward Yorkshire and Humber Regional Development Agency,,Victoria House,2 Victoria Place,Holbeck,Leeds,West Yorkshire                ,England                       ,LS11 5AE,Central Government,NDPB,False
+10011275,Yorkshire Tourist Board,,312 Tadcaster Road,,,York,,England                       ,YO24 1GS,Wider Public Sector,Private Sector Enabler,False
+10011272,Yorkshire Cultural Consortium,,County Hall,Bond Street,,Wakefield,West Yorkshire                ,England                       ,WF1 2QW,Central Government,,False
+10011266,Yeshives Shaarei Torah Ltd,,38-40 Upper Park Road,Salford,,Manchester,,England                       ,M7 4GZ,Wider Public Sector,Private Sector Enabler,False
+10011264,Yeldall Manor,,Blakes Lane,Hare Hatch,,Reading,,England                       ,RG10 9XR,Wider Public Sector,Private Sector Enabler,False
+10011255,Wyre Forest Community Housing,,3 Foley Grove,Foley Business Park,Cookley,Kidderminster,,England                       ,DY11 7PT,Wider Public Sector,Private Sector Enabler,False
+10011253,Wymondham Medical Partnership,,Wymondham Medical Centre,Post Mill Close,,Wymondham,,England                       ,NR18 0RF,Wider Public Sector,Private Sector Enabler,False
+10011247,World Vision UK,,599 Avebury Boulevard,,,Milton Keynes,,England                       ,MK9 3PG,Wider Public Sector,Private Sector Enabler,False
+10011246,Worksop District,,Queens Building,Potter Street,,Worksop,,England                       ,S80 2AM,Wider Public Sector,Private Sector Enabler,False
+10011243,Work Permits UK,,ICD North (Home Office),Level 5,Moorfoot,Sheffield,,England                       ,S1 4PQ,Wider Public Sector,Private Sector Enabler,False
+10011241,Woolwich Health Team,,184 Frances Street,Woolwich,,London,,England                       ,SE18 5JS,Wider Public Sector,Private Sector Enabler,False
+10011240,Woolwich Garrison HQ,,"3c R A Barracks,Repository Road",,,London,,England                       ,SE18 4BB,Wider Public Sector,Private Sector Enabler,False
+10011239,Woolwich Common Community Centre,,16 Leslie Smith Square,Woolwich,,London,,England                       ,SE18 4DW,Wider Public Sector,Private Sector Enabler,False
+10011233,Woodland Trust,,Autumn Park,,,Grantham,,England                       ,NG31 9ED,Wider Public Sector,Private Sector Enabler,False
+10011229,Woodgrange Park Village Co-Op,,Estate Office,Bluebell Avenue,Manor Park,London,,England                       ,E12 6UJ,Wider Public Sector,Private Sector Enabler,False
+10011228,Woodgate Junior Infants,,Lutley Grove,,,Bartley Green,,England                       ,B32 3PN,Wider Public Sector,Private Sector Enabler,False
+10011225,Woodcroft Residential Home,,Abergele Rd,Rumney,,Cardiff,,Wales                         ,CF3 8RS,Wider Public Sector,Private Sector Enabler,False
+10011224,Womens Playhouse Trust,,The Wapping Hydrolic Power Station,Wapping Wall,,London,,England                       ,E1W 3ST,Wider Public Sector,Private Sector Enabler,False
+10011221,Women In Supported Housing,,Vernon House,80 Edna Street,,Hyde,,England                       ,SK14 1DR,Wider Public Sector,Private Sector Enabler,False
+10011220,Women Acting In Todays Society,,3 Raglan Road,Edgbaston,,Birmingham,West Midlands                 ,England                       ,B5 7RA,Wider Public Sector,Private Sector Enabler,False
+10011218,Wolverhampton Healthcare NHS Trust,,Clevelands/Leasowes,10-12 Tettenhall Road,,Wolverhampton,West Midlands                 ,England                       ,WV1 4SA,Wider Public Sector,Acute Trust,False
+10011217,Wolverhampton Girls' High,,Tettenhall Rd,,,Wolverhampton,,England                       ,WV6 7NP,Wider Public Sector,Private Sector Enabler,False
+10011216,Wolverhampton City PCT,,Coniston House,Chapel Ash,,Wolverhampton,West Midlands                 ,England                       ,WV3 0XE,Wider Public Sector,PCT - Commissioning,False
+10011215,Wolfson Foundation  (Isaac),,18-22 Haymarket,,,London,,England                       ,SW1Y 4DQ,Wider Public Sector,Private Sector Enabler,False
+10011211,Wirral Hospitals School and Home Education Service,,235 Leasowe Road,Wallasey,,Wallasey,,England                       ,CH45 8RE,Wider Public Sector,Private Sector Enabler,False
+10011204,Wimbledon VRO Enforcement,,137 Alexandra Road,,,London,,England                       ,SW19 7JY,Wider Public Sector,Private Sector Enabler,False
+10011203,Wiltshire Private Hospitals,,Capio New Hall Hospital,Bodenham,,Salisbury,,England                       ,SP5 4EY,Wider Public Sector,Private Sector Enabler,False
+10011202,Wilson and Garden,,520 Otley Road,Adel,,Leeds,West Yorkshire                ,England                       ,LS16 8DL,Wider Public Sector,Private Sector Enabler,False
+10011200,Wilmington Grammar School For Boys,,Common Lane,,,Dartford,,England                       ,DA2 7DA,Wider Public Sector,Private Sector Enabler,False
+10011193,William Morris Academy,,St Dunstans Road,,,London,,England                       ,W6 8RB,Wider Public Sector,Private Sector Enabler,False
+10011185,Will Charities of Sir Henry S Wellcome,,183 Euston Road,,,London,,England                       ,NW1 2BE,Wider Public Sector,Private Sector Enabler,False
+10011180,Wilberforce Home For Blind,,187 Tadcaster Road,,,York,,England                       ,YO24 1GZ,Wider Public Sector,Private Sector Enabler,False
+10011178,Widney Dental Care,,76 Widney Road,Knowle,,Solihull,,England                       ,B93 9AW,Wider Public Sector,Private Sector Enabler,False
+10011177,Wick Village Tmc Ltd,,Anchor House,"25 Meadow Close,Hackney",,London,,England                       ,E9 5NZ,Wider Public Sector,Private Sector Enabler,False
+10011175,Whitgift Foundation,,North End,,,Croydon,,England                       ,CR9 1SS,Wider Public Sector,Private Sector Enabler,False
+10011172,Whiteley Homes Trust,,Whiteley Village,,,Walton-On-Thames,,England                       ,KT12 4EH,Wider Public Sector,Private Sector Enabler,False
+10011169,Whitechapel Art Gallery,,80-82 Whitechapel High Street,,,London,,England                       ,E1 7QX,Wider Public Sector,Private Sector Enabler,False
+10011168,White Young Green,,Arndale Court,Headingley,,Leeds,West Yorkshire                ,England                       ,LS6 2UJ,Wider Public Sector,Private Sector Enabler,False
+10011159,Westminster Technical College,,76 Vincent Square,,,London,,England                       ,SW1P 2PD,Wider Public Sector,Colleges other,False
+10011158,Westminster Society For People With Lear,,16a Croxley Rd,,,London,,England                       ,W9 3HL,Wider Public Sector,Private Sector Enabler,False
+10011154,Westminster Medical Centre,,Aldams Grove,,,Liverpool,,England                       ,L4 3TT,Wider Public Sector,Private Sector Enabler,False
+10011152,Westminster Health Care Ltd,,15 Normanton Road,Crowland,Bushey,Peterborough,,England                       ,PE6 0JJ,Wider Public Sector,Private Sector Enabler,False
+10011149,Westminster Citizens Advice Bureau,CAB,Westminster Council House,97-113 Marylebone Road,,London,,England                       ,NW1 5PT,Wider Public Sector,Charity,False
+10011147,WestLB,,33-36 Gracechurch Street,,,London,,England                       ,EC3V 0AX,Wider Public Sector,Private Sector Enabler,False
+10011142,Western Training and Enterprise Council,,PO Box 164,St Lawrence House 29-31 Broad Street,,Bristol,,England                       ,BS99 7HR,Central Government,,False
+10011141,Western Traffic Area Licensing Authority,,Denmark Street,,,Bristol,,England                       ,BS1 5DR,Wider Public Sector,Private Sector Enabler,False
+10011138,Western Infirmary,,Dumbarton Road,,,Glasgow,,Scotland                      ,G11 6NT,Wider Public Sector,Private Sector Enabler,False
+10011137,Western Challenge,,5 Redlane Court,Addington Road,,Reading,,England                       ,RG1 5QT,Wider Public Sector,Private Sector Enabler,False
+10011135,Westcliffe Dental Practice,,81-83 Westcliffe Drive,Layton,,Blackpool,,England                       ,FY3 7DH,Wider Public Sector,Private Sector Enabler,False
+10011134,Westcare Business Services,,Gransha Hospital,Lilac Villa 12c Gransha Park,Clooney Road,Londonderry,,Northern Ireland              ,BT47 6WJ,Wider Public Sector,Private Sector Enabler,False
+10011133,West Yorkshire Scouts,,Community Resources Centre,4 Deercroft Avenue,,Huddersfield,West Yorkshire                ,England                       ,HD3 3SH,Wider Public Sector,Private Sector Enabler,False
+10011129,West Park Community School,,West Road,Spondon,,Derby,,England                       ,DE21 7BT,Wider Public Sector,Private Sector Enabler,False
+10011128,West Pack,,Gipsyville Multi-Purpose Centre,728-730 Hessle Road,,Hull,,England                       ,HU4 6JA,Wider Public Sector,Private Sector Enabler,False
+10011123,West Minister Children's Soceity,,121 Marsham Street,,,London,,England                       ,SW1P 4LX,Wider Public Sector,Private Sector Enabler,False
+10011114,West London Sports Trust,,Kensington and Chelsea College,Carlyle Building,Hortensia Road,London,,England                       ,SW10 0QS,Wider Public Sector,Private Sector Enabler,False
+10011113,West London Mission,,St Luke's Centre,25a Wincott Street,,London,,England                       ,SE11 4NT,Wider Public Sector,Private Sector Enabler,False
+10011108,West Hill Baptist Church,,17 Southfields Road,Wandsworth,,London,,England                       ,SW18 1QW,Wider Public Sector,Private Sector Enabler,False
+10011104,West Gate City Learning Centre,,West Gate Community College,West Road,,Newcastle upon Tyne,,England                       ,NE4 9LU,Wider Public Sector,Private Sector Enabler,False
+10011103,West Dorset Health Design Practice,,Damers House Dorset County Hospital,Williams Avenue,,Dorchester,,England                       ,DT1 2JZ,Wider Public Sector,Private Sector Enabler,False
+10011100,Wesley House,,Wesley House,32 Jesus Lane,,Cambridge,,England                       ,CB5 8BJ,Wider Public Sector,Private Sector Enabler,False
+10011099,Wescott House,,Wescott House,Jesus Lane,,Cambridge,,England                       ,CB5 8BP,Wider Public Sector,Private Sector Enabler,False
+10011098,Weoley Castle Library,,(Birmingham City Council),76 Beckbury Road,Weoley Castle,Birmingham,West Midlands                 ,England                       ,B29 5HR,Wider Public Sector,Private Sector Enabler,False
+10011094,Welsh Refugee Council,,Unit 8,Williams Court,Trade Street,Cardiff,,Wales                         ,CF10 5DQ,Wider Public Sector,Private Sector Enabler,False
+10011091,Welsh Institute of Rural Study,,Llanbadarn Fawr,,,Aberystwyth,,Wales                         ,SY23 3AL,Wider Public Sector,Private Sector Enabler,False
+10011090,Welsh Historic Monuments,,Brunel House,2 Fitzalan Road,,Cardiff,,Wales                         ,CF2 1UY,Wider Public Sector,Private Sector Enabler,False
+10011088,Welsh Health Estates,,PO Box 182,Bevan House,Llanishen,Cardiff,,Wales                         ,CF4 5GS,Wider Public Sector,Private Sector Enabler,False
+10011087,Welsh Health Common Services Authority,,Crickhowell House,Pierhead Street,Capital Waterside,Cardiff,,Wales                         ,CF1 5XT,Wider Public Sector,Private Sector Enabler,False
+10011085,Welsh European Funding Office,,Cwm Cynon Business Park,Mountain Ash,,Rhonnda Cynon Taff,,Wales                         ,CF45 4ER,Wider Public Sector,Private Sector Enabler,False
+10011074,Watershead Arts Trust Ltd,,1 Cannons Road,Harbourside,,Bristol,,England                       ,BS1 5TX,Wider Public Sector,Private Sector Enabler,False
+10011064,War Pensions Agency,,Flowers Hill,,,Bristol,,England                       ,BS4 5LE,Central Government,Executive Agency,False
+10011063,Wansdyke District Council,,The Hollies,Midsomer Norton,,Bath,,England                       ,BA3 2DP,Wider Public Sector,District Council,False
+10011059,Wandsworth Community H Co-Op Ltd,,51 Oldridge Road,Balham,,London,,England                       ,SW12 8PP,Wider Public Sector,Private Sector Enabler,False
+10011056,Walworth General Practice,,Walworth Road Surgery,1 Manor Place,,London,,England                       ,SE17 3BD,Wider Public Sector,Private Sector Enabler,False
+10011055,Walton Sports Centre,,Walton Hall Avenue,,,Liverpool,,England                       ,L4 9XP,Wider Public Sector,Private Sector Enabler,False
+10011038,WAGN Rail,WAGN,Hertford House,1 Cranwood Street,,London,,England                       ,EC1V 9QS,Wider Public Sector,Transport,False
+10011037,Wackenhut Corrections (UK) Ltd,,875 Sidcup Road,New Eltham,,London,,England                       ,SE9 3PP,Wider Public Sector,Private Sector Enabler,False
+10011031,Vinney Green Secure Unit,,Emersons Green,Emersons Green,,Bristol,,England                       ,BS16 7AA,Wider Public Sector,Private Sector Enabler,False
+10011030,Vineyard Christian Fellowship,,Church Office Radiant House,Crofton Road Marsh Barton,Marsh Barton,Exeter,,England                       ,EX2 8QW,Wider Public Sector,Private Sector Enabler,False
+10011028,Victory Services Club,,63-79 Seymour Street,,,London,,England                       ,W2 2HF,Wider Public Sector,Private Sector Enabler,False
+10011023,Vendepac,,Unit 7 Stockton Close,Minworth Industrial Park ,Minworth,Sutton Coldfield,,England                       ,B76 1DH,Wider Public Sector,Private Sector Enabler,False
+10011021,Driver and Vehicle Standards Agency,DVSA,PO Box 280,,,Newcastle upon Tyne,Tyne and Wear                 ,England                       ,NE99 1FP,Central Government,,False
+10011018,Valuation and Lands Agency,,Central Advisory Unit (Northern Ireland),Queen?s Court,56-66 Upper Queen Street,Belfast,,Northern Ireland              ,BT1 6FD,Wider Public Sector,Private Sector Enabler,False
+10011016,Uttlesford Consortium,,c/o Stebbing Primary School,High Street,,Stebbing,,England                       ,CM6 3SH,Wider Public Sector,Private Sector Enabler,False
+10011014,Urmston Leisure Centre,,Bowfell Road,Flixton,,Manchester,,England                       ,M41 5RR,Wider Public Sector,Private Sector Enabler,False
+10011012,Urban Learning Foundation,,Bede House,5b East India Dock Road,Poplar,London,,England                       ,E14 6JE,Wider Public Sector,Private Sector Enabler,False
+10010974,United Society for the Propagation of the Gospel,,Partnership House,157 Waterloo Road,,London,,England                       ,SE1 8XA,Wider Public Sector,Private Sector Enabler,False
+10010973,United Response,,7th Floor,113 Upper Richmond Road,,London,,England                       ,SW15 2TL,Wider Public Sector,Private Sector Enabler,False
+10010972,United Medical Enterprises Ltd,,1st Floor Garden Court Wing,Tavistock House,Tavistock Square,London,,England                       ,WC1H 9LG,Wider Public Sector,Private Sector Enabler,False
+10010971,United Bible Societies,,7th Floor,Reading Bridge House,,Reading,,England                       ,RG1 8PJ,Wider Public Sector,Private Sector Enabler,False
+10010969,Uniserv,,University of Leeds Main Boiler House,Woodhouse Lane,,Leeds,West Yorkshire                ,England                       ,LS2 9JT,Wider Public Sector,Private Sector Enabler,False
+10010968,Union Society,,Newcastle University,Kings Walk,,Newcastle Upon Tyne,,England                       ,NE1 8QB,Wider Public Sector,Private Sector Enabler,False
+10010967,Union Jack Club,,Sandell Street,,,London,,England                       ,SE1 8UJ,Wider Public Sector,Private Sector Enabler,False
+10010966,Union Church [URC],,50 Chanctonbury Way,,,London,,England                       ,N12 7AB,Wider Public Sector,Private Sector Enabler,False
+10010965,Underhill Baptist Church,,C/c 33 Kenerne Drive,,,Barnet,,England                       ,EN5 2NW,Wider Public Sector,Private Sector Enabler,False
+10010964,Umbrella,,154 Camden Road,,,London,,England                       ,NW1 9HJ,Wider Public Sector,Private Sector Enabler,False
+10010962,UKIS,,Status 4 Status Park,Nobel Drive Hayes,,Harlington,,England                       ,UB3 5EY,Wider Public Sector,Private Sector Enabler,False
+10010949,Tynedale Council,,Hadrian House,,,Hexham,Northumberland                ,England                       ,NE46 3NH,Wider Public Sector,,False
+10010947,Tyne and Wear Passenger Transport Authority,,The Tyne Tunnels,Bewick Road,,Wallsend,,England                       ,NE28 0PD,Wider Public Sector,Private Sector Enabler,False
+10010946,Tyne and Wear Dev Co Ltd,,Investor House,Colima Avenue,Sunderland Enterprise Park,Sunderland,,England                       ,SR5 3XB,Wider Public Sector,Private Sector Enabler,False
+10010938,Turner FM Ltd,,C/o MAFF Eastbury House,30/34 Albert Enbankment,,London,,England                       ,SE1 7TL,Wider Public Sector,Private Sector Enabler,False
+10010937,Turner Facilities Management Ltd,,65 Craigton Road,Govan,,Glasgow,,Scotland                      ,G51 3EQ,Wider Public Sector,Private Sector Enabler,False
+10010936,Turner and Townsend,,TTPM,111 Charles Street,,Sheffield,,England                       ,S1 2ND,Wider Public Sector,Private Sector Enabler,False
+10010932,Tube Lines Limited,,30 The South Colonnade,10th Floor,Canary Wharf,London,,England                       ,E14 5EU,Wider Public Sector,Transport,False
+10010931,Troup Bywaters and Anders,,Seymour House,51 Praed Street,,London,,England                       ,W2 1NR,Wider Public Sector,Private Sector Enabler,False
+10010930,Tristar Homes Limited,TH,Municipal Buildings,,,Stockton on Tees,Cleveland                     ,England                       ,TS18 1LD,Wider Public Sector,Housing Associations,False
+10010929,Trinity United Reform Church,,10 Middle Lane,,,Ringwood,,England                       ,BH24 1LE,Wider Public Sector,Private Sector Enabler,False
+10010927,Trinity School - Kenton Lodge,,1 Kenton Road,Gosforth,,Newcastle upon Tyne,,England                       ,NE3 4PD,Wider Public Sector,Private Sector Enabler,False
+10010926,Trinity Methodist Church,,Angel Way,,,Romford,,England                       ,RM1 1JH,Wider Public Sector,Private Sector Enabler,False
+10010924,Trinity Community Partnership,,Trinity Centre,Welseyan Row,,Clitheroe,,England                       ,BB7 2JY,Wider Public Sector,Private Sector Enabler,False
+10010919,Tribunals for Users Programme,,Room 8.15 8th Floor,Selborne House,54-60 Victoria Street,London,,England                       ,SW1E 6QW,Wider Public Sector,Private Sector Enabler,False
+10010914,Transport Trading,,Procurement - Office Services,2nd Floor Victoria Station House,191 Victoria Street,London,,England                       ,SW1E 5NE,Wider Public Sector,Private Sector Enabler,False
+10010912,Translink,,3 Milewater Road,,,Belfast,,Northern Ireland              ,BT3 9BG,Wider Public Sector,Private Sector Enabler,False
+10010910,Training Operation,,5th Floor West Point 501 Chester Road,Old Trafford,,Manchester,,England                       ,M16 9HU,Wider Public Sector,Private Sector Enabler,False
+10010909,Training for Life,,37 Houndsditch,,,London,,England                       ,EC3A 7DB,Wider Public Sector,Private Sector Enabler,False
+10010907,Trafford ICT Centre,,Sale West Development Centre,Manor Avenue,,Sale,,England                       ,M33 5JX,Wider Public Sector,Private Sector Enabler,False
+10010902,Toxteth Sports Centre,,Upper Hill Street,,,Liverpool,,England                       ,L8 8EN,Wider Public Sector,Private Sector Enabler,False
+10010901,Toxteth Park Employment Service,,172 Park Road,Toxteth,,Liverpool,,England                       ,L8 6XL,Wider Public Sector,Private Sector Enabler,False
+10010897,Tower Hamlets Housing Action Trust,,73 Usher Road,Bow,,London,,England                       ,E3 2HS,Central Government,NDPB,False
+10010886,Torpedo Countermeasures,,Integrated Project Team MOD (DPA) Abbey Wood 3120,Bristol,Avon,Bristol,Avon,England,BS34 8JH,Central Government,TBA,False
+10010881,Tollgate Health Centre,,220 Tollgate Road,Beckton,,London,,England                       ,E6 5JS,Wider Public Sector,Private Sector Enabler,False
+10010874,Threatre Museum,,1C Towlstock Street,,,London,,England                       ,WC2E 7RA,Wider Public Sector,Private Sector Enabler,False
+10010857,Theatre,,Bishops Road,,,Inverness,,Scotland                      ,IV5 3SE,Wider Public Sector,Private Sector Enabler,False
+10010852,Wellcome Trust The,,215 Euston Road,,,London,,England                       ,NW1 2BE,Wider Public Sector,Private Sector Enabler,False
+10010848,Thomas Risley Church The,,Locking Stumps,Birchwood,,Warrington,,England                       ,WA3 7PH,Wider Public Sector,Private Sector Enabler,False
+10010847,Tattenhall Centre The,,High Street,Tattenhall,,Chester,,England                       ,CH3 9PX,Wider Public Sector,Private Sector Enabler,False
+10010846,Stephen's Church Office The,,30 Crown Road,,,Twickenham,,England                       ,TW1 3EE,Wider Public Sector,Private Sector Enabler,False
+10010843,Spa Medical Practice The,,Droitwich Health Centre,,,Droitwich Spa,,England                       ,WR9 8RD,Wider Public Sector,Private Sector Enabler,False
+10010842,Society Of Archivists The,,40 Northampton Road,,,London,,England                       ,EC1R 0HB,Wider Public Sector,Private Sector Enabler,False
+10010840,Shipman Inquiry The,,1st Floor,Gateway House,Piccadilly South,Manchester,,England                       ,M60 7LP,Wider Public Sector,Private Sector Enabler,False
+10010839,Sea Cadets The,,HMS President,72 St Katherine's Way,,London,,England                       ,E1 1UQ,Wider Public Sector,Private Sector Enabler,False
+10010838,Scottish Qualification Authority The,SQA,Hanover House,24 DouglasStreet,Glasgow,Glasgow,,Scotland                      ,G2 7NQ,Wider Public Sector,Private Sector Enabler,False
+10010836,Sage Centre The,,c/o Sikeside Primary School,Sikeside Street,,Coatbridge,,Scotland                      ,ML5 4QH,Wider Public Sector,Private Sector Enabler,False
+10010833,Royal Collection The,,Buckingham Palace,,,London,,England                       ,SW1A 1AA,Wider Public Sector,Private Sector Enabler,False
+10010830,Rent Service The,TRS,5 Welbeck Street,1 Angel Square,Torrens Street,LONDON,,England                       ,W1G 9YQ,Central Government,Executive Agency,False
+10010829,Redress Trust Limited The,,3rd Floor,87 Vauxhall Walk,,London,,England                       ,SE11 5HJ,Wider Public Sector,Private Sector Enabler,False
+10010823,Prestbury Centre The,,236 Prestbury Road,,,Cheltenham,,England                       ,GL52 3EY,Wider Public Sector,Private Sector Enabler,False
+10010822,Peak Centre The,,Champion House,Edale,,Hope Valley,,England                       ,S33 7ZA,Wider Public Sector,Private Sector Enabler,False
+10010821,Oval Wirral The,,Sports Centre,Old Chester Road,,Bebington,,England                       ,CH63 7LF,Wider Public Sector,Private Sector Enabler,False
+10010816,Nursery The,,17/18 The Close,,Babraham,Cambridge,,England                       ,CB2 4QA,Wider Public Sector,Private Sector Enabler,False
+10010813,National Society The,,Church House,Great Smith Street,,London,,England                       ,SW1P 3NZ,Wider Public Sector,Private Sector Enabler,False
+10010812,National Centre for Volunteering The,,Regents Wharf,8 All Saints Street,,London,,England                       ,N1 9RL,Wider Public Sector,Private Sector Enabler,False
+10010810,Millennium Commission The,,26th Floor Portland House,Stag Place,,London,,England                       ,SW1E 5EZ,Central Government,NDPB,False
+10010805,Linnean Society of London The,,Burlington House,Piccadilly,,London,,England                       ,W1V 0LQ,Wider Public Sector,Private Sector Enabler,False
+10010803,Leybourne Surgery The,,1 Leybourne Avenue,,,Bournemouth,,England                       ,BH10 6ES,Wider Public Sector,Private Sector Enabler,False
+10010801,Learning Centre Ltd The,,Central Library,Broadway,,Peterborough,,England                       ,PE1 1RX,Wider Public Sector,Private Sector Enabler,False
+10010800,Law Society The,,113 Chancery Lane,,,London,,England                       ,WC2A 1PL,Wider Public Sector,Private Sector Enabler,False
+10010799,Labrador Rescue Trust The,,4 Hadden Road,,,Bournemouth,,England                       ,BH8 9HH,Wider Public Sector,Private Sector Enabler,False
+10010798,Kipper Project The,,St Margarets House,15 Old Ford Road,,London,,England                       ,E2 9PL,Wider Public Sector,Private Sector Enabler,False
+10010797,Kingwood City Learning Centre The,,Hammersmith and Fulham LEA,Kingwood Road,,London,,England                       ,SW6 6JL,Wider Public Sector,Private Sector Enabler,False
+10010793,John White Centre The,,Calderwood Road,East Kilbride,,Glasgow,,Scotland                      ,G74 3EU,Wider Public Sector,Private Sector Enabler,False
+10010788,House Of St Barnabus-In-Soho The,,1 Greek Street,Soho Square,,London,,England                       ,W1D 4NQ,Wider Public Sector,Private Sector Enabler,False
+10010782,Highlands The,,Seathwood,365 Perth Road,,Dundee,,Scotland                      ,DD2 1LX,Wider Public Sector,Private Sector Enabler,False
+10010780,Herts and Essex High School for Girls The,,Warwick Road,Bishops Stortford,,Bishops Stortford,,England                       ,CM23 5NJ,Wider Public Sector,Private Sector Enabler,False
+10010777,Great Western Road Medical Group The,,327 Great Western Road,,,Aberdeen,,Scotland                      ,AB10 6LT,Wider Public Sector,Private Sector Enabler,False
+10010770,Dudley Gateway Project The,,Churchill House,Third Avenue,Pensnett Trading Estate,Kingswinford,West Midlands                 ,England                       ,DY6 7XZ,Wider Public Sector,,False
+10010766,Daughters of Charity of Great Britain The,,St Vincent De Paul,Carlisle Place,Westminster,London,,England                       ,SW1P 1NL,Wider Public Sector,Private Sector Enabler,False
+10010761,Cornerstone Network The,,Central Hall,St Mary Street,,Southampton,,England                       ,SO14 1NF,Wider Public Sector,Private Sector Enabler,False
+10010758,City Literacy Institute The,,16 Stukeley Street,,,London,,England                       ,WC2B 5LJ,Wider Public Sector,Private Sector Enabler,False
+10010757,City Learning Centre The,,Tiverton Road,,,London,,England                       ,NW10 3HE,Wider Public Sector,Private Sector Enabler,False
+10010756,City Academy Bristol The,,St George Campus,Russell Town Avenue,,Bristol,,England                       ,BS5 9JH,Wider Public Sector,Private Sector Enabler,False
+10010755,Christopher Whitehead HS The,,Main Office,,, ,,England                       ,OO,Wider Public Sector,Private Sector Enabler,False
+10010754,Chrisp Street Practice The,,Chrisp Street Health Centre,100 Chrisp Street,,London,,England                       ,E14 6PG,Wider Public Sector,Private Sector Enabler,False
+10010753,Chinese Centre The,,Callerton House,4 Callerton Place,Fenham,Newcastle upon Tyne,,England                       ,NE4 5NQ,Wider Public Sector,Private Sector Enabler,False
+10010752,Children's Society The,,Edward Rudolf House,Marjery Street,,London,,England                       ,WC1X 0JL,Wider Public Sector,Private Sector Enabler,False
+10010751,Chartered Society of Physiotheraphy The,CSP,14 Bedford Row,,,London,,England                       ,WC1R 4ED,Wider Public Sector,Private Sector Enabler,False
+10010750,Carlton Road Study Support Centre The,,KS4 Alternative Curriculum,Laughton Road,,Boston,,England                       ,PE21 8LN,Wider Public Sector,Private Sector Enabler,False
+10010747,Brandon Trust The,,Olympus House,Britannia Road,Patchway,Bristol,,England                       ,BS34 5TA,Wider Public Sector,Private Sector Enabler,False
+10010743,Big Issue in North Trust The,,135-141 Oldham Street,,,Manchester,,England                       ,M4 1LN,Wider Public Sector,Private Sector Enabler,False
+10010742,Bible Talks The,,21b Downs Street,,Mayfair,London,,England                       ,W1J 7AW,Wider Public Sector,Private Sector Enabler,False
+10010737,Angel Group The,,Suite 4  Lion Court,The Highway,,Wapping,,England                       ,E1 9HT,Wider Public Sector,Private Sector Enabler,False
+10010736,ALBA Centre The,,ALBA Campus,Rosebank,Livingston,Edinburgh,,Scotland                      ,EH54 7EG,Wider Public Sector,Private Sector Enabler,False
+10010732,Abbey Medical Centre The,,87/89 Abbey Road,St John's Wood,,London,,England                       ,NW8 0AG,Wider Public Sector,Private Sector Enabler,False
+10010728,Thames Reach Bondway,,Graham House,62 Bondway,,London,,England                       ,SW8 1SF,Wider Public Sector,Private Sector Enabler,False
+10010727,Thames Postgraduate Medical and Dental Education,,33 Millman Street,,,London,,England                       ,WC1N 3EJ,Wider Public Sector,Private Sector Enabler,False
+10010725,Thames Gateway River Crossings Team,,Business Exchange,10 Greycoat Place,,London,,England                       ,SW1P 1SB,Wider Public Sector,Private Sector Enabler,False
+10010715,Technology Support for Learning,,Surrey County Council,Glyn House,Church Street,Ewell,,England                       ,KT17 2AR,Wider Public Sector,Private Sector Enabler,False
+10010714,Technical Support Services,,Regus House,4 Admiral Way,Doxford International Business Park,Sunderland,,England                       ,SR3 3XW,Wider Public Sector,Private Sector Enabler,False
+10010713,Technical Services Agency,,Osler Road,Headington,,Oxford,,England                       ,OX3 9RJ,Wider Public Sector,Private Sector Enabler,False
+10010712,Technical Projects Service,,8a Barnsbury Park,,,London,,England                       ,N1 1QQ,Wider Public Sector,Private Sector Enabler,False
+10010707,Police Scotland,,P.O. Box 59 West Bell Street,Dundee,Tayside,Dundee,Tayside,Scotland,DD1 9JU,Wider Public Sector,Emergency,False
+10010706,Tayside OCC Health and Safety Service,,Wedderburn House,1 Edward Street,,Dundee,,Scotland                      ,DD1 5NS,Wider Public Sector,Private Sector Enabler,False
+10010696,Tanc Co-Op Ltd,,106 Malden Road,(1st Floor),,London,,England                       ,NW5 4DA,Wider Public Sector,Private Sector Enabler,False
+10010693,Tameside Health Centre,,Bentinck Street,Ashton,,Underlyne,,England                       ,OL7 OPT,Wider Public Sector,Private Sector Enabler,False
+10010691,Talmud Education Trust,,Etz Chaim,The Belmont,89 Middleton Road,Manchester,,England                       ,M8 4JY,Wider Public Sector,Private Sector Enabler,False
+10010690,Tain Royal Academy,,Scotsburn Road,,,Tain,,Scotland                      ,IV19 1NR,Wider Public Sector,Private Sector Enabler,False
+10010689,Tabernacle Baptist Church,,High Street,,,Newbridge,,Wales                         ,NP11 4FH,Wider Public Sector,Private Sector Enabler,False
+10010687,T P Riley Community School,,Lichfield Road,Bloxwich,,Walsall,,England                       ,WS3 3LU,Wider Public Sector,Private Sector Enabler,False
+10010686,Symonds Group Ltd,,Buchanan House,24-30 Holborn,,London,,England                       ,EC1N 2LX,Wider Public Sector,Private Sector Enabler,False
+10010682,Swansea Housing Association Limited,,The Old Post Office,11 Wind Street,,Swansea,West Glamorgan                ,Wales                         ,SA1 1DP,Wider Public Sector,Not for Profit,False
+10010679,SVC Devia,,G6 Branch,HQ UKSC(G),, ,,Germany                       ,BFPO 140,Wider Public Sector,Private Sector Enabler,False
+10010674,Sussex Probation Board,,185 Dyke Rd,,,Hove,,England                       ,BN3 1TL,Wider Public Sector,Private Sector Enabler,False
+10010673,Sussex Enterprise,SE,Greenacre Court,Station Road,,Burgess Hill,West Sussex                   ,England                       ,RH15 9DS,Wider Public Sector,Private Sector Enabler,False
+10010671,Survey Squadron,,HQ P & SS,RAF Henlow,,Badford,,England                       ,SG16 6DH,Wider Public Sector,Private Sector Enabler,False
+10010669,Surrey Heath Health Care,,192A Frimley Road,,,Camberley,,England                       ,GU15 2QJ,Wider Public Sector,Private Sector Enabler,False
+10010665,Sure Start,,Town Hall,Spalcester Street,,Redditch,,England                       ,B98 8AH,Wider Public Sector,,False
+10010661,Sunderland City Cleansing,,Commercial Road,,,Sunderland,,England                       ,SR4 6BU,Wider Public Sector,Private Sector Enabler,False
+10010660,Sunderland Action Team for Jobs,,51-53 Blackwood Road,Town End Farm,,Sunderland,,England                       ,SR5 4PT,Wider Public Sector,Private Sector Enabler,False
+10010659,Summerside Medical Centre,,29b Summerside Place,,,Edinburgh,,Scotland                      ,EH6 4NY,Wider Public Sector,Private Sector Enabler,False
+10010657,Summer Horizons,,24 Saltwell View,,,Gateshead,,England                       ,NE8 4NT,Wider Public Sector,Private Sector Enabler,False
+10010656,Summer Fields School Trust Ltd,,Mayfield Road,,,Oxford,,England                       ,OX2 7EN,Wider Public Sector,Private Sector Enabler,False
+10010654,Sue Ryder Care,,Central Office,2nd Floor,114-118 Southampton Row,London,,England                       ,WC1B 5AA,Wider Public Sector,Private Sector Enabler,False
+10010652,Sudbury  District Volunteer Centre,,The Christopher Centre,10 Gainsborough Street,,Sudbury,,England                       ,CO10 2EU,Wider Public Sector,Private Sector Enabler,False
+10010651,Subscription Services Ltd,,Barton House,Bond Street,,Bristol,,England                       ,BS98 1TL,Wider Public Sector,Private Sector Enabler,False
+10010644,Strike Command,,Building 1512,RAF Daws Hill,,High Wycombe,,England                       ,HP11 1SH,Wider Public Sector,Private Sector Enabler,False
+10010643,Stretford Leisure Centre,,Trafford Metropolitan Borough Council,Greatstone Road Stretford,,Manchester,,England                       ,M32 0ZP,Wider Public Sector,Private Sector Enabler,False
+10010640,Strathmore Associates,,Strathmore House,27 Queens Park Avenue,,Stoke-on-Trent,,England                       ,ST3 4AU,Wider Public Sector,Private Sector Enabler,False
+10010632,Storey Sons and Parker,,Higham House,New Bridge Street West,,Newcastle-Upon-Tyne,,England                       ,NE1 8AV,Wider Public Sector,Private Sector Enabler,False
+10010629,Stonecroft Under 5's Centre,,100 Priory Road,,,London,,England                       ,N8 7HR,Wider Public Sector,Private Sector Enabler,False
+10010628,Stonebridge Housing Action Trust,,Kassinga House,37-41 Winchelsea Road,,London,,England                       ,NW10 8UN,Central Government,NDPB,False
+10010624,Stockwell Park EMB,,145 Stockwell Road,,,London,,England                       ,SW9 9TN,Wider Public Sector,Private Sector Enabler,False
+10010622,Stockton-On-Tees Area Child Protection Committee,,Review & Development Unit,Parkside,Melrose Avenue,Billingham,,England                       ,TS23 2JH,Wider Public Sector,Private Sector Enabler,False
+10010619,Stockton Almshouses Charities,,13 Brisbane Grove,Hartburn,,Stockton On Tees,,England                       ,TS18 5BW,Wider Public Sector,Private Sector Enabler,False
+10010612,Sterling Publications Ltd,,57 North Wharf Road,,,London,,England                       ,W2 1XR,Wider Public Sector,Private Sector Enabler,False
+10010611,Stephenson Harwood,,1 St. Pauls Churchyard,,,London,,England                       ,EC4M 8SH,Wider Public Sector,Private Sector Enabler,False
+10010610,Stephen and Matilda Co-Op Ltd,,50 Matilda House,St Katharine's Way,,London,,England                       ,E1 9TN,Wider Public Sector,Private Sector Enabler,False
+10010609,Steer Davies Gleave,,28-32 Upper Ground,,,London,,England                       ,SE1 9PD,Wider Public Sector,Private Sector Enabler,False
+10010608,State Veterinary Service,,Room 303b 1A Page Street,,,London,,England                       ,SW1P 4PQ,Wider Public Sector,Private Sector Enabler,False
+10010603,Stanhurst Elderly Peoples Home,,10 Victoria Rd,Eccles,,Manchester,,England                       ,M30 9HB,Wider Public Sector,Private Sector Enabler,False
+10010601,Standish Community High School,,Kenyon Road,Standish,,Wigan,,England                       ,WN6 0NX,Wider Public Sector,Private Sector Enabler,False
+10010600,Standards for England,,Level 1 The Cottons Centre,Cotton Lane,London Bridge,LONDON,,England                       ,SE1 0QG,Central Government,NDPB,False
+10010597,Staffordshire Army Cadet Force,,The Walter James Centre,RAF Stafford,Beaconside,Stafford,Staffordshire                 ,England                       ,ST18 0QA,Central Government,Army,False
+10010583,St Stephen's Canterbury (The Manna),,17 Canonbury Road,Islington,,London,,England                       ,N1 2DF,Wider Public Sector,Private Sector Enabler,False
+10010581,St Robert Bellarmine,,Orrell Road,Bootle,,Liverpool,,England                       ,L20 6DX,Wider Public Sector,Private Sector Enabler,False
+10010577,St Peters Hospice Limited,,Charlton Road,Brentry,,Bristol,,England                       ,BS10 6NL,Wider Public Sector,Private Sector Enabler,False
+10010571,St Pauls Way Community School,,Shelmerdine Close,,,London,,England                       ,E3 4AN,Wider Public Sector,Private Sector Enabler,False
+10010568,St Paul's Church,,St Paul's Church Centre,Fisherton Street,,Salisbury,,England                       ,SP2 7QW,Wider Public Sector,Private Sector Enabler,False
+10010567,St Pauls Church,,The Parish of Woborough,Devon Square,, ,,England                       ,TQ12 2HN,Wider Public Sector,Private Sector Enabler,False
+10010562,St Patricks Academy for Girls,,35 Killymeal Road,,,Dungannon,,Northern Ireland              ,BT71 6DF,Wider Public Sector,Private Sector Enabler,False
+10010560,St Pancras Coroners Court,,Camley Street,,,London,,England                       ,NW1 0PP,Wider Public Sector,Private Sector Enabler,False
+10010551,St Michaels Hospice,,25 Upper Maze Hill,St Leonards On Sea,,East Sussex,,England                       ,TN38 0LB,Wider Public Sector,Private Sector Enabler,False
+10010546,St Matthew Society Ltd,,4 The Old Church,St Matthews Road,,Norwich,,England                       ,NR1 1SP,Wider Public Sector,Private Sector Enabler,False
+10010541,St Mary's Hospice,,176 Raddlebarn Road,Selly Park,,Birmingham,West Midlands                 ,England                       ,B29 7DA,Wider Public Sector,Private Sector Enabler,False
+10010538,St Mary's Church,,23 Chatteris Avenue,Queen Street,,Leicester,,England                       ,LE5 6JA,Wider Public Sector,Private Sector Enabler,False
+10010530,St Marks South Norwood,,101 Albert Road,,,London,,England                       ,SE25 4JE,Wider Public Sector,Private Sector Enabler,False
+10010518,St Lukes Church,,74 Acworth Court,,,Luton,,England                       ,LU4 9JD,Wider Public Sector,Private Sector Enabler,False
+10010514,St Kentigern Hospice,,5 Oak Hill Drive,Prestatyn,,Clwyd,,Wales                         ,LL19 9PY,Wider Public Sector,Private Sector Enabler,False
+10010501,St John Supplies,,Friend Street,PO Box 707b,,London,,England                       ,EC1V 7NE,Wider Public Sector,Private Sector Enabler,False
+10010498,St James Pupil Referral Unit,,Beauchamp Lane,Cowley,,Oxford,,England                       ,OX4 3LF,Wider Public Sector,Private Sector Enabler,False
+10010493,St Hildas East Community Centre,,18 Club Row,Shoreditch,,London,,England                       ,E2 7EY,Wider Public Sector,Private Sector Enabler,False
+10010488,St Helens Church,,The Rectory,Great St Helens,,London,,England                       ,EC3A 6AT,Wider Public Sector,Private Sector Enabler,False
+10010487,St Helena's Hospice and Eastern Association Hospice,,82 Malting Green Road,Layer-de-la-Haye,,Colchester,,England                       ,CO2 0JJ,Wider Public Sector,Private Sector Enabler,False
+10010483,St Giles Hospice,,Fisherwick Road,Whittington,,Lichfield,,England                       ,WS14 9LH,Wider Public Sector,Private Sector Enabler,False
+10010478,St George Catholic School for Boys,,Leaside Way,Swaythling,,Southampton,,England                       ,SO16 3DQ,Wider Public Sector,Private Sector Enabler,False
+10010476,St Gabriel's Parish Church,,34 Mode Hill Lane,Whitefield,,Manchester,,England                       ,M45 8JH,Wider Public Sector,Private Sector Enabler,False
+10010473,St Francis Hospice,,The Hall,Havering Atte Bower,,Romford,,England                       ,RM4 1QH,Wider Public Sector,Private Sector Enabler,False
+10010461,St Dunstans,,12-14 Harcourt Street,,,London,,England                       ,W1H 4HD,Wider Public Sector,Private Sector Enabler,False
+10010458,St Davids Hospice,,25-31 Madog Street,,Llandudno,Conway,,Wales                         ,LL30 2TL,Wider Public Sector,Private Sector Enabler,False
+10010456,St Cuthburts Society,,12 South Bailey,,,Durham,,England                       ,DH1 3EE,Wider Public Sector,Private Sector Enabler,False
+10010455,St Cuthbert's Care,,St Cuthberts House,West Road,,Newcastle-Upon-Tyne,,England                       ,NE15 7PY,Wider Public Sector,Private Sector Enabler,False
+10010454,St Columba's RC High,,Malvina Place,,,Perth,,Scotland                      ,PH1 5BD,Wider Public Sector,Private Sector Enabler,False
+10010453,St Columba's Hospice,,Challenger Lodge,15 Boswall Road,,Edinburgh,,Scotland                      ,EH5 3RW,Wider Public Sector,Private Sector Enabler,False
+10010452,St Clouds Care PLC,,Crown East Lane,Lower Broadheath,,Worcester,,England                       ,WR2 6RH,Wider Public Sector,Private Sector Enabler,False
+10010451,St Clements Partnership,,Tanner Street,,,Winchester,,England                       ,SO23 8AD,Wider Public Sector,Private Sector Enabler,False
+10010448,St Christopher's Fellowship,,217 Kingston Road,Wimbledon,,London,,England                       ,SW19 3NL,Wider Public Sector,Private Sector Enabler,False
+10010443,St Bridgets Cheshire Home,,Ilex Close,,,Rustington,,England                       ,BN16 2RX,Wider Public Sector,Private Sector Enabler,False
+10010441,St Botolph's Project,,2 Whitechurch Lane,,,London,,England                       ,E1 7QR,Wider Public Sector,Private Sector Enabler,False
+10010437,St Bendicts Parish Centre,,Rhodes Street,,,Warrington,,England                       ,WA2 7QE,Wider Public Sector,Private Sector Enabler,False
+10010435,St Barts Royal School Of Medicine and Dentistry,,Turner Street,Mile End Road,,London,,England                       ,E1 2 AD,Wider Public Sector,Private Sector Enabler,False
+10010429,St Anthony's Health Centre,,St Anthony's Road,Walker,,Newcastle-Upon-Tyne,,England                       ,NE6 2NN,Wider Public Sector,Private Sector Enabler,False
+10010415,St Ambrose Barlow,,Lakey Lane,Hall Green,,Birmingham,West Midlands                 ,England                       ,B28 8QU,Wider Public Sector,Private Sector Enabler,False
+10010401,Spitalfields Crypt Trust,,22a Hanbury Street,,,London,,England                       ,E1 6QR,Wider Public Sector,Private Sector Enabler,False
+10010391,Sovereign Consultancy Services,,RAF Boulmer,Building 056 operations site,,Alnwick,,England                       ,NE66 3JF,Wider Public Sector,Private Sector Enabler,False
+10010389,Southwark Direct,,Manor Place Depot,30-34 Penrose Street,,London,,England                       ,SE17 3DW,Wider Public Sector,Private Sector Enabler,False
+10010388,Southwark Diocesan Board of Education,,Diocesan Education Centre,48 Union Street,,London,,England                       ,SE1 1TD,Wider Public Sector,Private Sector Enabler,False
+10010386,Southwark College,,Surrey Docks Centre,Drummond Road,,London,,England                       ,SE16 4EE,Wider Public Sector,Colleges of Further Education,False
+10010383,Southwalk Social Services Department,,49 Grange Walk,,,London,,England                       ,SE1,Wider Public Sector,Private Sector Enabler,False
+10010382,Southside Partnership Ltd,,Scout Hall,Scout Lane,Clapham,London,,England                       ,SW4 0LA,Wider Public Sector,Private Sector Enabler,False
+10010381,Southside Family Project,,36 St Michaels Road,Whiteway,,Bath,,England                       ,BA2 1PZ,Wider Public Sector,Private Sector Enabler,False
+10010380,Southmead Development Trust,,The Greenway Centre,Doncaster Road,Southmead,Bristol,,England                       ,BS10 5PY,Wider Public Sector,Private Sector Enabler,False
+10010373,Southern Education and Library Board,,3 Charlemont Place,The Mall,,Armargh,,Northern Ireland              ,BT61 9AX,Wider Public Sector,Private Sector Enabler,False
+10010370,Southbourne Adult Education,,Bourne Community College,Park Road,Southbourne Emsworth,Chichester,West Sussex                   ,England                       ,PO10 3PT,Wider Public Sector,Private Sector Enabler,False
+10010364,South West England Regional Network Ltd,,c/o University of Plymouth,316 Babbage,Drake Circus,Plymouth,,England                       ,PL4 8AA,Wider Public Sector,Private Sector Enabler,False
+10010358,South Thames Blood Transfusion,,75 Cranmer Terrace,,,London,,England                       ,SW17 0RB,Wider Public Sector,Private Sector Enabler,False
+10010355,South Mildmay Tenant Co-Op Ltd,,52 Mildmay Park,,,London,,England                       ,N1 4PR,Wider Public Sector,Private Sector Enabler,False
+10010343,South East Sheffield Education Action Zone,,Alison Centre,39 Alison Crescent,Manor,Sheffield,,England                       ,S2 1AS,Wider Public Sector,Private Sector Enabler,False
+10010342,South East London Baptist Homes,,The Elms,147 Barry Road,East Dulwich,London,,England                       ,SE22 0JR,Wider Public Sector,Private Sector Enabler,False
+10010338,South Bucks RDA,,Mill House Farm,Framewood Road,Fulmer,Slough,,England                       ,SL3 6JR,Wider Public Sector,Private Sector Enabler,False
+10010330,Soldier Magazine,,Ordenance Road,,,Aldershot,,England                       ,GU11 2DU,Wider Public Sector,Private Sector Enabler,False
+10010329,Sojourners House,,PO BOX 79,,,Manchester,,England                       ,M16 8BG,Wider Public Sector,Private Sector Enabler,False
+10010327,Society of the Sacred Heart,,Duchesne House,Aubyn Square,Roehampton Lane,London,,England                       ,SW15 5ND,Wider Public Sector,Private Sector Enabler,False
+10010322,SMILE Mathematics,,Royal Borough of Kensington and Chelsea,Issac Newton Centre,108A Lancaster Road,London,,England                       ,W11 1QS,Wider Public Sector,Private Sector Enabler,False
+10010319,Small Business Gateway,,7 West George Street,,,Glasgow,,Scotland                      ,G2 1BQ,Wider Public Sector,Private Sector Enabler,False
+10010317,Sitra,,3rd Floor,55 Bondway,,London,,England                       ,SW8 1SJ,Wider Public Sector,Private Sector Enabler,False
+10010316,SITPRO Limited,,Oxford House,76 Oxford Street,,London,,England                       ,W1D 1BS,Central Government,NDPB,False
+10010315,Sister Of Notre Dame,,21 Weld Road,,,Southport,,England                       ,PR8 2AZ,Wider Public Sector,Private Sector Enabler,False
+10010314,Siren Conversation Education,,Halifax House,6 South Parks Road,,Oxford,,England                       ,OX1 3WB,Wider Public Sector,Private Sector Enabler,False
+10010311,Sir Oswald Stoll Foundation,,446 Fulham Road,,,London,,England                       ,SW6 1DT,Wider Public Sector,Private Sector Enabler,False
+10010304,Sir Frank Markham Community School,,Woughton Campus,Chaffron Way,,Milton Keynes,,England                       ,MK6 5EH,Wider Public Sector,Private Sector Enabler,False
+10010301,Single Homeless Project Ltd,,1st Floor Bramah House,65-71 Bermondsey Street,,London,,England                       ,SE1 3XF,Wider Public Sector,Private Sector Enabler,False
+10010297,Silverlink Train Services Limited,STS,1st Floor,Hertford House,1 Cranwood Street,London,,England                       ,EC1V 9QS,Wider Public Sector,Transport,False
+10010293,Sianel Pedwar Cymru,,Parc Ty Glas,Llanishen,,Cardiff,,Wales                         ,CF14 5DU,Wider Public Sector,Private Sector Enabler,False
+10010292,Shropshire Chamber of Commerce,,Trevithick House,Stafford Park 4,,Telford,,England                       ,TF3 3BA,Wider Public Sector,Private Sector Enabler,False
+10010287,Sheriff Court House,,Sheriff Court House,Dunnotter Avenue,,Stonehaven,,Scotland                      ,AB39 2JH,Wider Public Sector,Private Sector Enabler,False
+10010277,Sheffield Leisure Services,,52 Shoreham Street,,,Sheffield,,England                       ,S1 4SP,Wider Public Sector,Private Sector Enabler,False
+10010276,Sheffield Guides Association,,Whitely Wood OAC,Common Lane,,Sheffield,,England                       ,S11 7TG,Wider Public Sector,Private Sector Enabler,False
+10010275,Sheffield City Libraries,,Surrey Street,,,Sheffield,,England                       ,S1 1XZ,Wider Public Sector,Private Sector Enabler,False
+10010274,Sheffield Care Trust,,Supplies & Support Services,45 Wardsend Road,,Sheffield,,England                       ,S6 1LX,Wider Public Sector,Private Sector Enabler,False
+10010273,SHCES Boys  Girls Welfare Society,,Schools Hill,Cheadle,,Stockport,,England                       ,SK8 1JT,Wider Public Sector,Private Sector Enabler,False
+10010271,Shaw Homes,,1 Links Court,Link Business Park,Fortran Road,Cardiff,,Wales                         ,CF3 0LT,Wider Public Sector,Private Sector Enabler,False
+10010267,SGI,,Room 10/145,St Christopher House,Southwark Street,London,,England                       ,SE1 0TD,Wider Public Sector,Private Sector Enabler,False
+10010265,Seymour Harris Keppie,,160 West Regent Street,,,Glasgow,,Scotland                      ,G2 4RL,Wider Public Sector,Private Sector Enabler,False
+10010264,Sexton (H J) Norwich Arts Trust,,Paston House,Princes Street,,Norwich,,England                       ,NR3 1BD,Wider Public Sector,Private Sector Enabler,False
+10010263,Sewell Group,,Geneva Way,Leads Road,,Hull,,England                       ,HU7 0DG,Wider Public Sector,Private Sector Enabler,False
+10010261,Servus,,Ireland House,150 New Bond Street,,London,,England                       ,W1Y 9FE,Wider Public Sector,Private Sector Enabler,False
+10010258,Sergeant at Arms Office,,FE Office,3 Deans Yard Westminister,,London,,England                       ,SW1,Wider Public Sector,Private Sector Enabler,False
+10010257,SERCO Limited (Justice),,Pavillion 2 Olympus Park Business Centre,Quedgeley,,Gloucester,,England                       ,GL2 4NF,Wider Public Sector,Private Sector Enabler,False
+10010255,SERCO,,Health Department,Bridge,Hatfield Road,Witham,,England                       ,CM8 1EQ,Wider Public Sector,Private Sector Enabler,False
+10010253,Selsey Adult Education Centre,,West Sussex County Council,Manhood Community College,School Lane Selsey,Chichester,West Sussex                   ,England                       ,PO20 9EH,Wider Public Sector,Private Sector Enabler,False
+10010247,Sefton Technical Services,,Balliol House,Balliol Road,Bootle,Liverpool,,England                       ,L20 3NJ,Wider Public Sector,Private Sector Enabler,False
+10010246,Sefton Neighbourhood Initiative Project,,Alexandra Hall,Coronation Road,Crosby,Liverpool,,England                       ,L23 3BH,Wider Public Sector,Private Sector Enabler,False
+10010243,Security Services Group,,Building 10/10,MOD,Ha Ha Road,Woolwich,,England                       ,SE18 4QF,Central Government,Private Sector Enabler,False
+10010237,Scout Association,,Gilwell Park,,,London,,England                       ,E4 7QW,Wider Public Sector,Private Sector Enabler,False
+10010234,Scottish Traffic Area,,3 Lady Lawson Street,3 Lady Lawson Street,,Edinburgh,,Scotland                      ,EH3 9SE,Wider Public Sector,Private Sector Enabler,False
+10010233,Scottish Society for the Prevention,,Braehead Mains,603 Queensferry Road,,Edinburgh,,Scotland                      ,EH4 6EA,Wider Public Sector,Private Sector Enabler,False
+10010232,Scottish Screen,,249 West George Street,,,Glasgow,,Scotland                      ,G2 4QE,Wider Public Sector,Private Sector Enabler,False
+10010231,Scottish Road Safety Campaign,,Heriot-Watt Research Park (North),Riccarton ,Currie,Edinburgh,,Scotland                      ,EH14 4AP,Wider Public Sector,Private Sector Enabler,False
+10010230,Scottish Public Services Ombudsman,,23 Walker Street,,,Edinburgh,,Scotland                      ,EH3 7HX,Wider Public Sector,Private Sector Enabler,False
+10010227,Scottish Power Plc,,1 Atlantic Quay,York Street,,Glasgow,,Scotland                      ,G2 8SP,Wider Public Sector,Private Sector Enabler,False
+10010220,Scottish Law Commission,,140 Causewayside,,,Edinburgh,,Scotland                      ,EH9 1PR,Wider Public Sector,Private Sector Enabler,False
+10010219,Scottish Land Court,,1 Grosvenor Crescent,,,Edinburgh,,Scotland                      ,EH12 5ER,Wider Public Sector,Private Sector Enabler,False
+10010215,Scottish Health Advisory Service,,Elliot House,8-10 Hillside Crescent,,Edinburgh,,Scotland                      ,EH7 5EA,Wider Public Sector,Private Sector Enabler,False
+10010203,Scottish Crop Research Institute,,Invergowrie,,,Dundee,,Scotland                      ,DD2 5DA,Wider Public Sector,Private Sector Enabler,False
+10010200,Scottish Consumer Council,,Royal Exchange House,100 Queen Street,,Glasgow,Strathclyde                   ,Scotland                      ,G1 3DN,Wider Public Sector,,False
+10010199,Scottish Community Foundation,,126 Canongate,,,Edinburgh,,Scotland                      ,EH8 8DD,Wider Public Sector,Private Sector Enabler,False
+10010195,Scottish Blood Transfusion Service,,Microbiology Reference Unit,25 Shelley Street,,Glasgow,,Scotland                      ,G12 0XB,Wider Public Sector,Private Sector Enabler,False
+10010192,Scottish Archive Network,,99 Bankhead Crossway North,Sighthill Ind Est,,Edinburgh,,Scotland                      ,EH11 4DX,Wider Public Sector,Private Sector Enabler,False
+10010190,Scotland The Brand,,14 St Vincent Place,,,Glasgow,,Scotland                      ,G1 2EU,Wider Public Sector,Private Sector Enabler,False
+10010186,Science and Technology Centre,,Monkmoor Site,Racecourse Crescent,,Shrewsbury,,England                       ,SY2 5BP,Wider Public Sector,Private Sector Enabler,False
+10010185,SCHS Trust,,Moorgreen Hospital Botley Rd,West End,,Southampton,,England                       ,SO30 3JB,Wider Public Sector,Private Sector Enabler,False
+10010183,School of Vision and Rehabilitation,,28 Park Circus,,,Glasgow,,Scotland                      ,G3 6AP,Wider Public Sector,Private Sector Enabler,False
+10010182,School of St David and St Katherine,,Hillfield Avenue,,,London,,England                       ,N8 7DT,Wider Public Sector,Private Sector Enabler,False
+10010180,School of Oriental and African Studies,,Thornhaugh Street,Russel Square,,London,,England                       ,WC1H 0XG,Wider Public Sector,Private Sector Enabler,False
+10010179,School of Clinical Dentistry,,Department of Oral Max Facial Surgery,Claremont Crescent,,Sheffield,,England                       ,S10 2TA,Wider Public Sector,Private Sector Enabler,False
+10010178,Schal International Management Ltd,,Elizabeth House,39 York Road,,London,,England                       ,SE1 7NQ,Wider Public Sector,Private Sector Enabler,False
+10010176,SBM Consulting Engineers,,The Matrix,64 Newhaven Road,,Edinburgh,,Scotland                      ,EH6 5QB,Wider Public Sector,Private Sector Enabler,False
+10010174,SAUL,,5th Floor Glen House,200-208 Tottenham Court Road,,London,,England                       ,W1P 9LA,Wider Public Sector,Private Sector Enabler,False
+10010172,Sardis Baptist Church,,9 Blaen-y-myarth,Llangynidr,,Powys,,Wales                         ,NP8 1NQ,Wider Public Sector,Private Sector Enabler,False
+10010166,Samuel Lewis HT Ltd,,Knights' Court,6-8 St John'S Square,,London,,England                       ,EC1M 4DE,Wider Public Sector,Private Sector Enabler,False
+10010165,Samanta Bhadra,,46 Poplar Road,Kings Heath,,Birmingham,West Midlands                 ,England                       ,B14 7AG,Wider Public Sector,Private Sector Enabler,False
+10010163,Salvage and Marine Operations IPT,,Room 209,Navy Buildings,Eldon Street,Greenock,,Scotland                      ,PA16 7SL,Wider Public Sector,Private Sector Enabler,False
+10010162,Salpi,,62 Rosemont Road,Acton,,London,,England                       ,W3 9LY,Wider Public Sector,Private Sector Enabler,False
+10010161,Salisbury City Learning Centre,,EIC,7th Floor Civic Centre,Silver Street,Enfield,,England                       ,EN1 3XQ,Wider Public Sector,Private Sector Enabler,False
+10010156,Salford College,,Worsley Campus,Walkden Road,Worsley,Manchester,Greater Manchester            ,England                       ,M28 7QD,Wider Public Sector,Colleges of Further Education,False
+10010152,Safe Start Foundation,,Hazell House,1-3 Lancelot Road,,Wembley,,England                       ,HA0 2AL,Wider Public Sector,Private Sector Enabler,False
+10010149,S&W Wales Trust Supplies Consortium,,Gorseinon Hospital,Brynawel Road,,Gorseinon,,Wales                         ,SA4 4UU,Wider Public Sector,Private Sector Enabler,False
+10010146,Ryden Property Consultants,,46 Castle Street,,,Edinburgh,,Scotland                      ,EH2 3BN,Wider Public Sector,Private Sector Enabler,False
+10010143,Ruskin Park House Ltd,,Registered Office,"Ruskin Park House,Champion Hill",,London,,England                       ,SE5 8TH,Wider Public Sector,Private Sector Enabler,False
+10010140,Rushden Medical Centre,,Adnitt Road,,,Rushden,,England                       ,NN10 9TU,Wider Public Sector,Private Sector Enabler,False
+10010138,Rugby Fire Station,,Corporation Street,,,Rugby,,England                       ,CV21 2DN,Wider Public Sector,Private Sector Enabler,False
+10010136,RUC-ICS,,N10 Procurement Unit,Lislea Drive,,Belfast,,Northern Ireland              ,BT9 7JG,Wider Public Sector,Private Sector Enabler,False
+10010135,RUC Estates Services,,Level 17 Churchill House,Victoria Square,,Belfast,,Northern Ireland              ,BT1 4TH,Wider Public Sector,Private Sector Enabler,False
+10010127,Royal Society of Medicine,,1 Wimpole St,,,London,,England                       ,W1M 8AE,Wider Public Sector,Private Sector Enabler,False
+10010126,Royal Society of Health,,38a Saint Georges Drive,,,London,,England                       ,SW1V 4BH,Wider Public Sector,Private Sector Enabler,False
+10010124,Royal Society for Chemistry,,Burlington House,Piccadilly,,London,,England                       ,W1J 0BA,Wider Public Sector,Private Sector Enabler,False
+10010122,Royal Scottish Academy of Music and Drama,,100 Renfrew Street,,,Glasgow,,Scotland                      ,G2 3DB,Wider Public Sector,Private Sector Enabler,False
+10010120,Royal Post Graduate Medical School,,Clinical Sciences Centre,Ducane Road,,London,,England                       ,W12 0NN,Wider Public Sector,Private Sector Enabler,False
+10010117,Royal Northern Infirmary,,Ness Walk,,,Inverness,,Scotland                      ,IV1,Wider Public Sector,Private Sector Enabler,False
+10010114,Royal Naval Armament Depot Coulport,,"Maintenence Service Division,Building 87",PO Box 1 Cove,,Helensburgh,,Scotland                      ,G84 0PD,Wider Public Sector,Private Sector Enabler,False
+10010113,Royal National Theatre,,Upper Ground,South Bank,,London,,England                       ,SE1 9PX,Wider Public Sector,Private Sector Enabler,False
+10010110,Royal Masonic Benevolent Institution,,20 Great Queen St,Hospital Road,,London,,England                       ,WC2B 5BG,Wider Public Sector,Private Sector Enabler,False
+10010108,Royal Marines Reserve Tyne,,AN210 House,Quayside,,Newcastle Upon Tyne,,England                       ,NE6 1BU,Wider Public Sector,Private Sector Enabler,False
+10010107,Royal Marines Reserve (City Of London),,2 Old Jamaica Road,Bermondsay,,London,,England                       ,SE16 4AN,Wider Public Sector,Private Sector Enabler,False
+10010103,Royal Mail Scotland and NI,,102 West Port Street,,,Edinburgh,,Scotland                      ,EH3 9HS,Wider Public Sector,Private Sector Enabler,False
+10010099,Royal Institute For Deaf People,,9 Old Oak Road,Acton,,London,,England                       ,W3 7HN,Wider Public Sector,Private Sector Enabler,False
+10010095,Royal Hospital School,,Holbrook,,,Ipswich,,England                       ,IP9 2RX,Wider Public Sector,Private Sector Enabler,False
+10010093,Royal Hospital For Neuro-Disability,,West Hill,,,London,,England                       ,SW15 3SW,Wider Public Sector,Private Sector Enabler,False
+10010092,Royal Hospital Chelsea,,Royal Chelsea Road,Chelsea,,London,,England                       ,SW3 4SR,Wider Public Sector,Private Sector Enabler,False
+10010091,Royal Horticultural Society Enterprises,,80 Vincent Square,,,London,,England                       ,SW1P 2PE,Wider Public Sector,Private Sector Enabler,False
+10010088,Royal Foundation For The Royal Naval,,Old Royal Naval College,Greenwich,Greenwich,London,,England                       ,SE10 9LW,Wider Public Sector,Private Sector Enabler,False
+10010087,Royal Fine Arts Commission For Scotland,,Bakerhouse Close,146 Canongate,,Edinburgh,,Scotland                      ,EH8 8DD,Wider Public Sector,Private Sector Enabler,False
+10010078,Royal Commission of Ancient and Historic Monuments of Scotland,,John Sinclair House,16 Bernard Terrace,,Edinburgh,Mid Lothian,Scotland,EH8 9NX,Wider Public Sector,NDPB,False
+10010067,Royal Britanic Gardens,,20a Inerleith Row,,,Edinburgh,,Scotland                      ,EH15 1AU,Wider Public Sector,Private Sector Enabler,False
+10010061,Royal Academy Of Music,,Marylebone Road,,,London,,England                       ,NW1 5HT,Wider Public Sector,Private Sector Enabler,False
+10010059,Royal Academy Of Arts,,Burlington House,Piccadilly,Westminster,London,,England                       ,W1V 0DS,Wider Public Sector,Private Sector Enabler,False
+10010055,Roulement Regt,,Alexander Barracks,,Pirbright,Woking,,England                       ,GU24 0QQ,Wider Public Sector,Private Sector Enabler,False
+10010053,Rosyth Royal Dockyard,,Dept Of Logistics,1st Foor Synchrolift Complex,,Rosyth,,Scotland                      ,KY11 2BY,Wider Public Sector,Private Sector Enabler,False
+10010049,Rosebank Medical Practice,,Ashton Road,,,Lancaster,,England                       ,LA1 4JS,Wider Public Sector,Private Sector Enabler,False
+10010044,Romec Installation,,2nd Floor,Bolton LDO,King Street,Bolton,,England                       ,BL1 1AE,Wider Public Sector,Private Sector Enabler,False
+10010042,Roger Preston and Partners Ltd,,Chatworth,29 Broadway,,London,,England                       ,WC1H 9BQ,Wider Public Sector,Private Sector Enabler,False
+10010040,Roehampton Hostel,,230 Roehampton Lane,,,London,,England                       ,SW15 4AE,Wider Public Sector,Private Sector Enabler,False
+10010035,Robinson Low Francis,,54 St John Street,,,London,,England                       ,EC1M 4HF,Wider Public Sector,Private Sector Enabler,False
+10010032,Robertson Group (Scotland) Ltd,,Suite 2,Lomond Court,Castle Business Park,Stirling,,Scotland                      ,FK9 4TU,Wider Public Sector,Private Sector Enabler,False
+10010028,Riverside Medical Centre,,Victoria Road,Walton-Le-Dale,,Preston,,England                       ,PR5 4AY,Wider Public Sector,Private Sector Enabler,False
+10010000,RFASIPT,,Room 506 Carpenter House,Broadquay,,Bath,,England                       ,BA1 5AB,Wider Public Sector,Private Sector Enabler,False
+10009999,RF and C Association,,NE RFCA,53 Old Elvet,,Durham,,England                       ,DH1 3JJ,Wider Public Sector,Private Sector Enabler,False
+10009996,Revenue Commision,,Block 22,Dublin Castle,,Dublin,,Ireland                       ,XXXX,Wider Public Sector,Private Sector Enabler,False
+10009994,Residential Property Tribunal Service,,10 Alfred Place,45-46 Stephenson Street,45-46 Stephenson Street,London,,England                       ,WC1E 7LR,Central Government,Private Sector Enabler,False
+10009993,Residential House,,Penpergwm House,Abergavenny,,Newport,,Wales                         ,NP7 9AE,Wider Public Sector,Private Sector Enabler,False
+10009992,Residential Home,,2nd Floor Cathedral View Home,Gabalfa Avenue,,Cardiff,,Wales                         ,CF4 2RU,Wider Public Sector,Private Sector Enabler,False
+10009989,Renver Primary Care Trust,,Glenburn Health Centre,,,Paisley,Renfrewshire                  ,Scotland                      ,PA2 8DX,Wider Public Sector,Health,False
+10009987,Renfrewshire and Invernesshire Primary Care Trust,,Dykebar Hospital,Grahamston Road,,Paisley,Renfrewshire                  ,Scotland                      ,PA2 7DE,Wider Public Sector,Health,False
+10009985,Rehab Without Walls,,29 Shenley Pavillions,Chalkdell Drive,,Milton Keynes,,England                       ,MK5 6LB,Wider Public Sector,Private Sector Enabler,False
+10009984,Registry Of Shipping and Seamen,,"Anchor Court Keen Rd,",,,Cardiff,,Wales                         ,CF24 5JW,Wider Public Sector,Private Sector Enabler,False
+10009983,Registered Nursey Education Inspectors,,Appeals Tribunal Level 2,Caxton House 6-12 Tothill Street,,London,,England                       ,SW1H 9NH,Wider Public Sector,Private Sector Enabler,False
+10009981,Regimental Headquarters Grenadier Guards,,Wellington Barracks,Birdcage Walk,,London,,England                       ,SW1E 6HQ,Wider Public Sector,Private Sector Enabler,False
+10009980,Regime Services,,Amp House 8th Floor North,Dingwall Road,,Croydon,,England                       ,CR0 2LX,Wider Public Sector,Private Sector Enabler,False
+10009968,Redcliff Royal Infirmary,,Woodstock Road,,,Oxford,,England                       ,OX2 6HE,Wider Public Sector,Private Sector Enabler,False
+10009964,Redbridge and Waltham Forest Health Author,,Beckett's House,2-14 Ilford Hill,,Ilford,,England                       ,IG1 2QX,Wider Public Sector,Private Sector Enabler,False
+10009961,Reaside Clinic,,Birmingham Great Park,Bristol Road South,,Birmingham,West Midlands                 ,England                       ,B45 9BE,Wider Public Sector,Private Sector Enabler,False
+10009960,Reality of Work in Scotland,,Dean House,Kirkentilloch Road Lenzie,,Glasgow,,Scotland                      ,G66 4LD,Wider Public Sector,Private Sector Enabler,False
+10009958,Re Air Sp Group    T,,Waterbeach Barracks,Waterbeach,,Cambridge,,England                       ,CB5 9PA,Wider Public Sector,Private Sector Enabler,False
+10009953,Rathbone Training,,5 Onford Road,,,Aylesbury,,England                       ,HP19 3EQ,Wider Public Sector,Private Sector Enabler,False
+10009952,Rates Collection Agency,,Oxford House,49-55 Chichester Street,,Belfast,,Northern Ireland              ,BT1 4HH,Wider Public Sector,Private Sector Enabler,False
+10009951,RAP Team,,Wrensfield House,Wrensfield Road,,Stockton on Tees,,England                       ,TS19 0AT,Wider Public Sector,Private Sector Enabler,False
+10009948,Ramgarhia Sabha Reading,,Ramgarhia Sikh Centre,234 London Road,Earley,Reading,,England                       ,RG6 1AH,Wider Public Sector,Private Sector Enabler,False
+10009945,Railtrack,,Fitzroy House,355 Euston Road,,London,,England                       ,NW1 3AL,Wider Public Sector,Private Sector Enabler,False
+10009943,Rail Passengers Council,,Ground Floor,Whittles House,14 Pentonville Road,London,,England                       ,N1 9HF,Wider Public Sector,Private Sector Enabler,False
+10009933,(closed) RAF Detatchment,,Gioia Del Colle Supplies Squadron,,,,,BFP,BFPO 569,Central Government,MoD - RAF,False
+10009931,RAF Bruggen,,Main Office,Bruggen,,Bruggen,,BFP,BFPO 25,Central Government,MoD - RAF,False
+10009923,Quinzone EiCAZ,,Four Dwellings High School ,Four Dwellings Lane,,Birmingham,West Midlands                 ,England                       ,B32 1RJ,Wider Public Sector,Private Sector Enabler,False
+10009918,Queensland Purchasing,,Room 15,Mineral House,41 George Street,Brisbane,,Australia                     ,4000,Wider Public Sector,Private Sector Enabler,False
+10009914,Queens Park Community School,,Aylestone Avenue,,,London,,England                       ,NW6 7AD,Wider Public Sector,Private Sector Enabler,False
+10009912,Queens Drive Pools,,County Road,,,Liverpool,,England                       ,L4 5SD,Wider Public Sector,Private Sector Enabler,False
+10009901,Queen Elizabeth Hospital NHS Trust (Queen Elizabeth Hospital Kings Lynn NHS Trust The),,Queen Elizabeth Hospital,Stadium Road,Woolwich,Woolwich,Buckinghamshire               ,England                       ,SE18 4QH,Wider Public Sector,Acute Trust,False
+10009895,Quedgeley Medical Centre,,Olympus Park,Quedgeley,,Gloucester,,England                       ,GL2 4NF,Wider Public Sector,Private Sector Enabler,False
+10009893,Quantum Care,,4 Silver Court,Watchmead,,Welwyn Garden City,,England                       ,AL7 1TS,Wider Public Sector,Private Sector Enabler,False
+10009890,Qualifications and Curriculum Development Agency,QCDA,1st Floor,83 Piccadilly,,London,,England                       ,W1J 8QA,Central Government,NDPB,False
+10009889,Quaker Resource,,Friends House,173 - 177 Euston Road,,London,,England                       ,NW1 2BJ,Wider Public Sector,Private Sector Enabler,False
+10009888,Quadrant-Brownswood Tenant Ltd,,43-45 Mountgrove Road,,,London,,England                       ,N5 2LX,Wider Public Sector,Private Sector Enabler,False
+10009887,Quadrant Wdo Post Office,,35/50 Rathbone Place,,,London,,England                       ,W1P 1AA,Wider Public Sector,Private Sector Enabler,False
+10009886,QMP Management,,Spratton Road,Brixworth,,Northampton,,England                       ,NN6 9DS,Wider Public Sector,Private Sector Enabler,False
+10009885,QM 1st Battalion Coldstream Guards,,Victoria Barracks,Sheet Street,,Windsor,,England                       ,SL4 1HF,Wider Public Sector,Private Sector Enabler,False
+10009884,QM (A) Dept,,1 Regt AAC,,, ,,Germany                       ,BFPO 47,Wider Public Sector,Private Sector Enabler,False
+10009880,Public Works and Government Services London,,Canada House,Trafalgar Square,Pall Mall East,London,,England                       ,SW1Y 5BJ,Wider Public Sector,Private Sector Enabler,False
+10009879,Public Trust Office,,Room 12 Stewart House,24 Kingsway,,London,,England                       ,WC2B 6JX,Wider Public Sector,Private Sector Enabler,False
+10009878,Public Record Office Northern Ireland,,66 Balmoral Avenue,,,Belfast,,Northern Ireland              ,BT9 6NY,Wider Public Sector,Private Sector Enabler,False
+10009877,Public Procurement Service,,Government Complex-Daejeon,920 Dunsan-dong,Seo-gu,Daejeon,,"Korea, Republic of            ",302-701,Wider Public Sector,Private Sector Enabler,False
+10009873,Public Contractors Association,,7 Marsham Street,,,London,,England                       ,SW1P 3DW,Wider Public Sector,Private Sector Enabler,False
+10009871,Promoting Regeneration in Oldham,,Hollingwood Business Centre,Albert Street,Hollingwood,Oldham,,England                       ,OL8 3QL,Wider Public Sector,Private Sector Enabler,False
+10009870,Professional Construction Skills (PCS),,Redridge House,100 Trippet Lane,,Sheffield,,England                       ,S1 4EL,Wider Public Sector,Private Sector Enabler,False
+10009869,Procureweb,,Information Services,Duthie Library,Heath Park Hospital,Cardiff,,Wales                         ,CF14 4XN,Wider Public Sector,Private Sector Enabler,False
+10009868,Procurement Strategy Implementation Group,,George Service House Level 6,11 University Gardens,,Glasgow,,Scotland                      ,G12 8QH,Wider Public Sector,Private Sector Enabler,False
+10009866,Privy Council Office,,2 Carlton Garden,,,London,,England                       ,SW1Y 5AA,Central Government,,False
+10009865,Private Sector Partnering Unit,,Room 225,Churchill House,,Belfast,,Northern Ireland              ,BT,Wider Public Sector,Private Sector Enabler,False
+10009864,Prison Insitute Of Psychiatry,,De Crespigny Park,,,London,,England                       ,SE5 8AF,Wider Public Sector,Private Sector Enabler,False
+10009861,Priory and Springhill Surgeries,,Priory Surgery,26 High Street,,Holywood,,Northern Ireland              ,BT18 9AD,Wider Public Sector,Private Sector Enabler,False
+10009860,Priority Youth Housing,,62 Bedminster Parade,Bedminster,,Bristol,,England                       ,BS4 4HR,Wider Public Sector,Private Sector Enabler,False
+10009858,Princes Trust,,"7th Floor,Lion House",Oscott Road Witton,,Birmingham,West Midlands                 ,England                       ,B6 7UH,Wider Public Sector,Private Sector Enabler,False
+10009856,Prince of Wales Hospice,,Halfpenny Lane,,,Pontefract,,England                       ,WF8 4BG,Wider Public Sector,Private Sector Enabler,False
+10009853,Prime Ministers Office,,10 Downing Street,,,London,,England                       ,SW1A 2AA,Central Government,,False
+10009845,Prescribing Support Unit,,Brunswick Court,Bridge Street,,Leeds,West Yorkshire                ,England                       ,LS2 7RJ,Wider Public Sector,Private Sector Enabler,False
+10009843,Precinct Catering,,Staff House,4 Abercromby Square,,Liverpool,,England                       ,L69 3BX,Wider Public Sector,Private Sector Enabler,False
+10009842,Prebend Day Centre,,12 Prebend Street,,,Bedford,,England                       ,MK40 1QW,Wider Public Sector,Private Sector Enabler,False
+10009841,Practitioner Services Pharmacy,,Hillside Crescent,,,Edinburgh,,Scotland                      ,EH7 5EA,Wider Public Sector,Private Sector Enabler,False
+10009838,Consumer Council for Postal Services (Postwatch),Postwatch,28-30 Grosvenor Gardens,,,London,,England                       ,SW1W 0TT,Central Government,NDPB,False
+10009836,Post Graduate Medical School,,Hammersmith Hospital,Du Cane Road,,London,,England                       ,W12 0NN,Wider Public Sector,Private Sector Enabler,False
+10009835,POSND,,55 Argyle St,,,Swindon,,England                       ,SN2 6AS,Wider Public Sector,Private Sector Enabler,False
+10009833,Portsmouth Students Union,,Student Centre,Cambridge Road,,Portsmouth,,England                       ,PO1 2EF,Wider Public Sector,Private Sector Enabler,False
+10009832,Portsmouth Outdoor Centre,,Eastern Road,,,Portsmouth,,England                       ,PO3 5LY,Wider Public Sector,Private Sector Enabler,False
+10009828,Portlethen Group Practice,,Medical Centre,Portlethen,,Aberdeen,,Scotland                      ,AB12 4QP,Wider Public Sector,Private Sector Enabler,False
+10009827,Portico Housing Association Ltd,,Portico House,3 Jo Street,Salford,Manchester,Greater Manchester            ,England                       ,M5 4AB,Wider Public Sector,Housing Associations,False
+10009807,Picton Sports Centre,,Wellington Road,,,Liverpool,,England                       ,L15 4LE,Wider Public Sector,Private Sector Enabler,False
+10009806,Pickering and Ferens Homes,,Silvester House,The Maltings,Silvester Street,Hull,,England                       ,HU1 3HA,Wider Public Sector,Private Sector Enabler,False
+10009802,Petworth Cottage Nursing Home,,Fittleworth Road,,,Petworth,,England                       ,GU28 0MQ,Wider Public Sector,Private Sector Enabler,False
+10009800,Peter Lloyd Leisure Centre,,Bankfield Road,,,Liverpool,,England                       ,L13 0BQ,Wider Public Sector,Private Sector Enabler,False
+10009797,Chemicals Regulation Directorate,,Mallard House,Kings Pool,3 Peasholme Green,York,North Yorkshire               ,England                       ,YO1 2PX,Central Government,Executive Agency,False
+10009796,Perth Royal Infirmary,,Taymount Terrace,,,Perth,,Scotland                      ,PH1 1NX,Wider Public Sector,Private Sector Enabler,False
+10009795,Perth Leisure Pool,,Glasgow Road,,,Perth,,Scotland                      ,PH2 0HZ,Wider Public Sector,Private Sector Enabler,False
+10009791,Perth Academy,,Murray Place,,,Perth,,Scotland                      ,PH1 1NJ,Wider Public Sector,Private Sector Enabler,False
+10009788,Penumbra,,Norton Park,57 Albion Road,,Edinburgh,,Scotland                      ,EH7 5QY,Wider Public Sector,Private Sector Enabler,False
+10009786,Pentlands Science Park,,Bush Loan,,,Edinburgh,,Scotland                      ,EH17 7JH,Wider Public Sector,Private Sector Enabler,False
+10009782,Pensions and Overseas Benefit Directorate,,"Tyneview Park,",Whitley Road,,Newcastle-Upon-Tyne,,England                       ,NE98 1BA,Wider Public Sector,Private Sector Enabler,False
+10009766,Pecan Ltd,,1-3 Atwell Road,Peckham,,London,,England                       ,SE15 4TW,Wider Public Sector,Private Sector Enabler,False
+10009764,Pearce Institute Care Services,,840 Govan Road,Glasgow,,Glasgow,,Scotland                      ,G51 3UU,Wider Public Sector,Private Sector Enabler,False
+10009760,PCB,,11 Belgrave Road,,,London,,England                       ,SW1V 1RB,Wider Public Sector,Private Sector Enabler,False
+10009759,PC and DAS,,"Building 2,",TSG    DSDC Dulmen,, ,,Germany                       ,BFPO 44,Wider Public Sector,Private Sector Enabler,False
+10009757,Paymaster 1836 Ltd,,Sutherland House,Russell Way,,Crawley,,England                       ,RH10 1UH,Wider Public Sector,Private Sector Enabler,False
+10009753,Patterson Institute for Cancer Research,,Christie Hospital NHS Trust,Wilmslow Road,,Manchester,,England                       ,M20 4BX,Wider Public Sector,Private Sector Enabler,False
+10009751,Pathhead Medical Centre,,210 Main Street,,,Pathhead,,Scotland                      ,EH37 5PP,Wider Public Sector,Private Sector Enabler,False
+10009745,Partners In Health,,153a Stroud Rd,,,Gloucester,,England                       ,GL1 5JJ,Wider Public Sector,Private Sector Enabler,False
+10009744,Parsons Brinckerhoff Ltd,PB,Poplar House,Park West Sealand Road,Sealand Road,Chester,Cheshire                      ,England                       ,CH1 4RN,Wider Public Sector,Private Sector Enabler,False
+10009740,Parole Board for Scotland,,Room Y1/13 Saughton House,Broomhouse Drive,,Edinburgh,,Scotland                      ,EH11 3DX,Wider Public Sector,Private Sector Enabler,False
+10009738,Parliamentary Office,,12 - 14 High Road,,,London,,England                       ,N2 9PJ,Wider Public Sector,Private Sector Enabler,False
+10009732,Parkside Housing,,Norfolk Square Mews,,,London,,England                       ,W2 1RZ,Wider Public Sector,Private Sector Enabler,False
+10009729,Parkroyal Community School,,Athey Street,,,Macclesfield,,England                       ,SK11 6QU,Wider Public Sector,Private Sector Enabler,False
+10009721,Park Road Sports Centre,,Steble St,,,Liverpool,,England                       ,L8 6QH,Wider Public Sector,Private Sector Enabler,False
+10009717,Park Avenue Mental Health Resource Centr,,65C Park Avenue,,,Enfield,,England                       ,EN1 2HH,Wider Public Sector,Private Sector Enabler,False
+10009716,Parish of St Mary Magdalin and St Davids,,St Mary Magdalin Church,Holloway Road,,London,,England                       ,N7 8LT,Wider Public Sector,Private Sector Enabler,False
+10009715,Parcel Force,,Curzon Street,Orrell Lane Bootle,Winnersh Triangle,Birmingham,West Midlands                 ,England                       ,B4 7XG,Wider Public Sector,Private Sector Enabler,False
+10009710,Paisley Partnership,,10 Fallow Crescent,,,Paisley,,Scotland                      ,PA3 1NS,Wider Public Sector,Private Sector Enabler,False
+10009707,Oxfordshire Private Hospitals,,St Lukes Hospital,Latimer Road,,Oxford,,England                       ,OX3 7PF,Wider Public Sector,Private Sector Enabler,False
+10009705,Ovingdean Hall School,,Greenways,Ovingdean,,Brighton,Sussex                        ,England                       ,BN2 7BJ,Wider Public Sector,Specialist Schools,False
+10009702,Outlook,,1 Kay Street,Openshaw,,Manchester,,England                       ,M11 2DX,Wider Public Sector,Private Sector Enabler,False
+10009698,Our Lady of Victories Church,,16 Abingdon Road,,,London,,England                       ,W8 6AF,Wider Public Sector,Private Sector Enabler,False
+10009689,Otterburn ATE,,Main Office,,,Otterburn,,England                       ,NE19 1NX,Wider Public Sector,Private Sector Enabler,False
+10009675,Operational Managers Office - Womens Pri,,2 Foston Close,Foston,,Derby,,England                       ,DE65 5DL,Wider Public Sector,Private Sector Enabler,False
+10009672,Open Zone CLC,,Behind St Wilfrids RC School,Harton Lane,,South Shields,,England                       ,NE34 0PH,Wider Public Sector,Private Sector Enabler,False
+10009666,Olton Grange,,84 Warwick Road,Olton,,Solihull,,England                       ,B92 7JJ,Wider Public Sector,Private Sector Enabler,False
+10009662,Oldham Citizens Advice Bureau,,1-2 Ascroft Court,Peter Street,,Oldham,,England                       ,OL1 1HP,Wider Public Sector,Charity,False
+10009661,Old Trafford Community School,,Malvern Street,Old Trafford,,Manchester,,England                       ,M16 9AD,Wider Public Sector,Private Sector Enabler,False
+10009660,Old Medical School Micology Ref Laborato,,Thoresby Place,,,Leeds,West Yorkshire                ,England                       ,LS2 9NL,Wider Public Sector,Private Sector Enabler,False
+10009656,OHM CI Wales,,Phase 1 Government Buildings,Ty - Glas,Llanislen,Cardiff,,Wales                         ,CF4 5FQ,Wider Public Sector,Private Sector Enabler,False
+10009651,Office Of The Second Sea Lord and Commander-in-Chief,,"Naval Home Command Victory Building,",The Parade HM Naval Base,,Portsmouth,,England                       ,PO1 3LS,Wider Public Sector,Private Sector Enabler,False
+10009645,e Government Unit,,Stockley House,130 Wilton Road,,London,,England                       ,SW1V 1LQ,Central Government,,False
+10009642,Office of Passenger Rail Franchising,,2 Hays Lane,Golding's House,,London,,England                       ,SE1 2HB,Central Government,NDPB,False
+10009639,Office of Manpower Economics,,Oxford House 76 Oxford Street,London,Greater London,London,Greater London,England,W1D 1BS,Central Government,Other,False
+10009636,Office of Fair Trading,,Fleetbank House 2-6 Salisbury Square,London,Greater London,London,Greater London,England,EC4Y 8JX,Central Government,TBA,False
+10009635,Office Of Electrical Regulation,,10th Floor Hagley House,Hagley Road,Edgbaston,Birmingham,West Midlands                 ,England                       ,B16 8QG,Wider Public Sector,Private Sector Enabler,False
+10009633,Office Of Commodore RFA Flotilla,,COM RFA  Lancelot Building,"Postal Point 29,HM Naval Base",,Portsmouth,,England                       ,PO1 3NH,Wider Public Sector,Private Sector Enabler,False
+10009624,Oakengates Medical Practice,,27 Limes Walk,Oakengates,,Telford,,England                       ,TF2 6JJ,Wider Public Sector,Private Sector Enabler,False
+10009619,Nutwood Cottage Childrens Day Nursery,,553 Newark Road,,,Lincoln,,England                       ,LN6 8RY,Wider Public Sector,Private Sector Enabler,False
+10009615,NTMBC,,Moor Edse 1st School,Gartmsix ,Killingworth,Newcastle Upon Tyne,,England                       ,NE12 0QL,Wider Public Sector,Private Sector Enabler,False
+10009614,Novas Ouvertures Group,,Bridge House,233-234 Blackfriars Road,,London,,England                       ,SE1 8NW,Wider Public Sector,Private Sector Enabler,False
+10009610,Norwich Diocesan Board of Education,,Diocesan House,109 Dereham Road,Easton,Norwich,,England                       ,NR9 5ES,Wider Public Sector,Private Sector Enabler,False
+10009609,Norwegian Trade Council,,Lower Regent Street,,,London,,England                       ,SW1Y 4LR,Wider Public Sector,Private Sector Enabler,False
+10009604,Northumbria Calvert Trust,,Kielder Water,,,Hexham,,England                       ,NE48 1BS,Wider Public Sector,Private Sector Enabler,False
+10009603,Northumberland Park Community School,,Trulock Road,,,London,,England                       ,N17 OPG,Wider Public Sector,Private Sector Enabler,False
+10009572,North West Water PLC,,Dawson House,Liverpool Road,Great Sankey,Warrington,Cheshire                      ,England                       ,WA5 3LW,Wider Public Sector,Water,False
+10009570,North West Region,,Main Office,,,Warrington,,England                       ,WA4 1HG,Wider Public Sector,Private Sector Enabler,False
+10009564,North West Institute of Further and Higher Education,,Strand Road,,,Londonderry,County Londonderry            ,Northern Ireland              ,BT48 7AL,Wider Public Sector,Education,False
+10009562,North West Arts Board,,Duke Street,,,Liverpool,,England                       ,L1 4JR,Wider Public Sector,Private Sector Enabler,False
+10009560,North Wakefield Community Group,,c/o 2 Marizon Grove,,,Wakefield,,England                       ,WF1 3NJ,Wider Public Sector,Private Sector Enabler,False
+10009558,North Trent Workforce Confederation,,Floor 5 Don Valley House,Savile Street,,Sheffield,,England                       ,S4 UQ,Wider Public Sector,Private Sector Enabler,False
+10009554,North Manchester Womens Aide,,PO Box 35,NDO,,Manchester,,England                       ,M8 0BD,Wider Public Sector,Private Sector Enabler,False
+10009546,North Irish Horse,,Main Office,,, ,,Northern Ireland              ,BFPO 806,Wider Public Sector,Private Sector Enabler,False
+10009544,North East Sheffield Education Action Zone,,Thorncliffe Hall Annexe,Thorncliffe Park Estate,Chapeltown,Sheffield,,England                       ,S35 2PH,Wider Public Sector,Private Sector Enabler,False
+10009543,North East Chamber of Commerce,,Aykley Heads Business Centre,Aykley Heads,,Durham,,England                       ,DH1 5TS,Wider Public Sector,Private Sector Enabler,False
+10009539,Norris Green Leisure Centre,,Carr Lane,Norris Green,,Liverpool,,England                       ,L11 2XY,Wider Public Sector,Private Sector Enabler,False
+10009538,Norfolk Property Services,,County Hall,Martineau Lane,,Norwich,,England                       ,NR1 2SF,Wider Public Sector,Private Sector Enabler,False
+10009525,No 1 Dental Group,,Main Office,,, ,,England                       ,OO,Central Government,,False
+10009512,NHS Purchasing and Supply Agency,NHS PASA,Premier House,60 Caversham Road,,Reading,Berkshire                     ,England                       ,RG1 7EB,Wider Public Sector,Government Bodies Responsible for Health,False
+10009511,NHS Magazine,,Clifford Chambers,Clifford Street,,York,Yorkshire                     ,England                       ,YO1 9RD,Wider Public Sector,Acute Trust,False
+10009506,NHS Executive,,80-94 Newington Causeway,6E60 Quarry House Quarry Hill,930-932 Birchwood Boulevard,London,,England                       ,SE1 6EF,Wider Public Sector,Acute Trust,False
+10009502,Newtownabbey Borough Council,,Headquarters Mossley Mill,Newtonabbey,County Antrim,Newtonabbey,County Antrim,Northern Ireland,BT36 5QA,Wider Public Sector,Local Government,False
+10009499,Newsham House,,Newsham Park,,,Liverpool,,England                       ,L6 7UJ,Wider Public Sector,Private Sector Enabler,False
+10009491,Newland Childrens Services,,Francis Reckitt House,Newland,,Hull,,England                       ,HU6 7RJ,Wider Public Sector,Private Sector Enabler,False
+10009480,Newcastle Basic Skills Service,,Heaton Education Centre,Trewhitt Road,,Newcastle upon Tyne,,England                       ,NE6 5DY,Wider Public Sector,Private Sector Enabler,False
+10009475,New Testament Church of God,,3 Easterly Road,,,Leeds,West Yorkshire                ,England                       ,LS8 2TN,Wider Public Sector,Private Sector Enabler,False
+10009472,New Millenium Experience Company,,110 Buckingham Palace Road,Park Gate,18 Westgate Street,London,,England                       ,SW1W 9SA,Central Government,NDPB,False
+10009470,New Link Project Ltd,,Unit 37,Lenton Business Centre,Lenton Boulevard,Nottingham,,England                       ,NG7 2BY,Wider Public Sector,Private Sector Enabler,False
+10009454,Neovenator Community Organisation,,The Peckham Settlement,Goldsmith Road,Peckham,London,,England                       ,SE15 5TF,Wider Public Sector,Private Sector Enabler,False
+10009453,Neath Port Talbot CBF Print and Graphics,,Unit 12,Milland Road Ind Park,,Neath,,Wales                         ,SA11 1NJ,Wider Public Sector,Private Sector Enabler,False
+10009452,NDC,,Airedale House,Landmark Court,Revie Road,Leeds,West Yorkshire                ,England                       ,LS11 8JT,Wider Public Sector,Private Sector Enabler,False
+10009451,NBW Crosher and James,,Brunswick House,Brunswick Place,,Southampton,,England                       ,SO15 2AP,Wider Public Sector,Private Sector Enabler,False
+10009449,Naval Party 2010 Rfa Diligence,,Main Office,-,,-,,England,BFPO 494,Central Government,MoD - Navy,False
+10009447,Nationwide Nursing Home,,24 Osidge Lane,Southgate,,London,,England                       ,N1 5JE,Wider Public Sector,Private Sector Enabler,False
+10009446,National Specialist Law Enforcement Centre,,PO Box 208,,,Bedford,,England                       ,MK44 3WA,Wider Public Sector,Private Sector Enabler,False
+10009442,National Patient Safety Agency,,4-8 Maple Street,,,London,,England                       ,W1T 5HD,Central Government,Central Bodies,False
+10009441,National Office for the Information Econ,,Main Office,,,Canberra,,Australia                     ,2605,Wider Public Sector,Private Sector Enabler,False
+10009439,National Museums Liverpool,,0151 478 4245,William Brown Street,,Liverpool,Merseyside                    ,England                       ,L3 8EN,Central Government,NDPB,False
+10009423,National Exhibition Centre,,Level 1V Offices,,,Birmingham,West Midlands                 ,England                       ,B40 1NT,Wider Public Sector,Private Sector Enabler,False
+10009421,National Design Consultancy,,102 West Port,,,Edinburgh,,Scotland                      ,EH3 9HS,Wider Public Sector,Private Sector Enabler,False
+10009417,National Community Safety Network,,7 Prospero Way,Harftord,,Huntingdon,,England                       ,PE29 1PG,Wider Public Sector,Private Sector Enabler,False
+10009414,National Centre For Popular Music,,Development Office The Workstation,15 Paternoster Row,,Sheffield,,England                       ,S1 2BX,Wider Public Sector,Private Sector Enabler,False
+10009412,National Care Standards Commission,,St Davids Court,Union Street,,Wolverhampton,West Midlands                 ,England                       ,WV1 3NE,Central Government,Central Bodies,False
+10009400,Murray Ward and Partners,,12 Ogle Street,,,London,,England                       ,W1P 7LG,Wider Public Sector,Private Sector Enabler,False
+10009398,Multi-site Connectivity Advisory Service,,Minority Communities Achievement Service Stour Valley LRC,Shalmsford Street,Chartham,Canterbury,,England                       ,CT4 7QN,Wider Public Sector,Private Sector Enabler,False
+10009392,Mowlem Aqumen c/o The Pensions Service,,TD223,D Block,Tyneview Park,Newcastle Upon Tyne,,England                       ,NE98 1BA,Wider Public Sector,Private Sector Enabler,False
+10009388,Mount Stuart House and Gardens,,Mount Stuart,,,Isle Of Bute,,Scotland                      ,PA20 9LR,Wider Public Sector,Private Sector Enabler,False
+10009380,Mostyn Gallery Ltd,,12 Vaughan Street,,,Llandudno,,Wales                         ,LL30 1AB,Wider Public Sector,Private Sector Enabler,False
+10009372,Moray Leisure Centre,,Borough Briggs Road,,,Elgin,,Scotland                      ,IV30 1AP,Wider Public Sector,Private Sector Enabler,False
+10009361,Montrose Port Authority,,South Quay,,Ferryden,Montrose,,Scotland                      ,DD10 9SL,Wider Public Sector,Private Sector Enabler,False
+10009343,Mixenden Outdoor Centre,,Clough Lane,Mixenden,,Halifax,West Yorkshire                ,England                       ,HX2 8SH,Wider Public Sector,Private Sector Enabler,False
+10009332,Millhouse Farm,,Framewood Road,Fulmer,,Slough,,England                       ,SL3 6JR,Wider Public Sector,Private Sector Enabler,False
+10009316,Mid Yorkshire Chamber of Commerce and Industry Ltd.,MYCCI,Commerce House,Wakefield Road,Aspley,Huddersfield,West Yorkshire                ,England                       ,HD5 9AA,Wider Public Sector,Private Sector Enabler,False
+10009312,Metropolitan Housing Trust Limited,,Cambridge House 109 Mayes Road Wood Green,London,Greater London,London,Greater London,England,N22 6UR,Wider Public Sector,Housing Associations,False
+10009311,Metronet Rail BCV Limited,,30 The Colonnade,Level 5,Canary Wharf,London,,England                       ,E14 5EU,Wider Public Sector,Private Sector Enabler,False
+10009310,Methodist Homes,,Parkman House,Lloyd Drive,,Elesmere Port,,England                       ,CH65 9HQ,Wider Public Sector,Private Sector Enabler,False
+10009296,Mental Health Act Commission,MHAC,Maid Marian House,56 Hounds Gate,,Nottingham,Nottinghamshire               ,England                       ,NG1 6BG,Central Government,Support,False
+10009292,Medisource,,35-37 Grosvenor Gardens,,,London,,England                       ,SW1W OBS,Wider Public Sector,Private Sector Enabler,False
+10009291,Medirest,,Royal Hospital for Neuro Disability,West Hill,Putney,London,,England                       ,SW15 3SW,Wider Public Sector,Private Sector Enabler,False
+10009290,Medico Legal Centre,,Water Street,,,Sheffield,,England                       ,S3 7ES,Wider Public Sector,Private Sector Enabler,False
+10009262,Mapeley Ltd,,Euston Tower,"20th Floor, Euston Tower",286 Euston Road,London,,England                       ,NW1 3AS,Wider Public Sector,Private Sector Enabler,False
+10009228,Look Ahead Housing and Care Limited,,1 Derry Street Kensington,London,Greater London,London,Greater London,England,W8 5HY,Wider Public Sector,Housing Associations,False
+10009215,London Transport Users Committee,,Clements House,14-18 Gresham Street,,London,,England                       ,EC2V 7PR,Wider Public Sector,Private Sector Enabler,False
+10009206,London Diocesan Board for Schools,,36 Causton Street,,,London,,England                       ,SW1P 4AU,Wider Public Sector,Private Sector Enabler,False
+10009183,London 2012 (Bid Company for London),,British Olympic Association,1 Wandsworth Plain,,London,,England                       ,SW18 1EH,Wider Public Sector,Private Sector Enabler,False
+10009173,Local Purchase,,Building 33a,Menwith Hill Station,,Harrogate,,England                       ,HG3 2RP,Wider Public Sector,Private Sector Enabler,False
+10009163,Llandaff Diocesan,,Heol Fair,Llandaff,,Cardiff,,Wales                         ,CF5 2EE,Wider Public Sector,Private Sector Enabler,False
+10009162,LJB and Co,,144 Liverpool Road,,,London,,England                       ,N1 1LA,Wider Public Sector,Private Sector Enabler,False
+10009159,Liverpool Vision,,The Observatory,1 Old Haymarket,,Liverpool,,England                       ,L1 6EN,Wider Public Sector,Private Sector Enabler,False
+10009158,Liverpool Student Homes,,140 Mount Pleasant,,,Liverpool,,England                       ,L3 5SR,Wider Public Sector,Private Sector Enabler,False
+10009153,Liverpool Disabled Living Centre,,101 Kempston Street,,,Liverpool,,England                       ,L3 8HE,Wider Public Sector,Private Sector Enabler,False
+10009151,Liverpool Chamber of Commerce,,1st Floor,1 Old Hall Street,,Liverpool,,England                       ,L3 9HG,Wider Public Sector,Private Sector Enabler,False
+10009149,Littledown Centre,,Chaseside,,,Bournemouth,,England                       ,BH7 7DX,Wider Public Sector,Private Sector Enabler,False
+10009134,Lincolnshire Tec,,Waterside South,,,Lincoln,,England                       ,LN5 7JH,Wider Public Sector,Private Sector Enabler,False
+10009131,Lincoln Co-Op,,1 Boultham Park Road,,,Lincoln,,England                       ,LN6 7SA,Wider Public Sector,Private Sector Enabler,False
+10009124,Life Education Centres Swindon,,5 Wardour Close,Lann,,Swindon,,England                       ,SN3 1JZ,Wider Public Sector,Private Sector Enabler,False
+10009120,Liberata (on behalf of Redcar and Cleveland B C),,156 Council Offices,Fabian Road,,Eston,,England                       ,TS6 9AR,Wider Public Sector,Private Sector Enabler,False
+10009115,Ley Community (Oxford) Ltd,,Sandy Croft,"Sandy Lane,Yarnton",,Oxford,,England                       ,OX5 1PB,Wider Public Sector,Private Sector Enabler,False
+10009094,Leicestershire and Rutland Organisation for the Relief of Suffering,,Groby Road,,,Leicester,,England                       ,LE3 9QE,Wider Public Sector,Private Sector Enabler,False
+10009089,Leicester Education Business Comp,,17a Meridian East,,,Leicester,,England                       ,LE19 1WZ,Wider Public Sector,Private Sector Enabler,False
+10009088,Leicester City Cluster,,Knighton Fields Centre,Herrick Rd.,,LEICESTER,,England                       ,LE2 6DH,Wider Public Sector,Private Sector Enabler,False
+10009082,Legal Aid Board,,12 Rower  Street,,,London,,England                       ,WC1N 2JL,Wider Public Sector,Private Sector Enabler,False
+10009081,Leeds Theatre Trust Ltd,,West Yorkshire Playhouse,Quarry Hill,,Leeds,West Yorkshire                ,England                       ,LS2 7UP,Wider Public Sector,Private Sector Enabler,False
+10009078,Leeds Irish Health and Homes Ltd,,170-172 Roundhay Road,,,Leeds,West Yorkshire                ,England                       ,LS8 5PL,Wider Public Sector,Private Sector Enabler,False
+10009076,Leeds Detox Centre,,186 Wood House Lane,,,Leeds,West Yorkshire                ,England                       ,LS2 9DX,Wider Public Sector,Private Sector Enabler,False
+10009072,Lee Manor Sports Centre,,Childwall Valley Rd,,,Liverpool,,England                       ,L27 3YA,Wider Public Sector,Private Sector Enabler,False
+10009071,LEDU,,LEDU House,Upper Galwally,,Belfast,,Northern Ireland              ,BT8 6TB,Wider Public Sector,Private Sector Enabler,False
+10009070,Learning Support Team - Newbury,,Fir Tree Lane,,,Newbury,,England                       ,RG14 2HX,Wider Public Sector,Private Sector Enabler,False
+10009068,Learning and Skills Developement Agency,,Citadel Place,,,Tinworth,,England                       ,SE11 5EF,Wider Public Sector,Private Sector Enabler,False
+10009067,Learn Direct West Yorkshire,,Annexe 1,Barley Business and Technology Centre,Grange Road,Berley,,England                       ,WF17 6ER,Wider Public Sector,Private Sector Enabler,False
+10009065,L'Chu Vonim Youth Centre,,81 Bewick Road,,,Gateshead,,England                       ,NE8 1RR,Wider Public Sector,Private Sector Enabler,False
+10009063,Law Society,,Rich House,40 Crimscott Street,,Bermondsey,,England                       ,SE1 5TE,Wider Public Sector,Private Sector Enabler,False
+10009062,Law Courts,,Quayside,,,Newcastle Upon Tyne,,England                       ,NE1 3LA,Central Government,Private Sector Enabler,False
+10009061,Laurencekirk Medical Group,,Blackiemuir Avenue,,,Laurencekirk,,Scotland                      ,AB30 1DX,Wider Public Sector,Private Sector Enabler,False
+10009059,Latch,,176 Chapletown Road,,,Leeds,West Yorkshire                ,England                       ,LS7 4HP,Wider Public Sector,Private Sector Enabler,False
+10009048,Landmarc Support Services,,HQ Army Training Estate,Land Warfare Centre,Imber Road,Warminster,,England                       ,BA12 0DJ,Central Government,Private Sector Enabler,False
+10009047,Land Registers (NI),,Lincoln Building,27-45 Great Victoria Street,,Belfast,,Northern Ireland              ,BT2 7SL,Wider Public Sector,Private Sector Enabler,False
+10009044,Lancashire Purchasing Agency Ltd,,Lea Road,Lea,,Preston,,England                       ,PR4 0RB,Wider Public Sector,Private Sector Enabler,False
+10009040,Lanarkshire Development Agency,,New Lanarkshire House,"Willow Drive,Strathclyde Business Park",,Bellshill,,Scotland                      ,ML4 3AD,Wider Public Sector,Private Sector Enabler,False
+10009036,Lambeth Supplies,,Zennor Road Ind Estate,"Wier Road,Balham",,London,,England                       ,SW12 0PP,Wider Public Sector,Private Sector Enabler,False
+10009020,Ladybur H Co-Op Ltd,,68 Ladysmith Road,Tottenham,,London,,England                       ,N17 9AG,Wider Public Sector,Private Sector Enabler,False
+10009012,KSS Workforce Development Confederation,,"2nd Floor International HSe,",5 Trafalgar Court,,Brighton,,England                       ,BN1 4FB,Wider Public Sector,Private Sector Enabler,False
+10009011,Korean Embassy,,6 Buckingham Gate,,,London,,England                       ,SW1E 6AJ,Wider Public Sector,Private Sector Enabler,False
+10009009,Office of the e-Envoy,KN,OE,Stockley House,130 Wilton Road,London,,England                       ,SW1V 1LQ,Wider Public Sector,NDPB,False
+10009008,Knightswood Hospital,,Knightswood Road,,,Glasgow,,Scotland                      ,G12,Wider Public Sector,Health,False
+10009007,Knights Warner,,20 Hanover Square,,,London,,England                       ,W1R 0AH,Wider Public Sector,Private Sector Enabler,False
+10009006,Kiwi Playgroup,,c/o St Kenneths Primary School,Westmains Road,,East Kilbride,,Scotland                      ,G74 1PU,Wider Public Sector,Private Sector Enabler,False
+10008973,Kings Cliffe Resource Centre,KCRC,Church Walk,Kings Cliffe,,Peterborough,Cambridgeshire                ,England                       ,PE8 6XD,Wider Public Sector,Other,False
+10008969,Kingdom of Fife Tourist Board,,Haig House,Haig Business Park,Balgonie Road Markinch,Fife,,Scotland                      ,KY7 6AQ,Wider Public Sector,Private Sector Enabler,False
+10008968,King Sturge,,7 Stratford Place,,,London,,England                       ,W1C 1ST,Wider Public Sector,Private Sector Enabler,False
+10008967,King George VI Memorial Youth Hostel,,Holland Walk,,,London,,England                       ,W8 7QU,Wider Public Sector,Private Sector Enabler,False
+10008961,King David Foundation,,Harold House,Dunbabin Road,,Liverpool,,England                       ,L15 6XL,Wider Public Sector,Private Sector Enabler,False
+10008958,Kilmore and Oban Church of Scotland,,Church Centre,Glencruitten Road,Oban,Argyll,,Scotland                      ,PA34 4DN,Wider Public Sector,Private Sector Enabler,False
+10008956,Kilburn H Co-Op Ltd,,67c Willesden Lane,Corner Of Douglas Road,,London,,England                       ,NW6 7RL,Wider Public Sector,Private Sector Enabler,False
+10008955,Kidsgrove Citizens Advice Bureau,,Claire House,Liverpool Road,Kidsgrove,Stoke on Trent,,England                       ,ST7 4EM,Wider Public Sector,Private Sector Enabler,False
+10008953,Kerrier Homes Trust Ltd,,ICT Department,Ferris House,Dolcoath Avenue,Camborne,,England                       ,TR14 8SD,Wider Public Sector,Private Sector Enabler,False
+10008939,Keeping It Simple Training Ltd,KIST,Sentinel House,1 Ashley Road,Tottenham Hale,London,,England                       ,N17 9LP,Wider Public Sector,Private Sector Enabler,False
+10008937,Kausar Mahmood Khan,,Dentist,74 High Street,Lees,Oldham,,England                       ,OL4 5AA,Wider Public Sector,Private Sector Enabler,False
+10008934,Justice Research Consortium,,407-409 Archway Road,,,London,,England                       ,N6 4NW,Wider Public Sector,Private Sector Enabler,False
+10008923,Joint Research Councils,,Joint London Office,22 Henrietta Street,Room DP1046A,London,,England                       ,WC2E 8NA,Wider Public Sector,Private Sector Enabler,False
+10008917,John Laing Plc,,133-139 Page Street,Mill Hill,,London,,England                       ,NW7 2ER,Wider Public Sector,Private Sector Enabler,False
+10008915,John Innes Institute,,Colney La,Colney,,Norwich,,England                       ,NR4 7UH,Wider Public Sector,Private Sector Enabler,False
+10008909,Job Ready Unit,,18 South Street,,,Chesterfield,,England                       ,S40 1QX,Wider Public Sector,Private Sector Enabler,False
+10008903,JDCS (Air),,MOD Main Building,"Room 7158 (c/o DFD Registry),Whitehall",,London,,England                       ,SW1A 2HB,Wider Public Sector,Private Sector Enabler,False
+10008902,Jarvis Workspace FM,,Jarvis House,Atlantic Street,Broadheath,Altringham,,England                       ,WA14 5DD,Wider Public Sector,Private Sector Enabler,False
+10008901,Jarvis Plc,,Frogmore Park,,,Hertford,,England                       ,SG14 3RU,Wider Public Sector,Private Sector Enabler,False
+10008897,Jakeman Nursery,,Jakeman Road,Balsall Heath,,Birmingham,West Midlands                 ,England                       ,B12 9NX,Wider Public Sector,Private Sector Enabler,False
+10008895,ITS,,19-30 Alfred Place,,,London,,England                       ,WC1E 7LW,Wider Public Sector,Private Sector Enabler,False
+10008887,Islington Central Library,,2 Fieldway Cres,,,London,,England                       ,N5 1PF,Wider Public Sector,Private Sector Enabler,False
+10008885,ISIS Southampton LEA,,Glenfield Avenue,Bitterne,,Southampton,,England                       ,SO18 4EG,Wider Public Sector,Private Sector Enabler,False
+10008884,ISHS Charitable Trust,,2 Dartmouth Court,Dartmouth Grove,,London,,England                       ,SE10 8AS,Wider Public Sector,Private Sector Enabler,False
+10008879,Iqpl,,15-19 Britten Street,,,London,,England                       ,SW3 3QL,Wider Public Sector,Private Sector Enabler,False
+10008878,IPPortfolio,,Regents College,Inner Circle  Regents Park,,London,,England                       ,NW1 4NS,Wider Public Sector,Private Sector Enabler,False
+10008875,Invictus Training/Learn Direct Centre,,The Orchard,111 Church Lane,Ormston,Manchester,,England                       ,M41 9FJ,Wider Public Sector,Private Sector Enabler,False
+10008865,Interserve FM Ltd,,Foreign & Commonwealth Office,Main Building King Charles Street,,London,,England                       ,SW1A 2AH,Wider Public Sector,Private Sector Enabler,False
+10008864,International Youth Hostel Federation,,1st Floor,Fountain House,Parkway,Welwyn Garden City,,England                       ,AL8 6JH,Wider Public Sector,Private Sector Enabler,False
+10008863,International Students HQ,,229 Great Portland Street,,,London,,England                       ,W1N 5HD,Wider Public Sector,Private Sector Enabler,False
+10008859,International Bible Students Association,,IBSA House,The Ridgeway,,London,,England                       ,NW7 1RN,Wider Public Sector,Private Sector Enabler,False
+10008858,Intercity Westcoast Ltd,,P.O.Box 5631,Birmingham New Street,,Birmingham,West Midlands                 ,England                       ,B2 4QG,Wider Public Sector,Private Sector Enabler,False
+10008857,Integrated and Local Goverment,,Room 2 Riverwalk House,157-161 Millbank,,London,,England                       ,SW1P 4RR,Wider Public Sector,Private Sector Enabler,False
+10008855,Institution Of Electrical Engineers,,2 Savoy Place,6 Hills Way,,London,,England                       ,WC2R 0BL,Wider Public Sector,Private Sector Enabler,False
+10008854,Institute Of Zoology,,The Zoological Society,Regents Park,,London,,England                       ,NW1 4RY,Wider Public Sector,Private Sector Enabler,False
+10008852,Institute of Occupational Medicine,,8 Roxburgh Place,,,Edinburgh,,Scotland                      ,EH8 9SU,Wider Public Sector,Private Sector Enabler,False
+10008851,Institute of Naval Medicine,,Crescent Road,Alverstoke,Alverstoke,Gosport,,England                       ,PO12 2DL,Wider Public Sector,Private Sector Enabler,False
+10008850,Institute Of Germanic Studies,,Institute of Germanic Studies,29 Russell Square,,London,,England                       ,WC1B 5DP,Wider Public Sector,Private Sector Enabler,False
+10008848,Institute Of Environmental Health,,260 Picton Road,Wavertree,,Liverpool,,England                       ,L15 4LP,Wider Public Sector,Private Sector Enabler,False
+10008847,Institute Of Education,,20 Bedford Way,,,London,,England                       ,WC1 0AL,Wider Public Sector,Private Sector Enabler,False
+10008845,Institute Of Community Studies,,18 Victoria Park Square,,,London,,England                       ,E2 9PF,Wider Public Sector,Private Sector Enabler,False
+10008844,Institute Of Child Health,,30 Guilford Street,,,London,,England                       ,WC1N 1EH,Wider Public Sector,Private Sector Enabler,False
+10008843,Institute of Cancer Research,,123 Old Brompton Road,,,London,,England                       ,SW7 3RP,Wider Public Sector,,False
+10008842,Institute Of Animal Health,,West Mains Road,,,Edinburgh,,Scotland                      ,EH9 3JF,Wider Public Sector,Private Sector Enabler,False
+10008837,Inner London Probation Service,,71-73 Great Peter St,,,London,,England                       ,SW1P 2BN,Wider Public Sector,Private Sector Enabler,False
+10008835,Inner London Crown Court,,Newington Causeway,,,London,,England                       ,SE1 6AZ,Central Government,Private Sector Enabler,False
+10008827,Industry and Parliament Trust,,1 Buckingham Place,,,London,,England                       ,SW1E 6HR,Wider Public Sector,Private Sector Enabler,False
+10008826,Industrial Tribunals Regional Office,,14 East Pde,,,Sheffield,,England                       ,S1 2ET,Wider Public Sector,Private Sector Enabler,False
+10008824,Indian Senior Citizens Centre,,Lifelong Learning Centre,16-18 Whalley Road,Whalley Range,Manchester,,England                       ,M16 8AB,Wider Public Sector,Private Sector Enabler,False
+10008823,Independent Tribunal Service,,36 Dale Street,,,Liverpool,,England                       ,L2 5UZ,Wider Public Sector,Private Sector Enabler,False
+10008822,Independent Review Service,,5 Hill St,,,Birmingham,West Midlands                 ,England                       ,B5 4UB,Central Government,Private Sector Enabler,False
+10008810,Ilkeston Christian Fellowship Centre,,112 Smithhurst Road,Giltbrook,,Nottingham,,England                       ,NG16 2UP,Wider Public Sector,Private Sector Enabler,False
+10008809,Ilford Park Polish Home,,.,Stoves,,Newton Abbot,,England                       ,TQ12 6QH,Wider Public Sector,Private Sector Enabler,False
+10008807,IDS,,5th Floor Ockway House,41 Stamford Hill,,London,,England                       ,N16 5SR,Wider Public Sector,Private Sector Enabler,False
+10008804,IC Married Quarters Store,,Hms Caledonia Hilton Rd,Rosyth,,Fife,,Scotland                      ,KY11 2XH,Wider Public Sector,Private Sector Enabler,False
+10008803,IBSEC,,c/o Foreign Commonwealth Office,Room WH/2/308 F&Co Main Building,King Charles Street,London,,England                       ,SW1A 2AH,Wider Public Sector,Private Sector Enabler,False
+10008802,IACR- Long Ashton,,Research Station,Long Ashton,,Bristol,,England                       ,BS41 9AF,Wider Public Sector,Private Sector Enabler,False
+10008800,Hydon Hill,,Cheshire Home,Clockbarn Lane,,Godalming,,England                       ,GU8 4BA,Wider Public Sector,Private Sector Enabler,False
+10008799,Hyder Infrastructure Developments,,2-3 Cornwall Terrace,,,London,,England                       ,NW1 4QP,Wider Public Sector,Private Sector Enabler,False
+10008796,Hunting Contract Services,,Raf Lyneham,,,Chippenham,,England                       ,SN15 4PZ,Wider Public Sector,Private Sector Enabler,False
+10008795,Hunter and Partners,,26-28 Hammersmith Grove,,,London,,England                       ,W6 7HU,Wider Public Sector,Private Sector Enabler,False
+10008794,Hundred Houses S Ltd,,71 Scotland Road,,,Cambridge,,England                       ,CB4 1QN,Wider Public Sector,Private Sector Enabler,False
+10008787,Hull House Improvement S Ltd,,21 Hallgate,Cottingham,,Hull,,England                       ,HU16 4DN,Wider Public Sector,Private Sector Enabler,False
+10008774,HPRS/DETR,,20th floor Sunley Tower,Piccadilly Plaza,,Manchester,,England                       ,M1 4BE,Wider Public Sector,Private Sector Enabler,False
+10008771,Housing Partnership (London) Ltd,,The Office,"Bridgacre,",,Cambridge,,England                       ,CB4 1JU,Wider Public Sector,Private Sector Enabler,False
+10008769,Housing Corporation,,Maple House,149 Tottenham Court Road,,London,,England                       ,W1T 7BN,Central Government,NDPB,False
+10008761,Hounslow and Spelthorne Community,,Mental Health NHS Trust Phoenix Court,531 Staines Road,,Hounslow,,England                       ,TW4 5DP,Wider Public Sector,Private Sector Enabler,False
+10008759,Hospitality and Trading Services,,New Smithfield Market,Whitworth St. East,Ashton Old Road Openshaw,Manchester,,England                       ,M11 2WJ,Wider Public Sector,Private Sector Enabler,False
+10008757,Hospice of the Good Shepherd,,Gordon Lane,Backford,,Nr. Chester,,England                       ,CH2 4DG,Wider Public Sector,Private Sector Enabler,False
+10008756,Hospice Care for Burnley and Pendle,,Pendleside,Colne Road Reedley,,Burnley,,England                       ,BB10 2LW,Wider Public Sector,Private Sector Enabler,False
+10008755,Horsley Huber and Associates,,1 Dalling Road,Hammersmith,,London,,England                       ,W6 0JD,Wider Public Sector,Private Sector Enabler,False
+10008740,Honresfeld Cheshire Home,,Halifax Road,,,Littleborough,,England                       ,OL15 0JF,Wider Public Sector,Private Sector Enabler,False
+10008739,Honourable Society of the Inner Temple,,3 (S) Kings Bench Walk,Inner Temple,,London,,England                       ,EC4Y 7DQ,Wider Public Sector,Private Sector Enabler,False
+10008736,Home-Start Wokingham District,,Shinfield Grange,Cutbush Lane,Shinfield,Reading,,England                       ,RG2 9AF,Wider Public Sector,Private Sector Enabler,False
+10008728,Home in Scotland Ltd,,Cleghorne House,27 Albert Square,,Dundee,,Scotland                      ,DD1 1DJ,Wider Public Sector,Private Sector Enabler,False
+10008725,Home For The Elderly,,Little Sisters Of The Poor,St Joseph's 14 Cismnock Road,,Glasgow,,Scotland                      ,G33 1QT,Wider Public Sector,Private Sector Enabler,False
+10008724,Home Concern For The Elderly,,16 Ashmill Street,,,London,,England                       ,NW1 6RA,Wider Public Sector,Private Sector Enabler,False
+10008720,Holyhead Leisure Centre,,Kingsland Road,Holyhead,,Anglesey,,Wales                         ,LL65 2YE,Wider Public Sector,Private Sector Enabler,False
+10008711,Holy Family Church,,Mackets Lane,Woolton,,Liverpool,,England                       ,L25 8TG,Wider Public Sector,Private Sector Enabler,False
+10008706,Holmes Place Fulham Pools Healthclub,,Normand Park,Lillie Road,,London,,England                       ,SW6 7ST,Wider Public Sector,Private Sector Enabler,False
+10008704,Holmbury St Mary Youth Hostel,,Radnor Lane,Holmbury St Mary,,Dorking,,England                       ,RH5 6NW,Wider Public Sector,Private Sector Enabler,False
+10008666,HMFSI,,Horseferry House,,,London,,England                       ,SW1,Wider Public Sector,Private Sector Enabler,False
+10008664,HM Remand Centre Low Newton,,Braffide,,,Durham,,England                       ,DH1 55D,Central Government,Private Sector Enabler,False
+10008656,Navy Command - HQ / HM Naval Base - (Portsmouth),,Trinity House,Portsmouth,Hampshire,Portsmouth,Hampshire,England,PO1 3LU,Central Government,MoD - Navy,False
+10008644,Hillside Secure Centre,,Burnside,,,Neath,,Wales                         ,SA11 1UL,Wider Public Sector,Private Sector Enabler,False
+10008637,Highlands and Islands Partnership Programme,,Castle Wynd,,,Inverness,,Scotland                      ,IV2 3EB,Wider Public Sector,Private Sector Enabler,False
+10008632,Highland Rerserve Forces and Cadets Association,,Seathwood,365 Perth Road,,Dundee,,Scotland                      ,DD2 1LX,Wider Public Sector,Private Sector Enabler,False
+10008619,High Peak Citizens Advice Bureau,,Crown House,Bingswood Trading Estate,,Whaley Bridge,Derbyshire                    ,England                       ,SK23 7LY,Wider Public Sector,Charity,False
+10008616,HIAS,,Clarendon House,Romsey Road,,Winchester,,England                       ,SO22 5PW,Wider Public Sector,Private Sector Enabler,False
+10008615,HGV Testing Station,,65 Seafield Rd,Longman Industrial Estate,,Inverness,,Scotland                      ,IV1 1SQ,Wider Public Sector,Private Sector Enabler,False
+10008614,HGV Test Centre,,Cavalry Hill Industrial Pk,Weedon,,Northampton,,England                       ,NN7 4PP,Wider Public Sector,Private Sector Enabler,False
+10008611,Hey Acute Trust,,Hull Royal Infirmary,Anlaby Road,,Hull,,England                       ,HU3 3LT,Wider Public Sector,Private Sector Enabler,False
+10008606,Hertford County Court,,Hale Rd,,,Hertford,,England                       ,SG13 8DY,Central Government,Private Sector Enabler,False
+10008602,Hereford Diocesan Board Of Education,,The Palace,Hereford,,Hereford,,England                       ,HR4 9BL,Wider Public Sector,Private Sector Enabler,False
+10008595,Henshaws Society for the Blind,,232 Eccles Old Road,Pendleton,Salford,Mancherster,,England                       ,M6 8AG,Wider Public Sector,Private Sector Enabler,False
+10008594,Henry Smith (Estates Charities),,Five Chancery Lane,Cliffords Inn,,London,,England                       ,EC4A 1BU,Wider Public Sector,Private Sector Enabler,False
+10008593,Hennessy TD,,Silverdale Medical Centre,"Mount Avenue,",,Wirral,,England                       ,CH60 4RH,Wider Public Sector,Private Sector Enabler,False
+10008592,Hengistbury Head Centre,,The Broadway,,,Southbourne,,England                       ,BS6 4EN,Wider Public Sector,Private Sector Enabler,False
+10008582,Helen's Fine Foods,,Sherdley Industrial Estate,Roundwood Drive,,St. Helens,,England                       ,WA9 5JD,Wider Public Sector,Private Sector Enabler,False
+10008580,Helen House Children's Hospice,,37 Leopold Street,,,Oxford,,England                       ,OX4 1QT,Wider Public Sector,Private Sector Enabler,False
+10008575,Heathlands Residential Home,,Heath Drive,Prestwich,,Manchester,,England                       ,M25 9SB,Wider Public Sector,Private Sector Enabler,False
+10008568,Health Estates NI,,CSA Regional Supplies Service,Stoney Road,Dundonald,Belfast,,Northern Ireland              ,BT161 US,Wider Public Sector,Private Sector Enabler,False
+10008567,Health Estates,,Health Policy Directorate,Stoney Road,Dondonald,Belfast,,Northern Ireland              ,BT16 0US,Wider Public Sector,Private Sector Enabler,False
+10008566,Health Education Board for Scotland,,Woodburn House,Canaan Lane,,Edinburgh,,Scotland                      ,EH10 4SG,Wider Public Sector,Private Sector Enabler,False
+10008562,HBS FM,,Level 2,Elizabeth House,39 York Road,London,,England                       ,SE1 5LJ,Wider Public Sector,Private Sector Enabler,False
+10008561,HBG Construction,,Merit House,Edgware Road,Colindale,London,,England                       ,NW9 5AF,Wider Public Sector,Private Sector Enabler,False
+10008549,Havina Project Services,,Adelaide Street,,,Bolton,,England                       ,BL3 3NY,Wider Public Sector,Private Sector Enabler,False
+10008537,Harvester Trust (Tonbridge) Ltd,,The River Centre,Medway Wharf Road,,Tonbridge,,England                       ,TN9 1RE,Wider Public Sector,Private Sector Enabler,False
+10008535,Hartcliffe Self Build Hc Ltd,,50 Greenditch Avenue,Hartcliffe,,Bristol,,England                       ,BS13 0AT,Wider Public Sector,Private Sector Enabler,False
+10008532,Harrogate Flower Fund Homes,,58 West End Ave,,,Harrogate,,England                       ,HG2 9BY,Wider Public Sector,Private Sector Enabler,False
+10008531,Harrogate and District Womens Aid,,PO Box 309,,,Harrogate,,England                       ,HG2 0XF,Wider Public Sector,Private Sector Enabler,False
+10008524,Haringey Sports Development,,New River S.C,White Hart Lane,,London,,England                       ,N22 5QW,Wider Public Sector,Private Sector Enabler,False
+10008513,Hardingstone Day Nursery,,42 Hardingstone Lane,Hardingstone,,Northampton,,England                       ,NN4 6DE,Wider Public Sector,Private Sector Enabler,False
+10008512,Harborne Parish Lands Charity,,7 Harborne Park Road,Harborne,,Birmingham,West Midlands                 ,England                       ,B17 0DE,Wider Public Sector,Private Sector Enabler,False
+10008511,Hants and Dorset Christian Youth Camp,,145 Marble Lane,Grove Park,,London,,England                       ,SE12 NPP,Wider Public Sector,Private Sector Enabler,False
+10008509,Hampstead Garden Suburb Institute,,Central Square,,,London,,England                       ,NW11 7BN,Wider Public Sector,Private Sector Enabler,False
+10008508,Hampshire County Youth Services,,Eastleigh District,130 Bournemouth Road,,Chandlers Ford,,England                       ,SO53 3AL,Wider Public Sector,Private Sector Enabler,False
+10008507,Hampshire County Supplies,,Bar End Road,,,Winchester,,England                       ,S053 4PB,Wider Public Sector,Private Sector Enabler,False
+10008501,Halliford,,Building 217,Northrop Road,London Heathrow Airport,Hounslow,,England                       ,TW6 2QN,Wider Public Sector,Private Sector Enabler,False
+10008498,Halifax Learning Zone,,121 E Mill,Dean Clough,,Halifax,West Yorkshire                ,England                       ,HX3 5AX,Wider Public Sector,Private Sector Enabler,False
+10008497,Halewood Community Comprehensive School,,The Avenue,Wood Road,,Halewood,,England                       ,L26 1UU,Wider Public Sector,Private Sector Enabler,False
+10008489,Hackney Building Maintenance,,Hackney Building Maintenance,Yorkton Street Depot,Yorkton Street,London,,England                       ,E2 8NH,Wider Public Sector,Private Sector Enabler,False
+10008488,H and J Martin,,163 Ormeau Road,,,Belfast,,Northern Ireland              ,BT7 1SP,Wider Public Sector,Private Sector Enabler,False
+10008482,Guy's Kings and St Thomas School of Medicine,,Sheperds House,,,London,,England                       ,SE1 9RT,Wider Public Sector,Private Sector Enabler,False
+10008478,Gurdwara Tegh Bahadar Sahib,,7 Saint Marks Road,,,Southampton,,England                       ,SO14 0GW,Wider Public Sector,Private Sector Enabler,False
+10008474,GS Dyer Training Services,,Four Acres Farm,Canister Lane,Gipsey Bridge,Boston,,England                       ,PE22 7HD,Wider Public Sector,Private Sector Enabler,False
+10008473,Grovemead Health Centre,,67 Elliot Road,,,London,,England                       ,NW4 3EB,Wider Public Sector,Private Sector Enabler,False
+10008471,Groundwork Blackburn,,Bob Watts Building,Nova Scotia Wharf Bolton Road,,Blackburn,,England                       ,BB2 3GE,Wider Public Sector,Private Sector Enabler,False
+10008468,Grosvenor House Group Plc,,First Floor,15 Brook's Mews,,London,,England                       ,W1K 4DS,Wider Public Sector,Private Sector Enabler,False
+10008462,Greenwich Self Build Co-Op Ltd,,9c Llanover Road,Woolwich,,London,,England                       ,SE18 3ST,Wider Public Sector,Private Sector Enabler,False
+10008460,Greenwich Park Office,,Royal Park Agency,Blackheath Gate,,London,,England                       ,SE10 8QY,Wider Public Sector,Private Sector Enabler,False
+10008456,Greenwich Education,,9th Floor Riverside House,Woolwich High Street,,London,,England                       ,SE18 6DF,Wider Public Sector,Private Sector Enabler,False
+10008454,Greenwich Community Safety Trust,,St Marys,Greenlaw Street,,London,,England                       ,SE18 5AR,Wider Public Sector,Private Sector Enabler,False
+10008452,Greenmount Medical Centre,,9 Brandlesholme Road,Greenmount,,Bury,,England                       ,BL8 4DR,Wider Public Sector,Private Sector Enabler,False
+10008446,Greenacres Cheshire Home,,39 Vesey Road,,,Sutton Coldfield,,England                       ,B73 5NR,Wider Public Sector,Private Sector Enabler,False
+10008445,Greenacres Association,,Galland Street,Greenacres,,Oldham,,England                       ,OL4 3EU,Wider Public Sector,Private Sector Enabler,False
+10008442,Green Hill  Methodist Church,,School Lane,,,Sheffield,,England                       ,S8 7RL,Wider Public Sector,Private Sector Enabler,False
+10008441,Greater Manchester Transportation Unit,,Salisbury House,Granby Row,,Manchester,,England                       ,M1 7AH,Wider Public Sector,Private Sector Enabler,False
+10008435,Greater London Territorial Auxiliary and Volunteer Reserve Association,,Duke Of York's HQ Kings Road,Chelsea,,London,,England                       ,SW3 4RY,Wider Public Sector,Private Sector Enabler,False
+10008428,Great North Eastern Railway,,GNER Main HQ,1 Station Road,,York,,England                       ,YO1 6HT,Wider Public Sector,Private Sector Enabler,False
+10008426,Great Hospital Norwich,,Bishopgate,,,Norwich,,England                       ,NR1 4EL,Wider Public Sector,Private Sector Enabler,False
+10008414,GPC International,,40 Long Acre,,,London,,England                       ,WC2E 9LG,Wider Public Sector,Private Sector Enabler,False
+10008411,Government Offices Regional Co ordination Unit,,2nd Floor,Riverwalk House,157-161 Millbank,London,,England                       ,SW1P 4AR,Central Government,NDPB,False
+10008410,Government Office for London,GOL,10th Floor River Walk House,157-161 Mill Bank,,London,,England                       ,SW1P 4RR,Central Government,NDPB,False
+10008409,Government of Gibraltar,,Information Technology and Logistics,16 Library Street,, ,,Gibraltar                     ,GIB 1,Wider Public Sector,Private Sector Enabler,False
+10008402,Goverment Office for the South West,,The Pithy,,,Bristol,,England                       ,B31 2PB,Wider Public Sector,Private Sector Enabler,False
+10008401,Govan Community Organisations Council,,148 Muirdrum Avenue,Cardonald,,Glasgow,,Scotland                      ,G52 3AP,Wider Public Sector,Private Sector Enabler,False
+10008400,Gospel Literature Outreach Centre,,6 Whytehouse Avenue,,,Kirkcaldy,,Scotland                      ,KY1 1UW,Wider Public Sector,Private Sector Enabler,False
+10008398,Gosberton Kids Club,,Gosberton Community Primary School,High Street,Gosberton,Spalding,,England                       ,PE11 4NW,Wider Public Sector,Private Sector Enabler,False
+10008392,Godmanchester Baptist Church,,c/o 4 Hatfield Lane,Papworth Everard,,Cambridge,,England                       ,CB3 8GS,Wider Public Sector,Private Sector Enabler,False
+10008388,Gloucestershire Education Authority,,Churchdown Lane,Hucclecote,,Gloucester,,England                       ,GL3 3QN,Wider Public Sector,Private Sector Enabler,False
+10008387,Gloucester Tec,,33-35 Worcester Street,,,Gloucester,,England                       ,GL1 3AJ,Wider Public Sector,Private Sector Enabler,False
+10008385,Gloucester Islamic Sec School for Girls,,Synope Street,,,Gloucester,,England                       ,GL1 4AW,Wider Public Sector,Private Sector Enabler,False
+10008383,Gloucester Charities Trust,,London Road,London Road,,Gloucester,,England                       ,GL1 3PH,Wider Public Sector,Private Sector Enabler,False
+10008381,Glenhaven Care Home,,5 Clarence Road,,,Llandudno,,Wales                         ,LL30 1BX,Wider Public Sector,Private Sector Enabler,False
+10008379,Gleeds,,123 Regent Street,,,London,,England                       ,W1R 8TB,Wider Public Sector,Private Sector Enabler,False
+10008377,Glasgow School Of Art,,167 Renfrew Street,,,Glasgow,,Scotland                      ,G3 6RQ,Wider Public Sector,Private Sector Enabler,False
+10008374,Glasgow Development Agency,,Atrium Court,50 Waterloo Street,,Glasgow,,Scotland                      ,G2 6HQ,Wider Public Sector,Private Sector Enabler,False
+10008372,Glamorgan Heritage Coast Centre,,The Seawatch Centre,Southern Down,,Vale of Glamorgan,,Wales                         ,CF32 0PS,Wider Public Sector,Private Sector Enabler,False
+10008366,Gifford and Partners Ltd,,2a St. Martins La,Macklegate,,York,,England                       ,YO1 1LN,Wider Public Sector,Private Sector Enabler,False
+10008364,German Embassy,,23 Belgrave Square,Chesham Square,,London,,England                       ,SW1X 8PZ,Wider Public Sector,Private Sector Enabler,False
+10008356,General Teaching Council For England,,Victoria Square House,Victoria Square,,Birmingham,West Midlands                 ,England                       ,B2 4AJ,Central Government,NDPB,False
+10008355,General Social Care Council,,2nd Floor Goldings House,2 Hay's Lane,,London,,England                       ,SE1 2HB,Central Government,NDPB,False
+10008353,General Practice Administration System for Scotland,,Seaforth House,Seafoth Road,Hillington,Glasgow,,Scotland                      ,G52 4SQ,Wider Public Sector,Private Sector Enabler,False
+10008350,GCC,,Hucclecote Centre,Churchdown Lane,,Gloucester,,England                       ,GL3 3QW,Wider Public Sector,Private Sector Enabler,False
+10008349,Gateshead Academy For Torah Studies,,Whinney House,Durham Road Low Fell,,Gateshead,,England                       ,NE9 5AR,Wider Public Sector,Private Sector Enabler,False
+10008342,Garrison Family Accomodation Store,,Garrison Staff Office Athlone Barracks,,,Sennelager,,Germany                       ,BFPO 16,Wider Public Sector,Private Sector Enabler,False
+10008341,Garrison BQMS,,Main Office,,,London,,England                       ,SE18 4BH,Wider Public Sector,Private Sector Enabler,False
+10008339,Gardiner and Theobald Management Services,,40 Bedford Square,,,London,,England                       ,WC1B 3DP,Wider Public Sector,Private Sector Enabler,False
+10008335,Galashiels Academy,,Scottish Borders Council,Elm Row,,Galashiels,,Scotland                      ,TD1 3HU,Wider Public Sector,Private Sector Enabler,False
+10008334,Gaines Christian Youth Centre,,Whitbourne,,,Worcester,,England                       ,WR6 5RD,Wider Public Sector,Private Sector Enabler,False
+10008332,G4 Logs Support (Accn Svs),,HQUKSC (G),,, ,,Germany                       ,BFPO 140,Wider Public Sector,Private Sector Enabler,False
+10008331,Fylde and North West Lancashire Training Group,,250 Bristol Avenue,Bispham,,Blackpool,,England                       ,FY2 0JF,Wider Public Sector,Private Sector Enabler,False
+10008329,Fusion 21,,The Barn,Shevingtons Lane,,Kirkby,,England                       ,L33 1XA,Wider Public Sector,Private Sector Enabler,False
+10008328,Fusion,,Community Leisure Ltd,15 Spa Road Bermondsey,,London,,England                       ,SE16 3QW,Wider Public Sector,Private Sector Enabler,False
+10008325,Furrow Community School,,Windermere Road,Langley,Middleton,Manchester,,England                       ,M24 4LA,Wider Public Sector,Private Sector Enabler,False
+10008323,Fuller Peiser,,16 St George Street,Hanover Square,,London,,England                       ,W1S 1LX,Wider Public Sector,Private Sector Enabler,False
+10008316,Friends in Need Community Centre,,East Barnet Baptist Church,Crescent Road,,East Barnet,,England                       ,EN4 8PS,Wider Public Sector,Private Sector Enabler,False
+10008313,Freshways PSRC,,Knovill Close,Lawrence Weston,,Bristol,,England                       ,BS11 0SA,Wider Public Sector,Private Sector Enabler,False
+10008312,Freeman Group of Hospitals NHS Trust (Newcastle Upon Tyne Hospitals NHS Foundation Trust The),,Beckspool Road,Frenchay,High Heaton,Bristol,,England                       ,BS16 1ND,Wider Public Sector,Acute Trust,False
+10008311,Free Church of Scotland,,The Mound,,,Edinburgh,,Scotland                      ,EH1 2LS,Wider Public Sector,Private Sector Enabler,False
+10008308,Frank Markum Community School,,Woughton Campus,Shaffron Way,,Milton Keynes,,England                       ,MK6 5EH,Wider Public Sector,Private Sector Enabler,False
+10008303,Foxhill Centre (See Notes),,11-13 Plumstead Common Road,,,Woolwich,,England                       ,SE18 3AP,Wider Public Sector,Private Sector Enabler,False
+10008302,Four P'S,,6th Floor,83 Victoria Street,,London,,England                       ,SW1H 0HW,Wider Public Sector,Private Sector Enabler,False
+10008299,Foss Internal Drainage Board,,The Estate Office Providence House,Howden Lane,Crockey Hill,York,,England                       ,YO19 4SP,Wider Public Sector,Private Sector Enabler,False
+10008289,Forest Enterprise (Wales),,Victoria Terrace,Aberystwyth,,Ceredogion,,Wales                         ,SY23 2DQ,Wider Public Sector,Private Sector Enabler,False
+10008288,Forest Enterprise,,1 Highlander Way,Inverness Retail and Business Park,,Inverness,,Scotland                      ,IV2 7GB,Wider Public Sector,Private Sector Enabler,False
+10008277,Fishermen's Mission,,43 Nottingham Place,,,London,,England                       ,W1U 5BX,Wider Public Sector,Private Sector Enabler,False
+10008276,Fisheries Research Services (MarLab),FRS,FRS Marine Laboratory,PO Box 101,375 Victoria Road,Aberdeen,Aberdeenshire                 ,Scotland                      ,AB11 9DB,Wider Public Sector,,False
+10008265,Finland Trade Centre,,177-179 Hammersmith Road,,,London,,England                       ,W6 8BS,Wider Public Sector,Private Sector Enabler,False
+10008263,Findhorn Foundation,,The Park,,,Findhorn,,Scotland                      ,IV36 3TZ,Wider Public Sector,Private Sector Enabler,False
+10008254,Fife Health Board,,Springfield House,Cupar,Buckhaven,Fife,,Scotland                      ,KY15 5UP,Wider Public Sector,Private Sector Enabler,False
+10008252,Field Lane Foundation,,16 Vine Hill,,,London,,England                       ,EC1R 5EA,Wider Public Sector,Private Sector Enabler,False
+10008251,FFORWM,,Quadrant Centre,Cardiff Business Park,Llanishen,Cardiff,,Wales                         ,CF14 5WK,Wider Public Sector,Private Sector Enabler,False
+10008250,Ferrybridge Medical Centre,,8-10 High Street,Ferrybridge,,Knottingley,,England                       ,wf11 8nq,Wider Public Sector,Private Sector Enabler,False
+10008243,Federation of Independent Advice Centres,,FIAC Development Office,The Customs Office West Sunniside,,Sunderland,,England                       ,SR1 1BA,Wider Public Sector,Private Sector Enabler,False
+10008240,Fazakerley Sports Centre,,Sherwoods Lane,Fazakerley,,Liverpool,,England                       ,L10 1LN,Wider Public Sector,Private Sector Enabler,False
+10008239,Farrell Grant Sparks,,Chamber of Commerce House,22 Great Victoria Street,,Belfast,,Northern Ireland              ,BT2 7BA,Wider Public Sector,Private Sector Enabler,False
+10008237,Farm Lane Resource Centre,,25 Farm Lane,,,London,,England                       ,SW6 1PX,Wider Public Sector,Private Sector Enabler,False
+10008229,Family First Ltd,,The Croft,Albert Road Alexandra Park,,Nottingham,,England                       ,NG3 4JD,Wider Public Sector,Private Sector Enabler,False
+10008228,Fallingbostel HQ,,BFPO 38,,, ,,Germany                       ,BFPO 38,Wider Public Sector,Private Sector Enabler,False
+10008226,Falkirk Child Support Agency Centre,,Parklands,Callendar Business Pk; Callend,,Falkirk,,Scotland                      ,FK1 1XT,Wider Public Sector,Private Sector Enabler,False
+10008225,Faithful and Gould,,Dunedin House,Columbia Drive,,Stockton-on-Tees,,England                       ,TS17 6BJ,Wider Public Sector,Private Sector Enabler,False
+10008224,Fairway Early Years Centre,,1 The Fairway,Millhill,,London,,England                       ,NW7 3HS,Wider Public Sector,Private Sector Enabler,False
+10008223,Fairhazel H Co-Op Ltd,,23 Compayne Gardens,,,London,,England                       ,NW6 3DE,Wider Public Sector,Private Sector Enabler,False
+10008220,Fairfield High School For Girls,,Fairfield Avenue,Droylesden,,Manchester,,England                       ,M43 6AB,Wider Public Sector,Private Sector Enabler,False
+10008217,Facilities Management Limited Company,,Wellington House,133-155 Waterloo Road,,London,,England                       ,SE1 8UG,Wider Public Sector,Private Sector Enabler,False
+10008216,Facilities Management Group,,WED 1/H16 Ashdown House,123 Victoria Street,,London,,England                       ,SW1E 5DU,Wider Public Sector,Private Sector Enabler,False
+10008215,Facilities Directorate-Central Mancheste,,NHS Trust,7 Lorne Street,,Manchester,,England                       ,M13 0EZ,Wider Public Sector,Private Sector Enabler,False
+10008209,Exeter Vehicle Testing Station,,Grace Road,Marsh Barton Trading Estate,,Exeter,,England                       ,EX2 8PH,Wider Public Sector,Private Sector Enabler,False
+10008203,EWC/IPT,,B Block,c/o HQ BFC,Episkopi Support Unit,Episkopi,,Cyprus                        ,BFPO 53,Wider Public Sector,Private Sector Enabler,False
+10008201,Everton Park Sports Centre,,Great Homer Street,Great Homer Street,,Liverpool,,England                       ,L5 5PH,Wider Public Sector,Private Sector Enabler,False
+10008200,Everton Development Trust,,98 Great Homer Street,,,Liverpool,,England                       ,L5 3LF,Wider Public Sector,Private Sector Enabler,False
+10008199,Everbrook H Co-Op Ltd,,117 Rendlesham Road,,,London,,England                       ,E5 8PA,Wider Public Sector,Private Sector Enabler,False
+10008198,European Commission,EC,8 Storey's Gate,,,LONDON,,England                       ,SW1P 3AT,Central Government,,False
+10008196,European Bank,,One Exchange Square,,,London,,England                       ,EC2A 2EH,Wider Public Sector,Private Sector Enabler,False
+10008193,ETS,,1st Floor,Cunard Building,,Liverpool,,England                       ,L3 1TS,Wider Public Sector,Private Sector Enabler,False
+10008190,Estonian House Ltd,,18 Chepstow Villas,,,London,,England                       ,W11 2RB,Wider Public Sector,Private Sector Enabler,False
+10008187,Estates and National Contracts,,236 Gray'sInn Road,7th Floor,,London,,England                       ,WC1X 8HL,Wider Public Sector,Private Sector Enabler,False
+10008186,ESSI (Educational Service for Sensory Impairment),,17 Greek Street,,,Stockport,,England                       ,SK3 8AB,Wider Public Sector,Private Sector Enabler,False
+10008184,Essex County Youth Service,,Colchester Locality,Colchester Townhouse,East Stockwell Street,Colchester,,England                       ,CO1 1SS,Wider Public Sector,Private Sector Enabler,False
+10008182,Education Support and Inspection Service,ESIS,G5,Treforest Industrial Estate,,Pontypridd,,Wales                         ,CF37 5YL,Wider Public Sector,Private Sector Enabler,False
+10008181,Eruoinforcentre,,120  Bothwell Street,,,Glasgow,,Scotland                      ,G2 7JP,Wider Public Sector,Private Sector Enabler,False
+10008180,Ernst and Young,,Rolls House,7 Rolls Building,Fetter Lane,London,,England                       ,EC,Wider Public Sector,Private Sector Enabler,False
+10008175,Erewash CVS,,Parklands Connexion,Leopold Street,,Long Eaton,,England                       ,NG10 4QE,Wider Public Sector,Private Sector Enabler,False
+10008173,Equippers Church Network,,Main Office,,,Brentford,,England                       ,TW8 0BP,Wider Public Sector,Private Sector Enabler,False
+10008172,Equion Plc,,29 Bressenden Place,,,London,,England                       ,SW1E 5DZ,Wider Public Sector,Private Sector Enabler,False
+10008170,Equal Opportunities Commission,,Arndale House,Arndale Centre,,Manchester,,England                       ,M4 3EQ,Central Government,,False
+10008167,Entrust,,Portman House,Portland Road,,Newcastle Upon Tyne,,England                       ,NE62 5UJ,Wider Public Sector,Private Sector Enabler,False
+10008166,Enki Medical Practice,,Soho Health Centre,Louise Road,,Birmingham,West Midlands                 ,England                       ,B21 0RY,Wider Public Sector,Private Sector Enabler,False
+10008161,English Partnerships (Urban Regeneration Agency),,St Georges House,Kingsway,Team Valley,Gateshead,,England                       ,NE11 ONA,Wider Public Sector,Private Sector Enabler,False
+10008160,English Parnerships,,Main Office,,,Milton Keynes,,England                       ,MK9 2EA,Wider Public Sector,Private Sector Enabler,False
+10008158,English National Board For Nursing,,170 Tottenham Court Rd,,,London,,England                       ,W1P 0HA,Wider Public Sector,Private Sector Enabler,False
+10008155,Englandnet Ltd,,4 Berghem Mews,Blythe Road,,London,,England                       ,W14 0HN,Wider Public Sector,Private Sector Enabler,False
+10008153,Enfield Valuation Office,,Chase House,305 Chase Road Southgate,,London,,England                       ,N14 6LZ,Wider Public Sector,Private Sector Enabler,False
+10008151,Energywatch,,4th Floor Artillery House,Artillery Row,,London,,England                       ,SW1P 1RT,Central Government,NDPB,False
+10008149,Energy Efficienty Advice Centre,,13 Craddock Street,,,Swansea,,Wales                         ,SA1 3EW,Wider Public Sector,Private Sector Enabler,False
+10008147,Energy Conservation Branch,,River House,48 High Street,,Belfast,,Northern Ireland              ,BT1 2AW,Wider Public Sector,Private Sector Enabler,False
+10008146,Energy Action Grant Agency,EAGA,Eldon Ct,,,Newcastle Upon Tyne,,England                       ,NE1 7HA,Wider Public Sector,Private Sector Enabler,False
+10008145,Energis Communications Ltd,,Melbourne Street,,,Leeds,West Yorkshire                ,England                       ,LS2 7PS,Wider Public Sector,Private Sector Enabler,False
+10008143,Enable (Birmingham) Ltd,,Bierton Road,Yardley,,Birmingham,West Midlands                 ,England                       ,B25 8PQ,Wider Public Sector,Private Sector Enabler,False
+10008140,Employment Department Group,,Caxton House,Tothill Street,,London,,England                       ,SW1H 9NF,Wider Public Sector,Private Sector Enabler,False
+10008139,Emmaus House,,Clifton Hill,,,Bristol,,England                       ,BS8 4PD,Wider Public Sector,Private Sector Enabler,False
+10008138,EMMAUC,,Old Vicarige,Brinklow Road,,Coventry,,England                       ,CV3 2DT,Wider Public Sector,Private Sector Enabler,False
+10008134,Eme Regional Office,,New Town House,Maid Marion Way,,Nottingham,,England                       ,NG1 6GG,Wider Public Sector,Private Sector Enabler,False
+10008133,EMD,,Parks Department,4th Floor Blue Star House,234-244 Stockwell Road,London,,England                       ,SW( 9SP,Wider Public Sector,Private Sector Enabler,False
+10008132,EMCOR Drake and Scull Ltd,,86 Talbot Road,,,Manchester,,England                       ,M16 0QD,Wider Public Sector,Private Sector Enabler,False
+10008131,Embassy of the Republic of Korea,,60 Buckingham Gate,,,London,,England                       ,SW1E 6AJ,Wider Public Sector,Private Sector Enabler,False
+10008115,ELIM Pentecostal Church,,22 Arklow Drive,Hale,,Liverpool,,England                       ,L24 5RW,Wider Public Sector,Private Sector Enabler,False
+10008106,EEIBA,,8 Station Parade,Balham High Road,,London,,England                       ,SW12 9BH,Wider Public Sector,Private Sector Enabler,False
+10008104,Education Walsall,,Education Development Centre,Pelfall Lane,Rushall,Walsall,,England                       ,WS4 1NG,Wider Public Sector,Private Sector Enabler,False
+10008103,Education Services,,Room 403,Advance House,,Croydon,,England                       ,CR0 2AG,Wider Public Sector,Private Sector Enabler,False
+10008100,Education Authority Resource County Coun,,Swyddfa Addysg,Ffordd Glan Hwfa,Llangefni,Anglessey,,Wales                         ,LL77 7EY,Wider Public Sector,Private Sector Enabler,False
+10008099,Education and Leisure Support Service,,Wrexham County Borough Council,Ty Henblas,Queens Square,Wrexham,,England                       ,WL13 8AZ,Wider Public Sector,Private Sector Enabler,False
+10008097,Education and Cultural Services Departme,,Progress House,Clifton Road,,Blackpool,,England                       ,FY4 4US,Wider Public Sector,Private Sector Enabler,False
+10008096,Edmonton Vehicle Testing Station,,Anthony Wharf,Lee Valley Trading Estate Edmonton,,London,,England                       ,N18 3JR,Wider Public Sector,Private Sector Enabler,False
+10008095,Edmond Shipway,,New Loom House,101 Back Church Lane,,London,,England                       ,E1 1LU,Wider Public Sector,Private Sector Enabler,False
+10008092,Edinburgh Voluntary Organisations Council,,14 Ashley Place,,,Edinburgh,,Scotland                      ,EH6 5PX,Wider Public Sector,Private Sector Enabler,False
+10008087,Edgware Congregation of Jahovas Witnesse,,Avion Cresent,,,London,,England                       ,NW9 5NZ,Wider Public Sector,Private Sector Enabler,False
+10008086,Edexcel Foundation,,Room 121 Floor 2,Stewart House,32 Russell Square,London,,England                       ,WC18 5DN,Wider Public Sector,Private Sector Enabler,False
+10008084,Eden Court Theatre and Cinema,,Bishop's Road,,,Inverness,,Scotland                      ,IV3 5SA,Wider Public Sector,Private Sector Enabler,False
+10008083,Ecsc,,30 Great Guildford St,,,London,,England                       ,SE1 0HS,Wider Public Sector,Private Sector Enabler,False
+10008082,Economic Learning  Social Evolution,,ELSE - Dept of Economics,Gower Street,,London,,England                       ,WC1E 6BT,Wider Public Sector,Private Sector Enabler,False
+10008080,Ecclesholme Nursing Home,,Vicar Street,Eccles,,Manchester,,England                       ,M30 ODG,Wider Public Sector,Private Sector Enabler,False
+10008079,ECC Community Association,,320 Harborne Park Road,Harborne,,Birmingham,West Midlands                 ,England                       ,B17 0NE,Wider Public Sector,Private Sector Enabler,False
+10008078,ECB,,Central Hall,Oldham Street,,Manchester,,England                       ,M1 1JT,Wider Public Sector,Private Sector Enabler,False
+10008075,Eaton Hill Therapeutic Community,,Alfreton Rd,Little Eaton,,Derby,,England                       ,DE21 5AD,Wider Public Sector,Acute Trust,False
+10008073,Eastpoint Centre,,Burgoyne Rd,Thorn Hill,,Southampton,,England                       ,SO19 6PB,Wider Public Sector,Private Sector Enabler,False
+10008071,Eastern Leisure,,Eastern Leisure Centre Thrissel Street,Easton,,Bristol,,England                       ,BS5 0SW,Wider Public Sector,Private Sector Enabler,False
+10008070,Eastern Health Board,,Cherry Orchard Hospital,Ballyfermot,,Dublin 10,,Ireland                       ,XXXX,Wider Public Sector,Private Sector Enabler,False
+10008069,Easterhouse Health Centre,,Main Office,,,Glasgow,,Scotland                      ,G34 9HQ,Wider Public Sector,Private Sector Enabler,False
+10008067,Eastbourne  Council Buses,,Birch Road,,,Eastbourne,,England                       ,BN23 6PD,Wider Public Sector,Private Sector Enabler,False
+10008066,East Thames Group,,3 Tramway Avenue Stratford,London,Greater London,London,Greater London,England,E15 4PN,Wider Public Sector,Housing Associations,False
+10008060,East Radnor Leisure Centre,,Broad Axe,Presteign,,Pouys,,Wales                         ,LD8 2YT,Wider Public Sector,Private Sector Enabler,False
+10008056,East of England Broadband Consortium,,Office,,,Cambridge,,England                       ,CB,Wider Public Sector,Private Sector Enabler,False
+10008055,East Midlands Territorial Auxiliary and Volunteer Reserve Association,,TA Centre Broadgate,Beeston,,Nottingham,,England                       ,NG9 2HF,Wider Public Sector,Private Sector Enabler,False
+10008048,East Lancashire Careers Services Ltd,,The Guide Business Centre,School Lane Guide,,Blackburn,,England                       ,BB1 2QH,Wider Public Sector,Private Sector Enabler,False
+10008042,East Anglian Blood Transfusion Centre,,Long Rd,,,Cambridge,,England                       ,CB2 2PT,Wider Public Sector,Private Sector Enabler,False
+10008041,East and Wessex Territorial Auxiliary and Volunteer Reserve Association,,SERFCA  Seely House,Shoe Lane,,Aldershot,,England                       ,GU11 2HJ,Wider Public Sector,Private Sector Enabler,False
+10008039,Easdale Medical Practice,,Main Office,,,Isle of Seil,,Scotland                      ,PA34 4TL,Wider Public Sector,Private Sector Enabler,False
+10008037,Earl Consortium for Public Library Networking,,46th Floor,Gun Court,70 Wapping Lane,London,,England                       ,E1N 2RS,Wider Public Sector,Private Sector Enabler,False
+10008034,Ealing Consortium Ltd,,Cp House Annexe,97-107 Uxbridge Road Ealing,,London,,England                       ,W5 5TL,Wider Public Sector,Private Sector Enabler,False
+10008030,DWS,,Menwith Hill Station,Menwith Hill Station,,Harrogate,,England                       ,HG3 2RH,Wider Public Sector,Private Sector Enabler,False
+10008029,Duster Castle,,Duster,,,Minehead,,England                       ,TA24 6SL,Wider Public Sector,Private Sector Enabler,False
+10008022,Durham County Care,,Social Services Dept,Priory House Abbey Road Pitty Me,,Durham,,England                       ,DH1 5RR,Wider Public Sector,Private Sector Enabler,False
+10008021,Durham Aged Mineworkers' Homes,,P O Box 31 The Grove,168 Front Street,Chester Le Street,Durham,,England                       ,DH3 3YH,Wider Public Sector,Private Sector Enabler,False
+10008018,Dunlop Heywood,,7 Curzon Street,,,London,,England                       ,W1Y 7FL,Wider Public Sector,Private Sector Enabler,False
+10008015,Dundee Society for Visually Impaired People,,10 - 12 Ward Road,,,Dundee,,Scotland                      ,DD1 1LX,Wider Public Sector,Private Sector Enabler,False
+10008014,Dundee Rep Theatre,,The Rep,Tay Square,,Dundee,,Scotland                      ,DD1 1PB,Wider Public Sector,Private Sector Enabler,False
+10008010,Dunbartonshire Business Shop,,Southbank Business Park,Kirkintilloch,,Glasgow,,Scotland                      ,G66 1XQ,Wider Public Sector,Private Sector Enabler,False
+10008008,Dumfries Vehicle Testing Agency,,Heathall Industrial Estate,Locharbriggs,,Dumfries,,Scotland                      ,DG1 3PH,Wider Public Sector,Private Sector Enabler,False
+10008004,Dumfries and Galloway Citizens Service,,81-85 Irish Street,,,Dumfries,,Scotland                      ,DG1 2PQ,Wider Public Sector,Private Sector Enabler,False
+10007998,DTZ Debenham Tie Leung,DTZ,1 Curzon Street,,,London,,England                       ,W1A 5PZ,Wider Public Sector,Private Sector Enabler,False
+10007997,DTP,,3rd Floor Connect House,Alexandra Rd Wimbledon,,London,,England                       ,SW19 7JY,Wider Public Sector,Private Sector Enabler,False
+10007996,DTI (Knowledgepool Ltd),,1 Victoria Street,,,London,,England                       ,SW1H 0ET,Wider Public Sector,Private Sector Enabler,False
+10007995,DTEO,,West Freugh,,,Stranraer,,Scotland                      ,DG9 7DN,Wider Public Sector,Private Sector Enabler,False
+10007994,DSSR,,Cornwall Road,,,Harrogate,,England                       ,HG1 2PW,Wider Public Sector,Private Sector Enabler,False
+10007993,DSEFPOL,,Room 225,St Giles Court,1-13 St Giles High Street,London,,England                       ,WC2H 8LD,Wider Public Sector,Private Sector Enabler,False
+10007990,Drug Aid,,2nd Floor,Oldway House,,Merthyr-tydfil,,Wales                         ,CF47 8UX,Wider Public Sector,Private Sector Enabler,False
+10007988,Drivers Jonas,,6 Grosvenor Street,,,London,,England                       ,W1X 0DJ,Wider Public Sector,Private Sector Enabler,False
+10007986,Drink Crisis Centre,,Central Office,107 Waterloo Road,,London,,England                       ,SE1 8UL,Wider Public Sector,Private Sector Enabler,False
+10007985,Drayton and St Faiths Medical Practice,,The Surgery,Manor Farm Close,School Road Drayton,Norwich,,England                       ,NR8 6EE,Wider Public Sector,Private Sector Enabler,False
+10007984,Drake and Scull Technical Services,,c/o The British Library," 96 Euston Road,",,London,,England                       ,NW1 2DB,Wider Public Sector,Private Sector Enabler,False
+10007983,Dragon School Trust Ltd,,The Bursary,Bardwell Rd,,Oxford,,England                       ,OX2 6SS,Wider Public Sector,Private Sector Enabler,False
+10007963,DPMD,,ICT Centre,Vincent Drive,,Edgbaston,,England                       ,B15 2SQ,Wider Public Sector,Private Sector Enabler,False
+10007962,Downs Medical Facilities Partner,,Ferryview Health Centre,Woolwich,,London,,England                       ,SE18 6PZ,Wider Public Sector,Private Sector Enabler,False
+10007958,Dorset Trust,,118 Commercial Rd,118 Commercial Road,,Bournemouth,,England                       ,BH2 5LZ,Wider Public Sector,Private Sector Enabler,False
+10007957,Dorset Spastics Society,,Dorset Scope,13-15 Manor Avenue,Parkstone,Poole,,England                       ,BH12 4LB,Wider Public Sector,Private Sector Enabler,False
+10007955,Dorset Gardens Methodist Church,,PO BOX 3252,,,Brighton,,England                       ,BN2 1UX,Wider Public Sector,Private Sector Enabler,False
+10007952,Dorset Community Action,,The Barracks,Bridport Road,,Dorchester,,England                       ,DT1 1YG,Wider Public Sector,Private Sector Enabler,False
+10007947,Doncaster Vehicle Testing Station,,Wellsdyke Road,Adwick-le-Street,,Doncaster,,England                       ,DN6 7DU,Wider Public Sector,Private Sector Enabler,False
+10007944,Doncaster Communities in Partnership,,Enterprise House,White Rose Way,,Doncaster,,England                       ,DN4 5ND,Wider Public Sector,Private Sector Enabler,False
+10007940,Donald Smith Seymour and Rooley,,Warwick House,17 Warwick Road,Old Trafford,Manchester,,England                       ,M16 0PT,Wider Public Sector,Private Sector Enabler,False
+10007939,Dolphin Square Trust Ltd,,Dolphin Square,,,London,,England                       ,SW1V 3LX,Wider Public Sector,Private Sector Enabler,False
+10007935,DMT BS Projects,,Room 182,St Giles Court,,London,,England                       ,WC2H 8LD,Wider Public Sector,Private Sector Enabler,False
+10007934,DM Longtown,,PO Box 1,Longtown,,Carlisle,,England                       ,CA6 5LX,Wider Public Sector,Private Sector Enabler,False
+10007933,DLR For Wales,,TY Cwm Tawe Phoenix Way,"Enterprise Park,Llansamlet",,Swansea,,Wales                         ,SA7 9FQ,Wider Public Sector,Private Sector Enabler,False
+10007932,DLO Telford,,Sapphire House,Stafford Park 10,,Telford,,England                       ,TF3 3AD,Wider Public Sector,Private Sector Enabler,False
+10007930,Dixon Fletcher and Ingram,,7/8 Park Street,,,Ripon,,England                       ,HG4 2AX,Wider Public Sector,Private Sector Enabler,False
+10007929,Divisional Commercial Officer HQ,,Divisional Commercial Office HQ,HQ 1(UK) Armoured Division,,Hereford,,England                       ,BFPO 15,Wider Public Sector,Private Sector Enabler,False
+10007928,District Valuation Office,,Block A Government Buildings,Whittington Road,,Worcester,,England                       ,WR5 2LB,Wider Public Sector,Private Sector Enabler,False
+10007927,District Office Social Services,,County  Offices,Chapel Lane,,Wilmslow,,England                       ,SK9 1PU,Wider Public Sector,Private Sector Enabler,False
+10007925,Disability Rights Commission,,2nd Floor,Arndale House,Arndale Centre,Manchester,,England                       ,M4 3AQ,Central Government,NDPB,False
+10007924,Directorate Safety Enviro and Fire policy,,Room 740    St Giles Court,1-13 St Giles High Street,,London,,England                       ,WC2H 8LD,Wider Public Sector,Private Sector Enabler,False
+10007923,Directorate of Safety Environment and Fi,,Room 6118 St Christopher House,Southwark Street,,London,,England                       ,SE1 0TE,Wider Public Sector,Private Sector Enabler,False
+10007922,Director Land Digitization MOD,,Room 2-5,Willington Barracks,Birdcage Walk,London,,England                       ,SW1E 6HQ,Central Government,,False
+10007921,Director General Support Management (RAF),,RM W023,Swales Pavilion,RAF Wyton,Cambridge,,England                       ,PE17 2DL,Wider Public Sector,Private Sector Enabler,False
+10007920,Direct Services,,Davesfield Road,Roman Road Ind Estate,,Blackburn,,England                       ,BB1 2LX,Wider Public Sector,Private Sector Enabler,False
+10007919,Diplomatic Service Language Cenre,,Foreign & Commonwealth Office,Old Admiralty Building,,London,,England                       ,SW1A 2PA,Wider Public Sector,Private Sector Enabler,False
+10007918,Diocese of Winchester,,Church House,9 The Close,,Winchester,,England                       ,SO23 9LS,Wider Public Sector,Private Sector Enabler,False
+10007916,Diocese of Norwich,,Diocesan House,109 Dereham Road,Easton,Norwich,,England                       ,NR9 5ES,Wider Public Sector,Private Sector Enabler,False
+10007915,Diocese Of Leeds,,Pastoral Centre,62 Headingley Lane,,Leeds,West Yorkshire                ,England                       ,LS6 2BX,Wider Public Sector,Private Sector Enabler,False
+10007914,Diocese Of Birmingham,,175 Harborne Park Road,Harborne,,Birmingham,West Midlands                 ,England                       ,B17 0BH,Wider Public Sector,Private Sector Enabler,False
+10007913,Diocesan Schools Commission,,61 Coventry Road,Coleshill,,Birmingham,West Midlands                 ,England                       ,B46 3EA,Wider Public Sector,Private Sector Enabler,False
+10007911,Didsbury Baptist Church,,Beaver Road,Didsbury,,Manchester,,England                       ,M20 6SX,Wider Public Sector,Private Sector Enabler,False
+10007910,Dib Lane Practice,,112a Dib Lane,,,Leeds,West Yorkshire                ,England                       ,LS8 3AY,Wider Public Sector,Private Sector Enabler,False
+10007907,Devonshire Court,,Devonshire Court  Howden Road,Oadby,,Leicester,,England                       ,LE2 5WQ,Wider Public Sector,Private Sector Enabler,False
+10007906,Devonport High School for Boys,,Paradise Road,Stoke,,Plymouth,,England                       ,PL1 5QP,Wider Public Sector,Private Sector Enabler,False
+10007905,Devon Youth Offending Service,,Ivybank,45 St Davids Hill,,Exeter,,England                       ,EX4 4DN,Wider Public Sector,Private Sector Enabler,False
+10007904,Devon Surveyors Practice,,12th Floor Civic Centre,,,Plymouth,,England                       ,PL1 2EW,Wider Public Sector,Private Sector Enabler,False
+10007902,Devon Design Practice,,12th Floor Civic Centre,Civic Centre,,Plymouth,,England                       ,PL1 2EW,Wider Public Sector,Private Sector Enabler,False
+10007900,DCH,DCH,The Mount,Paris Street,,Exeter,Devon                         ,England                       ,EX1 2JG,Wider Public Sector,,False
+10007898,Developing Business Programme Office,,c/o Liverpool Chamber of Commerce,1 Old Hall Street,,Liverpool,,England                       ,L3 9HG,Wider Public Sector,Private Sector Enabler,False
+10007894,Design Consultancy,,4th Floor,Millennium House,60 Victoria Street,Liverpool,,England                       ,L1 6JD,Wider Public Sector,Private Sector Enabler,False
+10007891,Derby Vehicle Testing Station,,Raynesway,Alverston,,Derby,,England                       ,DE1 7AY,Wider Public Sector,Private Sector Enabler,False
+10007890,Derby Tertiary College,,London Road,Wilmorton,,Derby,Derbyshire                    ,England                       ,DE24 8UG,Wider Public Sector,Colleges other,False
+10007888,Deptford H Co-Op Ltd,,16 Rochdale Way,Deptford,,London,,England                       ,SE8 4EY,Wider Public Sector,Private Sector Enabler,False
+10007887,Dept Of Personnel and Community Services,,Longfield Centre,Prestwich,,Manchester,,England                       ,M25 1AY,Wider Public Sector,Private Sector Enabler,False
+10007886,Depot Services Support Group,,Oc Repair Shop,,, ,,Germany                       ,BFPO 44,Wider Public Sector,Private Sector Enabler,False
+10007884,Department of Regional Development,,Northern Division Academy House,121A Broughshane Street,,Ballymena,,Northern Ireland              ,BT43 6BA,Wider Public Sector,Private Sector Enabler,False
+10007880,Department Of Food Standard and Prod Tech,,SAC - Auchincruive,,,Ayr,,Scotland                      ,KA6 5HN,Wider Public Sector,Private Sector Enabler,False
+10007878,Department of Finance and Administration,,John Gorton Building,King Edward Terrace,,Canberra,,Australia                     ,2600,Wider Public Sector,Private Sector Enabler,False
+10007877,Department of Finance,,15 Lower Hatch Street,,,Dublin,,Ireland                       ,XXXX,Wider Public Sector,Private Sector Enabler,False
+10007873,Department Of Culture Arts and Leisure,,3rd Floor Interpoint Building,York Street,,Belfast,,Northern Ireland              ,BT15 1AQ,Wider Public Sector,Private Sector Enabler,False
+10007870,Department Of Chemistry,,Lensfield Rd,University Chemical Labs,,Cambridge,,England                       ,CB2 1EW,Wider Public Sector,Private Sector Enabler,False
+10007869,Department of Applied Social Sciences,,St Martins College,Bowerham Road,,Lancaster,,England                       ,LA1 3JD,Wider Public Sector,Private Sector Enabler,False
+10007867,Department for Trade and Industry,DTI,151 Buckingham Palace Road,,,London,,England                       ,SW1W 9SS,Central Government,,False
+10007863,Department for Education and Skills,DfES,1st Floor Caxton House,Tothill Street,Great Smith Street Westminster,London,,England                       ,SW1H 9NA,Central Government,,False
+10007858,Denbighshire County Contracting,,Kinmal Park Depot,Engine Hill,,Bodelyddan,,Wales                         ,LL18 5UX,Wider Public Sector,Private Sector Enabler,False
+10007856,Delves House Trust Ltd,,25-31 Queens Gate Terrace,,,London,,England                       ,SW7 5PP,Wider Public Sector,Private Sector Enabler,False
+10007855,Delamere Practice,,257 Dialstone Lane Great Moor,,,Stockport,,England                       ,SK2 7NA,Wider Public Sector,Private Sector Enabler,False
+10007853,Defence Transport and Movements Agency,,Monxton Road,,,Andover,Hampshire                     ,England                       ,SP11 8HT,Central Government,Executive Agency,False
+10007849,Defence Communication Services Agency,DCSA,HQ DCSA,CRM-3c1,Basil Hill Site,Corsham,Wiltshire                     ,England                       ,SN13 9NR,Central Government,Cross Service,False
+10007835,DDGS,,Maple/o E18 #2125 DPA Abbey Wood,Bristol,Avon,Bristol,Avon,England,BS34 8JH,Central Government,TBA,False
+10007834,DCSA MOD,,SCt 15 (West) Room 4,SO66 Building,HM Naval Base Devonport,Plymouth,,England                       ,PL2 2BG,Central Government,Private Sector Enabler,False
+10007833,DCSA (CIS) S,,Room 119,Bld 1/150,HMNB Portsmouth,Portsmouth,,England                       ,PO1 3LT,Wider Public Sector,Private Sector Enabler,False
+10007832,DCRE Royal Air Force Brize Norton,,Carterton,,,Oxford,,England                       ,OX18 3LX,Wider Public Sector,Private Sector Enabler,False
+10007831,DCITA,,28 National,Circuit Forrest,,Canberra,,Australia                     ,ACT 2617,Wider Public Sector,Private Sector Enabler,False
+10007830,DCBD,,Rm 109,Norcross Lane,,Blackpool,,England                       ,FY5 3TA,Wider Public Sector,Private Sector Enabler,False
+10007829,DCA,,2nd Floor,Southside,105 Victoria Street,London,,England                       ,SW1 6QT,Wider Public Sector,Private Sector Enabler,False
+10007828,Davis Langdon and Everest,,Princes House,39 Kingsway,,London,,England                       ,WC2B 6TP,Wider Public Sector,Private Sector Enabler,False
+10007827,DAVIDSON JE,,French Weir Health Centre,French Weir Avenue,,Taunton,,England                       ,TA1 1NW,Wider Public Sector,Private Sector Enabler,False
+10007823,DAS,,"Room 7/59,Metropole Bldgs",Northumberland Ave,,London,,England                       ,WC2N 5BL,Wider Public Sector,Private Sector Enabler,False
+10007820,Dare Valley Country Park,,Rhondda Cynon Taff CBC,,,Aberdare,,Wales                         ,CF44 7RG,Wider Public Sector,Private Sector Enabler,False
+10007817,Dalkia Energy and Technical Services,,1st Floor Lancastrian Office Centre,Colbert Road Old Trafford,,Manchester,,England                       ,M32 0FP,Wider Public Sector,Private Sector Enabler,False
+10007815,Dalbeattie Clinic,,Dalbeattie Clinic,,Millisle,Dalbeattie,,Scotland                      ,DG5 4AY,Wider Public Sector,Private Sector Enabler,False
+10007812,D Of C/Cp,,Wellesley House Room 103,103/109 Waterloo Street,,Glasgow,,Scotland                      ,G60 SNE,Wider Public Sector,Private Sector Enabler,False
+10007811,D Info (A)-Decision Support,,Room 2/01 Block 7,Wellington Barracks,Westminster,London,,England                       ,SW1E 6HQ,Wider Public Sector,Private Sector Enabler,False
+10007810,Cyron H Co-Op Ltd,,6 Bridge House,Chamberlayne Road,,London,,England                       ,NW10 3NR,Wider Public Sector,Private Sector Enabler,False
+10007809,Cyril Sweett Ltd,,60 Gray's Inn Road,,,London,,England                       ,WC1X 8AQ,Wider Public Sector,Private Sector Enabler,False
+10007806,Cymdeithas Tai Eryri,,Park Square,,,Blaneau Ffestiniog,,Wales                         ,LL41 3AD,Wider Public Sector,Private Sector Enabler,False
+10007803,CVS Clackmannanshire Ltd,,12-14 Primrose Street,,,Alloa,,Scotland                      ,FK10 1JG,Wider Public Sector,Private Sector Enabler,False
+10007802,Committee of Vice-Chancellors and Principals,CVCP,Woburn House,20 Tavistock Square,,London,,England                       ,WC1H 9HQ,Wider Public Sector,Private Sector Enabler,False
+10007801,Curtins Consulting Engineers Plc,,26-29 St Cross Street,,,London,,England                       ,EC1N 8UH,Wider Public Sector,Private Sector Enabler,False
+10007800,Currie and Brown,,9 King Street,,,London,,England                       ,EC2V 8EA,Wider Public Sector,Private Sector Enabler,False
+10007799,Cundall Johnston and Partners Llp,,13-17 Long Lane,,,London,,England                       ,EC1A 9PN,Wider Public Sector,Private Sector Enabler,False
+10007793,CSA - Regional Supplies Service,,Supplies Centre,Gransha Hospital,Clooney Road,Londonderry,,Northern Ireland              ,BT47 1YZ,Wider Public Sector,Private Sector Enabler,False
+10007792,CSA,,OD(S)ST 2nd Floor Beaumont House,Cliftonville,,Northampton,Northamptonshire              ,England                       ,NN1 5BE,Central Government,Executive Agency,False
+10007791,Crumlin Road Health Centre,,130-132 Crumlin Road,,,Belfast,,Northern Ireland              ,BT14 6AR,Wider Public Sector,Private Sector Enabler,False
+10007788,CRUCC,,Clements House,14-18 Gresham Street,,London,,England                       ,EC2V 7NL,Wider Public Sector,Private Sector Enabler,False
+10007787,Croxteth Sports Centre,,Altcross Road,West Derby,,Liverpool,,England                       ,L11 0BS,Wider Public Sector,Private Sector Enabler,False
+10007785,Crown Optical Centre,,79 Pendleton Way,Salford,,Manchester,,England                       ,M6 5FW,Wider Public Sector,Private Sector Enabler,False
+10007782,Crown Office and Procurator Fiscal Serv,,Abbey Business Centre,4th Floor 83 Princes Street,,Edinburgh,,Scotland                      ,EH2 2ER,Wider Public Sector,Private Sector Enabler,False
+10007779,Crown Dale Medical Centre,,61 Crown Dale,,,London,,England                       ,SE19 3NY,Wider Public Sector,Private Sector Enabler,False
+10007778,Crown Agents Purchasing Services Ltd,,C/O North Middlesex University Hospital NHS Trust,Sterling Way,,London,,England                       ,N18 1QX,Wider Public Sector,Private Sector Enabler,False
+10007777,Crossroads (Scotland) Care Attendance Scheme Ltd,,24 George Square,,,Glasgow,,Scotland                      ,G2 1EG,Wider Public Sector,Private Sector Enabler,False
+10007776,Crossrail Ltd,,2nd Floor,No. 1 Butler Place,,London,,England                       ,SW1H 0PT,Wider Public Sector,Private Sector Enabler,False
+10007772,Crooke Village,,99 Crooke Road,Crooke,,Wigan,,England                       ,WN6 8LR,Wider Public Sector,Private Sector Enabler,False
+10007767,Crisis Centre Ministries,,12 City Road,,,Bristol,,England                       ,BS2 8TP,Wider Public Sector,Private Sector Enabler,False
+10007766,Criminal Records Bureau,,10 Princes Parade,Princes Dock,,Liverpool,Merseyside                    ,England                       ,L3 1QY,Central Government,Executive Agency,False
+10007765,Home Office Criminal Justice IT,,24th Floor Portland House,Stag Place,,London,,England                       ,SW1E 5RS,Central Government,,False
+10007761,Crawley Citizens Advice Bureau,CAB,103 High Street,,,Crawley,West Sussex                   ,England                       ,RH10 1DD,Wider Public Sector,Charity,False
+10007756,Craigend Resource Centre,,McLeod Street,,,Greenock,,Scotland                      ,PA15 2HD,Wider Public Sector,Private Sector Enabler,False
+10007755,Craigavon and Banbridge Community Health,,Bannvale House,10 Moyallan Road,,Gilford,County Armagh                 ,Northern Ireland              ,BT63 5JX,Wider Public Sector,Health,False
+10007754,CQMS,,3 RMP(Rear),,, ,,Yugoslavia                    ,BFPO 544,Wider Public Sector,Private Sector Enabler,False
+10007752,Covingham Park Junior,,The Harriers,Covingham Park,,Swindon,,England                       ,SN3 5BD,Wider Public Sector,Private Sector Enabler,False
+10007751,Coventry Solihull and Warwickshire Partnership Ltd.,CSWP,First Floor,Tower Court,Coultards Way,Coventry,,England                       ,CV6 5QT,Wider Public Sector,Private Sector Enabler,False
+10007750,Coventry Social Services,,Civic Centre,Little Park Street,,Coventry,,England                       ,CV1 5RS,Wider Public Sector,Private Sector Enabler,False
+10007749,Coventry School Foundation,,Coventry Preparatory School,Kenilworth Road,,Coventry,,England                       ,CV3 6PT,Wider Public Sector,Private Sector Enabler,False
+10007743,Court of Masters Department,,1 RMP,Wentworth Barracks,,Hereford,,England                       ,BFPO 15,Wider Public Sector,Private Sector Enabler,False
+10007736,Countisbury Residential Home,,Minehead Rd,Llanrumney,,Cardiff,,Wales                         ,CF3 9TH,Wider Public Sector,Private Sector Enabler,False
+10007735,Counties Furniture Group,,The Shirehall,Abbey Foregate,,Shrewsbury,,England                       ,SY2 6ND,Wider Public Sector,Private Sector Enabler,False
+10007734,Council Offices,,High Street,,,Annan,,Scotland                      ,DG12 6AQ,Wider Public Sector,Private Sector Enabler,False
+10007730,Museums Libraries and Archives Council,MLA,Victoria House,Southampton Row,,London,,England                       ,WC1B 4EA,Central Government,NDPB,False
+10007728,Cottage Homes,,Crookfur Road,Marshall Estate,Hammers Lane,Glasgow,,Scotland                      ,G77 6JY,Wider Public Sector,Private Sector Enabler,False
+10007712,Co-Op Home Services,,367 Chiswick High Road,,,London,,England                       ,W4 4AG,Wider Public Sector,Private Sector Enabler,False
+10007707,Contracts Management Unit ISD1 Cmu,,80 London Road,,,London,,England                       ,SE1 6LW,Wider Public Sector,Private Sector Enabler,False
+10007706,Contracts Branch,,CSS Branch,HQ1 NI,, ,,Northern Ireland              ,BFPO 825,Wider Public Sector,Private Sector Enabler,False
+10007702,Connexions-MOB,,9b Alton House Office Park,Gatehouse Way,,Aylesbury,,England                       ,HP19 8YB,Wider Public Sector,Private Sector Enabler,False
+10007693,Compton Hospice,,4 Compton Road West,Compton,,Wolverhampton,,England                       ,WV3 9DH,Wider Public Sector,Private Sector Enabler,False
+10007689,Compass Group PLC,,Queens Wharf,Queen Caroline Street,,London,,England                       ,W6 9RJ,Wider Public Sector,Private Sector Enabler,False
+10007686,Community Teachers - Surestart,,Standhouse Centre,,,Sheffield,,England                       ,S2 1HX,Wider Public Sector,Private Sector Enabler,False
+10007685,Community Support Services,,Wood Green Business Centre,Western Road,,London,,England                       ,N22 6UH,Wider Public Sector,Private Sector Enabler,False
+10007684,Community Service Volunteers,,237 Pentonville Road,,,London,,England                       ,N1 9NJ,Wider Public Sector,Private Sector Enabler,False
+10007683,Community Self-Build Agency,,40 Bowling Green Lane,,,London,,England                       ,EC1R 0NE,Wider Public Sector,Private Sector Enabler,False
+10007682,Community School of Auchterarder,,New School Lane,,,Auchterarder,,Scotland                      ,PH3 1BL,Wider Public Sector,Private Sector Enabler,False
+10007680,Community Integration Partnership,,Ground Floor Newland House,137-139 Hagley Road,Edgbaston,Birmingham,West Midlands                 ,England                       ,B16 8UA,Wider Public Sector,Private Sector Enabler,False
+10007675,Community Health Services,,Aston Hall Hospital,Aston-On-Trent,,Derby,,England                       ,DE72 2AL,Wider Public Sector,Private Sector Enabler,False
+10007674,Community Futures,,15 Victoria Road,Fulwood,,Preston,,England                       ,PR2 8PS,Wider Public Sector,Private Sector Enabler,False
+10007672,Community Education Association,,Anderton Park School,Dennis Road,Balsall Heath,Birmingham,West Midlands                 ,England                       ,B12 8BL,Wider Public Sector,Private Sector Enabler,False
+10007671,(Closed) Community Development Foundation,,Unit 5 Angel Gate 320 - 326 City Road,London,Greater London,London,Greater London,England,EV1V 2PT,Central Government,NDPB,False
+10007669,Communication Workers Union,,20 Church Road,Lawrence Hill,,Bristol,,England                       ,BS5 9JA,Wider Public Sector,Private Sector Enabler,False
+10007664,Commission for Patient and Public Involvement in Health,,9th Floor,Ladywood House,45 Stephenson Street,Birmingham,West Midlands                 ,England                       ,B2 4DY,Central Government,NDPB,False
+10007662,Commission for improvement of health,,Hannibal House  3rd Floor,Elephant & Castle,,London,,England                       ,SE1 6UD,Wider Public Sector,Private Sector Enabler,False
+10007657,Commercial Branch,,HQNI,G4 Estate Building,, ,,Northern Ireland              ,BFPO 825,Wider Public Sector,Private Sector Enabler,False
+10007655,Combined Tax Tribunel,,15/19 Bedford Ave,,,London,,England                       ,WC1B 3AS,Wider Public Sector,Private Sector Enabler,False
+10007652,Colliers Conrad Ritblat Erdman,,Milner House,14 Manchester Square,,London,,England                       ,W1U 3PP,Wider Public Sector,Private Sector Enabler,False
+10007641,Colehill County,,Middlehill Road,Colehill,,Wimborne,,England                       ,BH12 2HL,Wider Public Sector,Private Sector Enabler,False
+10007640,Coleg Morgannwg,,Rhondda Campus,Pontrhondda Road,Llwynypia,Tonypandy,,Wales                         ,CF40 2SZ,Wider Public Sector,Private Sector Enabler,False
+10007639,Coleg Llysfasi,,Pentrcelyn,,,Ruthin,,Wales                         ,LL15 2LB,Wider Public Sector,Private Sector Enabler,False
+10007636,Colchester Citizens Advice Bureau,,Winsleys House,High Street,,Colchester,,England                       ,CO1 1UG,Wider Public Sector,Private Sector Enabler,False
+10007635,Colchester CDC - Advisory  Inspection Service,,Acacia Avenue,,,Colchester,,England                       ,CO4 3TQ,Wider Public Sector,Private Sector Enabler,False
+10007633,Coin Street Secondary Hc Ltd,,99 Upper Ground,,,London,,England                       ,SE1 9PP,Wider Public Sector,Private Sector Enabler,False
+10007629,Coastguard Agency,,105 Commercial Rd,,,Southampton,,England                       ,SO15 1EG,Wider Public Sector,Private Sector Enabler,False
+10007620,Clwyd Leisure Ltd,,Sun Centre,East Parade,,Rhyl,,Wales                         ,LL18 3AQ,Wider Public Sector,Private Sector Enabler,False
+10007618,CLP Structured Finance Ltd,,131 Baker Street,,,London,,England                       ,W1U 6SE,Wider Public Sector,Private Sector Enabler,False
+10007614,Clogher Palace Association,,St Macartans Residential Home,74 Main Street,,Clogher,,Northern Ireland              ,BT76 OAA,Wider Public Sector,Private Sector Enabler,False
+10007613,Clock Tower Associates,,87 Cadbury Heath Road,,Warmley,Gloucester,,England                       ,BS30 8DQ,Wider Public Sector,Private Sector Enabler,False
+10007608,Cleveland Lodge,,Church Lane,Figheldean,,Salisbury,,England                       ,SP4 8JL,Wider Public Sector,Private Sector Enabler,False
+10007604,Clays Lane H Co-Op Ltd,,Community Centre,Clays Lane,Stratford,London,,England                       ,E15 2HJ,Wider Public Sector,Private Sector Enabler,False
+10007602,Clarson Goff Management,,34 St James Street,,,London,,England                       ,SW1A 1HD,Wider Public Sector,Private Sector Enabler,False
+10007601,Claremont Centre,,2 Cookham Road,,,Maidenhead,,England                       ,SL6 8AN,Wider Public Sector,Private Sector Enabler,False
+10007597,Clapham Park Project NDC,,45 Streatham Place,,,London,,England                       ,SW2 4QG,Wider Public Sector,Private Sector Enabler,False
+10007595,CJC Programme,,Police,PO Box 4,Leek Wootton,Warwick,,England                       ,CV35 7QB,Wider Public Sector,Private Sector Enabler,False
+10007594,CJ Associates,,26 Upper Brook Street,,,London,,England                       ,W1K 7QE,Wider Public Sector,Private Sector Enabler,False
+10007592,City Wide Services,,"Civic Centre,Chorley Road",Swinton,,Manchester,,England                       ,M27 5BB,Wider Public Sector,Private Sector Enabler,False
+10007586,City of Westminster Adult Education Services,,Amberley Road Centre,Amberley Road,,London,,England                       ,W9 2JJ,Wider Public Sector,Private Sector Enabler,False
+10007583,City of Stoke onTrent,,Civic Centre ,Glebe Street,,Stoke on Trent,,England                       ,ST4 1RT,Wider Public Sector,Private Sector Enabler,False
+10007572,City Of Coventry Supplies Div,,Greyfriars Lane,Off Union St,,Coventry,,England                       ,CV1,Wider Public Sector,Private Sector Enabler,False
+10007571,City Of Birmingham Museum and Art Gallery,,Chamberlain Square,,,Birmingham,West Midlands                 ,England                       ,B3 3DH,Wider Public Sector,Private Sector Enabler,False
+10007569,City Museums and Art Gallery,,Queens Road,Clifton,,Bristol,,England                       ,BS 2BJ,Wider Public Sector,Private Sector Enabler,False
+10007568,City Literary Institute,,16 Stukeley Street,,,London,,England                       ,WC2B 5LJ,Wider Public Sector,Private Sector Enabler,False
+10007566,City College Manchester,,Moors Road,Wythenshawe,,Manchester,Greater Manchester            ,England                       ,M23 9BQ,Wider Public Sector,Colleges of Further Education,False
+10007564,City Catering Organisation,,Crown Square,,,Manchester,,England                       ,M60 3BB,Wider Public Sector,Private Sector Enabler,False
+10007563,City Catering,,"Cromer Rd Northwood,",,,Stoke on Trent,,England                       ,ST1 6YS,Wider Public Sector,Private Sector Enabler,False
+10007556,Citizens Advice Bureau - Bournemouth,,Town Hall,West Wing,Bourne Avenue,Bournemouth,,England                       ,BH2 6DX,Wider Public Sector,Private Sector Enabler,False
+10007554,Citex Group,,31 Worship Street,,,London,,England                       ,EC2A 2DX,Wider Public Sector,Private Sector Enabler,False
+10007550,CIPFA,,Public Finance & Accounts,215-221 Borough High Street,,London,,England                       ,SE1 1JA,Wider Public Sector,Private Sector Enabler,False
+10007549,Chartered Institute of Library and Information Professionals ,CILIP,7 Ridgmount Street,,,London,,England                       ,WC1E 7AE,Wider Public Sector,Private Sector Enabler,False
+10007547,Churchill Community School,,Churchill Green,Churchill,,Bristol,,England                       ,BS19 5QN,Wider Public Sector,Private Sector Enabler,False
+10007544,Church Street Practice,,The Health Centre,Garston Lane,,Wantage,,England                       ,OX12 7AY,Wider Public Sector,Private Sector Enabler,False
+10007542,Church Of England,,Top Flat St Marks Vicarage,Sandringham Road,,London,,England                       ,E8  2LL,Wider Public Sector,Private Sector Enabler,False
+10007541,Church Mission Society,,Partnership House,157 Waterloo Road,,London,,England                       ,SE1 8UU,Wider Public Sector,Private Sector Enabler,False
+10007540,Church Commissioners For England,,1-3 Millbank,,,London,,England                       ,SW1P NJZ,Wider Public Sector,Private Sector Enabler,False
+10007536,Christian Camping International,,2 Leon House,Queensway,Bletchley,Milton Keynes,,England                       ,MK2 2SS,Wider Public Sector,Private Sector Enabler,False
+10007535,Christian Camping Internation (UK) Ltd,,6A 1st Floor Cash's Business Centre,228 Widdington Road,,Coventry,,England                       ,CV1 4PB,Wider Public Sector,Private Sector Enabler,False
+10007525,Christ Apostolic Church,,215/223 Kingsland Road,,,London,,England                       ,E2 8AN,Wider Public Sector,Private Sector Enabler,False
+10007521,Choice Support,,27 Barry Street,,,London,,England                       ,SE22 0HY,Wider Public Sector,Private Sector Enabler,False
+10007520,Chk Charities Limited,,10 Fenchurch Street,,,London,,England                       ,EC3M 3LB,Wider Public Sector,Private Sector Enabler,False
+10007519,Chisel Ltd,,188a Brockley Road,,,London,,England                       ,SE4 2RN,Wider Public Sector,Private Sector Enabler,False
+10007514,Child Support Agency,CSA,Room 158A,Benton Park Road,Stephenson Street,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE98 1XX,Central Government,Executive Agency,False
+10007513,Chichester Baptist Church,,Office,,,Chichester,West Sussex                   ,England                       ,PO19 3AW,Wider Public Sector,Private Sector Enabler,False
+10007510,Chessington Computer Services,,Leatherhead Road,,,Chessington,,England                       ,KT9 2LT,Wider Public Sector,Private Sector Enabler,False
+10007508,Cheshire Information Consortium,,Chester Fire Station,St Anne Street,,Chester,,England                       ,CH1 2HP,Wider Public Sector,Private Sector Enabler,False
+10007504,Chelsfield,,67 Brook Street,,,London,,England                       ,W1Y 2NJ,Wider Public Sector,Private Sector Enabler,False
+10007500,Cheethams School Of Music,,Long Millgate,,,Manchester,,England                       ,M3 1SB,Wider Public Sector,Private Sector Enabler,False
+10007495,Chartered Institute Of Public Finance,,3 Robert Street,,,London,,England                       ,WC2N 6RL,Wider Public Sector,Private Sector Enabler,False
+10007494,Chartered Institute of Arbitrators,,24 Angel Gate,City Road,,London,,England                       ,EC1V 2RS,Wider Public Sector,Private Sector Enabler,False
+10007492,Charleston Academy,,Kinmylies,,,Inverness,,Scotland                      ,IV3 6ET,Wider Public Sector,Private Sector Enabler,False
+10007489,Charing Cross and Westminster Medical School,,The Reynolds Building,St Dunstans Road,,London,,England                       ,W6 8RP,Wider Public Sector,Private Sector Enabler,False
+10007484,CEPC,,Park Square West,,,London,,England                       ,NW1 4LJ,Wider Public Sector,Private Sector Enabler,False
+10007481,Centre for Political and Diplomatic Studies,,Hill House,Shotover Estate Wheatley,,Oxford,,England                       ,OX33 1QN,Wider Public Sector,Private Sector Enabler,False
+10007480,Centre for Genome Research,,University of Edinburgh,King's Buildings,West Main Road,Edinburgh,,Scotland                      ,EH9 3JQ,Wider Public Sector,Private Sector Enabler,False
+10007479,Centre for Ecology and Hydrology,,Hill of Brathens,Glassel,Banchory,Aberdeen,,Scotland                      ,AB31 4BW,Wider Public Sector,Private Sector Enabler,False
+10007460,Central Criminal Court,,Old Bailey,,,London,,England                       ,EC4M 7EH,Central Government,Private Sector Enabler,False
+10007459,Central Council For Education and Training,,Derbyshire House,St Chads Street,,London,,England                       ,WC1H 8AD,Wider Public Sector,Private Sector Enabler,False
+10007458,Central Chanery of the Orders of Knighthood,,St James Palace,,,London,,England                       ,SW1A 1BH,Wider Public Sector,Private Sector Enabler,False
+10007454,Central and Provincial Ht,,98 Chamberlayne Road,,,London,,England                       ,NW10 3JN,Wider Public Sector,Private Sector Enabler,False
+10007452,Centenary Surgery,,Centenary Gardens,,,Coatbridge,,Scotland                      ,ML5 4BY,Wider Public Sector,Private Sector Enabler,False
+10007447,CDDA,,Chatham Maritime,The Observatory,,Brunel,,England                       ,ME4 4MT,Wider Public Sector,Private Sector Enabler,False
+10007446,Caxton Facilities Management Ltd,,Conway House,St Mellons Business Park,,Cardiff,,Wales                         ,CF3 0LT,Wider Public Sector,Private Sector Enabler,False
+10007440,CAVE,,2 Rectory Grove,,,London,,England                       ,SW4 0DZ,Wider Public Sector,Private Sector Enabler,False
+10007435,Catering Direct,,"Catering Direct Education Centre,","Grawen Street,",,Porth,,Wales                         ,CF39 0BU,Wider Public Sector,Private Sector Enabler,False
+10007430,Castlereagh Borough Council,,Bradford Court Upper Galwally,Castlereagh,County Antrim,Castlereagh,County Antrim,Northern Ireland,BT8 6RB,Wider Public Sector,Local Government,False
+10007428,Castle View Independent,,Steuart Road,Bridge of Allan,,Stirling,,Scotland                      ,FK9 4JX,Wider Public Sector,Private Sector Enabler,False
+10007427,Castle Vale Housing Action Trust,,Farnborough Road,Castle vale,,Birmingham,West Midlands                 ,England                       ,B35 7NL,Central Government,NDPB,False
+10007426,Cass and Claredale,,31 Jewry Street,,,London,,England                       ,EC3N 2EY,Wider Public Sector,Private Sector Enabler,False
+10007424,Cartermatch Lane,,Cartermatch Lane,,,Enfield,,England                       ,EN1 4JY,Wider Public Sector,Private Sector Enabler,False
+10007423,Carrick Leisure Limited,,Gyllyngdune Cottage,41 Melvill Road,,Falmouth,,England                       ,TR11 4AR,Wider Public Sector,Private Sector Enabler,False
+10007422,Carr-Gomm Society Ltd,,Duke House,6-12 Tabard Street,,London,,England                       ,SE1 4JU,Wider Public Sector,Private Sector Enabler,False
+10007415,Carillion Services Ltd,,Room 3.05,Bow House Business Centre,153-159 Bow Road,London,,England                       ,E3 2SE,Wider Public Sector,Private Sector Enabler,False
+10007414,Carillion Plc,,24 Birch Street,,,Wolverhampton,,England                       ,WV1 4HY,Wider Public Sector,Private Sector Enabler,False
+10007409,Care Council for Wales,,6th Floor,Southgate House,Wood Street,Cardiff,,Wales                         ,CF14 1EW,Wider Public Sector,Private Sector Enabler,False
+10007408,Care and Support Services Ltd,,3 Tramway Avenue,Stratford,,London,,England                       ,E15 4PN,Wider Public Sector,Private Sector Enabler,False
+10007405,Cardinal Hume Centre,,3-7 Arneway Street,Horseferry Road,,London,,England                       ,SW1P 2BG,Wider Public Sector,Private Sector Enabler,False
+10007403,Cardinal Heenan Sports Centre,,Honeysgreen Lane,,,Liverpool,,England                       ,L12 9HZ,Wider Public Sector,Private Sector Enabler,False
+10007401,Cardiff Royal Infirmary,,Newport Rd,,,Cardiff,,Wales                         ,CF2 1SZ,Wider Public Sector,Private Sector Enabler,False
+10007395,CAPS Ltd,,North Middlesex University Hospital,Sterling Way,,London,,England                       ,N18 1QX,Wider Public Sector,Private Sector Enabler,False
+10007394,Capital Housing,,318/320 St Pauls Road,Highbury,,London,,England                       ,N1 2LF,Wider Public Sector,Private Sector Enabler,False
+10007391,Capability Scotland,,22 Corstorphine Road,Howwood Rd,,Edinburgh,,Scotland                      ,EH12 6HP,Wider Public Sector,Private Sector Enabler,False
+10007389,Canterbury Vehicle Testing Station,,Hersden,,,Canterbury,,England                       ,CT3 4HB,Wider Public Sector,Private Sector Enabler,False
+10007386,Canmore Partnership Ltd,,8th/9th Floor,St Andrew House,141 West Nile Street,Glasgow,,Scotland                      ,G1 2RN,Wider Public Sector,Private Sector Enabler,False
+10007383,CAN,,81 St Giles Street,,,Northampton,,England                       ,NN1 1JF,Wider Public Sector,Private Sector Enabler,False
+10007378,Camphill (Blair Drummond) Trust,,Blairdrummond,,,Stirling,,Scotland                      ,FK9 4LT,Wider Public Sector,Private Sector Enabler,False
+10007376,Campaign  Support Group Ethnic Minorities,,Pallingswick House,241 King Street,Hammersmith,London,,England                       ,W6 9LP,Wider Public Sector,Private Sector Enabler,False
+10007372,Camden Black Parents Teachers Association,,27-30 Cheriton,Queens Crescent,,London,,England                       ,NW5 4EZ,Wider Public Sector,Private Sector Enabler,False
+10007356,Calderdale and Kirklees Careers Service Partnership Ltd,,78 John William Street,,,Huddersfield,West Yorkshire                ,England                       ,HD1 1EH,Wider Public Sector,Private Sector Enabler,False
+10007353,CADW - Welsh Historic Monuments,,Crown Building,Cathays Park,,Cardiff,,Wales                         ,CF1 3NQ,Wider Public Sector,Private Sector Enabler,False
+10007350,Cadagan Court Nursing Home,,Cadogan Court,Barley Lane,,Exeter,,England                       ,EX4 1TA,Wider Public Sector,Private Sector Enabler,False
+10007347,Butterfly Conservation,,Manor Yard,East Lulworth,,Wareham,,England                       ,BH20 5QP,Wider Public Sector,Private Sector Enabler,False
+10007344,Business Link for West Yorkshire,BLWY,Unit 4,Meadow Court,Millshaw Business Park,Leeds,West Yorkshire                ,England                       ,LS11 8LZ,Wider Public Sector,Private Sector Enabler,False
+10007342,Business Developement,,Room 9/127 St Christophers House,90/114 Southwick Street,,London,,England                       ,SE1 0TD,Wider Public Sector,Private Sector Enabler,False
+10007341,Business and Technology Library,,Central Library,Surrey Street,,Sheffield,,England                       ,S1 1XZ,Wider Public Sector,Private Sector Enabler,False
+10007339,Bushmills Rural Surestart,,64 Main Street,,,Bushmills,,Northern Ireland              ,BT57 8QD,Wider Public Sector,Private Sector Enabler,False
+10007321,Buile Hill City Learning Centre,,2 Manor Road,,,Salford,,England                       ,M6 8QJ,Wider Public Sector,Private Sector Enabler,False
+10007320,Buildings and Plant Group Qmp 701,,Broad Street,,,Birmingham,West Midlands                 ,England                       ,B1 2HF,Wider Public Sector,Private Sector Enabler,False
+10007318,Building Management Northern Ireland,,Aldergrove District Office,199 Queensway  Lambeg,,Aldergrove,,Northern Ireland              ,BT29 4BS,Wider Public Sector,Private Sector Enabler,False
+10007317,Building Design Partnership,,PO Box 4WD,16 Gresse Street,,London,,England                       ,W1A 4WD,Wider Public Sector,Private Sector Enabler,False
+10007316,Building and Property Defence,,Building H46,Dera Fort Halstead,,Sevenoaks,Kent                          ,England                       ,TN14 7BP,Central Government,,False
+10007315,Budhisattva Buddhist Centre,,3 Lansdowne Road,Hove,,Brighton,,England                       ,BN,Wider Public Sector,Private Sector Enabler,False
+10007314,Buckingham Palace,,Office,,,London,,England                       ,SW1A 1AA,Wider Public Sector,Private Sector Enabler,False
+10007313,BSO (MQ),,16 Store PP12,HM Naval  Base,,Portsmouth,,England                       ,PO1 3LU,Wider Public Sector,Private Sector Enabler,False
+10007302,Broughton House Home for Ex Service Pers,,Park Lane,,,Salford,,England                       ,M7 4JD,Wider Public Sector,Private Sector Enabler,False
+10007301,Broughton Charitable Trust,,56 Broom Lane,,,Salford,,England                       ,M7 4RS,Wider Public Sector,Private Sector Enabler,False
+10007300,Broomgrove Nursing Home,,30 Broomgrove Road,,,Sheffield,,England                       ,S10 2LR,Wider Public Sector,Private Sector Enabler,False
+10007297,Bromley User Group,,Dunraven House,1 Weighton Road  Penge,,London,,England                       ,SE20 8SX,Wider Public Sector,Private Sector Enabler,False
+10007290,Broadcasting Standards Commission,,7 The Sanctuary,,,London,,England                       ,SW1P 3JS,Central Government,NDPB,False
+10007276,British High Commission Dhaka,,British High Commission,United Nations Road,PO Box 6079,Dhaka 1212,,BFPO                          ,1212,Central Government,,False
+10007274,British Geological Team,,DTI Core Store,376 Gilmerton Road,,Edinburgh,,Scotland                      ,EH17 7QS,Wider Public Sector,Private Sector Enabler,False
+10007222,Breakout Youth Training Group,,16-18 Alpha Road,Gorleston,,Great Yarmouth,,England                       ,NR31 0LQ,Wider Public Sector,Private Sector Enabler,False
+10007216,Brampton Restaurant,,Davidson Professional Centre,Davidson Road,,Croydon,,England                       ,CR0 6DD,Wider Public Sector,Private Sector Enabler,False
+10007191,Bournemouth Community Associations,,55 Beaufort Road,Southbourne,,Bournemouth,,England                       ,BH6 5AT,Wider Public Sector,Private Sector Enabler,False
+10007176,Bolton Metropolitan Social Services,,Washacre,Westhoughton,,Bolton,,England                       ,BL5 2NE,Wider Public Sector,Private Sector Enabler,False
+10007169,Bob Hopper,,147 Milton Road,,,Cambridge,,England                       ,CB4 1XE,Wider Public Sector,Private Sector Enabler,False
+10007168,Bob Ainsworth MP,,4-6 9th Floor,Coventry Point,Market Way,Coventry,Warwickshire                  ,England                       ,CV1 1EA,Wider Public Sector,,False
+10007165,BMAL,,Main Office,,, ,,Northern Ireland              ,BFPO 804,Wider Public Sector,Private Sector Enabler,False
+10007164,BM NI,,Main Office,,, ,,Northern Ireland              ,BFPO 803,Wider Public Sector,Private Sector Enabler,False
+10007141,Bishops Cleeve Youth Centre,,Gloucestershire County Council,Church Road,Bishops Cleeve,Cheltenham,,England                       ,GL52 8LR,Wider Public Sector,Private Sector Enabler,False
+10007129,Birmingham Specialist Community Health NHS Trust,,Carnegie Centre,Hunters Road Hockley,,Birmingham,West Midlands                 ,England                       ,B19 1DR,Wider Public Sector,Acute Trust,False
+10007107,BFC HQ,,Cyprus Works Unit,,, ,,Cyprus                        ,BFPO 53,Wider Public Sector,Private Sector Enabler,False
+10007105,Beverley Vehicle Testing Station,,Oldbeck Road,Off Grovehill Road,,Beverley,,England                       ,HU7 0JG,Wider Public Sector,Private Sector Enabler,False
+10007097,Berwick Community Centre,,N-RAIS Project,Palace Street East,,Berwick upon Tweed,,Scotland                      ,TD15 1HT,Wider Public Sector,Private Sector Enabler,False
+10007094,Bengworth care home,,Badsey Road,,,Evesham,,England                       ,WR11 7PA,Wider Public Sector,Private Sector Enabler,False
+10007086,Belgian Embassy,,103 Eaton Square,,,London,,England                       ,SW1W 9AB,Wider Public Sector,Private Sector Enabler,False
+10007082,Bedfordshire County Council,,County Hall,Cauldwell Street,,Bedford,Bedfordshire                  ,England                       ,MK42 9AP,Wider Public Sector,District Council,False
+10007075,BEC Limited,,351 Southwark Park Road,,,London,,England                       ,SE16 2JW,Wider Public Sector,Private Sector Enabler,False
+10007063,Battledown Childrens Centre,,Harp Hill Battledown,Cheltenham,Gloucestershire,Cheltenham,Gloucestershire,England,GL52 6PZ,Wider Public Sector,Private Sector Enabler,False
+10007058,Bath and North East Somerset Primary Care Trust,,Trust HQ,St. Martin's Hospital,Midford Road,Bath,,England                       ,BA2 5RP,Wider Public Sector,PCT - Commissioning,False
+10007057,Baskerville,,Fellows Lane,Harbourne,,Birmingahm,,England                       ,B17 9B,Wider Public Sector,Private Sector Enabler,False
+10007056,Basingstoke Consortium,,Management Centre,John Hunt of Everest School,Popley Way,Basingstoke,,England                       ,RG24 9AB,Wider Public Sector,Private Sector Enabler,False
+10007055,NHS Basildon & Brentwood Clinical Commissioning Group,,Phoenix Court Christopher Martin Road,Basildon,Essex,Basildon,Essex,England,SS14 3HG,Wider Public Sector,PCT - Commissioning,False
+10007047,Barnett Overseas Student Housing,,21 Woodside Avenue,,,London,,England                       ,N12 8AQ,Wider Public Sector,Private Sector Enabler,False
+10007039,Barclays Bank Plc,,Po Box 470,,,Northampton,Northamptonshire              ,England                       ,NN1 1ZR,Wider Public Sector,Private Sector Enabler,False
+10007037,Bankgesellschaft Berlin AG,,1 Crown Court,Cheapside,,London,,England                       ,EC2V 6LR,Wider Public Sector,Private Sector Enabler,False
+10007028,Balfour St (Housing) Project Ltd,,C/O 85c Balfour Street,,,London,,England                       ,SE17 1PB,Wider Public Sector,Private Sector Enabler,False
+10007024,Baer Youth Centre,,12 Bewick Road,,,Gateshead,,England                       ,NE8 4DP,Wider Public Sector,Private Sector Enabler,False
+10007015,Ayrshire and Arran Primary Care Trust,,Greenan House,P O Box 13,Ayr,Ayr,Ayrshire                      ,Scotland                      ,KA6 6AB,Wider Public Sector,Health,False
+10007003,Avenance,,Trinity School,Shirley Park,,Croydon,,England                       ,CR9 7AT,Wider Public Sector,Private Sector Enabler,False
+10006992,Atkins Asset Management,,Chilbrook  Oasis Business Park,Eynsham,,Oxford,,England                       ,OX29 4AH,Wider Public Sector,Private Sector Enabler,False
+10006974,Assets Recovery Agency - Belfast,,PO Box 592,,,Belfast,County Down                   ,Northern Ireland              ,BT4 3YR,Wider Public Sector,,False
+10006972,Ass for Public Service Excellence,,Floor 11  Council Offices,Almada Street,,Hamilton,,Scotland                      ,ML3 0AL,Wider Public Sector,Private Sector Enabler,False
+10006971,ASRA Greater London Housing Association,,239/241 Kennington Lane,,,London,,England                       ,SE11 5QU,Wider Public Sector,Housing Associations,False
+10006967,Ashwood Resource Centre,,123 Nottingham Road,Selsdon,,Nottingham,,England                       ,NG16 6BU,Wider Public Sector,Private Sector Enabler,False
+10006955,ASAR House,,2 Bates Crescent,Stepham Vale,,London,,England                       ,SW16 5BD,Wider Public Sector,Private Sector Enabler,False
+10006944,Army Technical Support Agency,,10 Ha Ha Road,Woolwich,,London,,England                       ,SE18 4QA,Central Government,Army,False
+10006915,Aqumen Services Ltd,,Building 24,Raf Brize Norton,,Carterton,,England                       ,OX18 3LX,Wider Public Sector,Private Sector Enabler,False
+10006913,Aqumen Group Plc,,Hetton Court,The Oval,Hunslet,Leeds,West Yorkshire                ,England                       ,LS10 2AU,Wider Public Sector,Private Sector Enabler,False
+10006912,Aqumen Facilities Management Ba,,3rd Floor,St Johns House,Merton Road,Bootle,,England                       ,L69 9BB,Wider Public Sector,Private Sector Enabler,False
+10006911,Aquatera,,Islington Council,Sobel Leisure Centre,Hornsey Road,London,,England                       ,N7 7NY,Wider Public Sector,Private Sector Enabler,False
+10006884,American Embassy,,24-32 Grosvenor Square,,,London,,England                       ,W1A 1AE,Wider Public Sector,Private Sector Enabler,False
+10006867,Albert Bridge Housing Association Ltd,,Estra House,Station Approach  Streatham,,London,,England                       ,SW16 6HW,Wider Public Sector,Housing Associations,False
+10006852,AEA Fuel Services,,Dounreay,Thurso,,Caithness,,Scotland                      ,KW14 7TZ,Wider Public Sector,Private Sector Enabler,False
+10006850,Advantage West Midlands,,3 Preistley Walk Holt Street Aston Science Park,Birmingham,West Midlands,Birmingham,West Midlands,England,B7 4BN,Central Government,NDPB,False
+10006823,Aberdeen Wing Air Cadets,ATC,Gordon Barracks,Bridge of Don,,Aberdeen,Aberdeenshire                 ,Scotland                      ,AB23 8DB,Central Government,RAF,False
+10006821,Aberdeen Advantage,,4 Albert Street,,,Aberdeen,,Scotland                      ,AB25 1XQ,Wider Public Sector,Private Sector Enabler,False
+10006804,603 City of Edinburgh Squadron,,RAuxAF,25 Learmonth Terrace,,Edinburgh,Mid Lothian                   ,Scotland                      ,EH4 1NZ,Central Government,,False
+10006803,52 Lowland Brigade HQ,,Main Office,,,Edinburgh,Mid Lothian                   ,Scotland                      ,EH1,Central Government,,False
+10006798,25 Engineer Regt Workshop Reme,,"25 Engineer Regt,",,,Antrim ,,Northern Ireland              ,BFPO 808,Central Government,,False
+10006797,216 The Bolton Artillery Bty RA V,,The Bolton Artillery Barracks,Nelson Street,,Bolton,,England                       ,BL3 2RW,Central Government,,False
+10006794,156 Pro Coy Rmp,,Goojerat Rd,,,Colchester,Essex                         ,England                       ,CO2 7TR,Central Government,,False
+10006792,100 Regiment RA,,244 Marsh Road,Leagrave,,Luton,Bedfordshire                  ,England                       ,LU3 2RX,Central Government,,False
+10006788,1 Kings Weeton Barracks,,Weeton,,,Preston,,England                       ,PR4 3JQ,Central Government,,False
+10006785,Yorkshire Blood Transfusion Service,,Bridle Path,,,Leeds,West Yorkshire                ,England                       ,LS15 7TW,Wider Public Sector,Private Sector Enabler,False
+10006784,Yorkshire and Humberside Tourist Board,,312 Tadcaster Rd,,,York,Yorkshire                     ,England                       ,YO2 2HF,Wider Public Sector,Private Sector Enabler,False
+10006779,Wakefield Diocesan Board of Education,,Church House,1 South Parade,,Wakefield,Yorkshire                     ,England                       ,WF1 1LP,Wider Public Sector,Private Sector Enabler,False
+10006778,Wakefield Civic Society,,8 Aberfold Road,,,Wakefield,Yorkshire                     ,England                       ,WF1 4AQ,Wider Public Sector,Private Sector Enabler,False
+10006775,Transplant Support Network,,Temple Row Centre,23 Temple Row,,Keighley,West Yorkshire                ,England                       ,BD21 2AH,Wider Public Sector,Private Sector Enabler,False
+10006764,Hull City Services,,Ringrose Street,Anlaby Road,,Hull,Yorkshire                     ,England                       ,HU3 5QA,Wider Public Sector,Private Sector Enabler,False
+10006762,Huddersfield Town Academy,,Leeds Road Playing Fields Complex,Leeds Road,,Huddersfield,West Yorkshire                ,England                       ,HD2 1YY,Wider Public Sector,,False
+10006757,Enterprise Centre,,1 Pontefract Road,,,Barnsley,Yorkshire                     ,England                       ,S71 1AJ,Wider Public Sector,Private Sector Enabler,False
+10006756,Domestic Supply Flight,,"RAF Leaming North Allerton North York""s",,,Northallerton,Yorkshire                     ,England                       ,DL7 9NJ,Wider Public Sector,Private Sector Enabler,False
+10006754,Barnsley Trust,,Keresforth Centre,,,Barnsley,Yorkshire                     ,England                       ,S70 6RS,Wider Public Sector,Private Sector Enabler,False
+10006749,Yorkshire Ladies Council Of Education,,Forest Hill,11 Park Crescent,,Leeds,West Yorkshire                ,England                       ,LS8 1DH,Wider Public Sector,Private Sector Enabler,False
+10006748,Radiology Integrated Training Initiative Project,,Dept Health and SW Peninsular HA,Diagnostic Services Dept Health,Rm 4N34 Quarry House,Leeds,West Yorkshire                ,England                       ,LS2 7UE,Wider Public Sector,Private Sector Enabler,False
+10006739,St Marys School - Clifford Road,,Clifford Road,Boston Spa,,Wetherby,West Yorkshire                ,England                       ,LS23 6DB,Wider Public Sector,Private Sector Enabler,False
+10006734,Yorkshire and Humberside Arts Board,,21 Bond Street,,,Dewsbury,West Yorkshire                ,England                       ,WF13 1AX,Wider Public Sector,Private Sector Enabler,False
+10006733,William Eyres and Sons,,Gay Lane,,,Otley,West Yorkshire                ,England                       ,LS21 1QQ,Wider Public Sector,Private Sector Enabler,False
+10006725,West Yorkshire County Scouts Bradley Wood,,Bradley Wood,Shepherds Thorn Lane,,Brighouse,West Yorkshire                ,England                       ,HD6 3TU,Wider Public Sector,Private Sector Enabler,False
+10006714,Touchstone - Leeds,,Touchstone House,2-4 Middleton Crescent,Beeston,Leeds,West Yorkshire                ,England                       ,LS11 6JU,Wider Public Sector,Private Sector Enabler,False
+10006712,Thomas Danby College,,5 Roundhay Road,Sheepscar,,Leeds,West Yorkshire                ,England                       ,LS7 3BG,Wider Public Sector,Colleges of Further Education,False
+10006710,Appeals Service The,,York House,York Place,,Leeds,West Yorkshire                ,England                       ,LS1 2ED,Wider Public Sector,Private Sector Enabler,False
+10006708,Support Works,,10 Legrams Terrace,Fieldhead Business Centre,,Bradford,West Yorkshire                ,England                       ,BD7 1LN,Wider Public Sector,Private Sector Enabler,False
+10006706,Spenborough Flower Fund Homes Ltd,,5 Layton Mount,Rawdon,,Leeds,West Yorkshire                ,England                       ,LS19 6PQ,Wider Public Sector,Private Sector Enabler,False
+10006701,Secta Group Ltd,,Triton House,Hare Park Lane,,Liversedge,West Yorkshire                ,England                       ,WF15 8HN,Wider Public Sector,Private Sector Enabler,False
+10006698,Royal Warrant Holders Association,,Sandal Business Centre,Asdale Road,,Wakefield,West Yorkshire                ,England                       ,WF2 7JE,Wider Public Sector,Private Sector Enabler,False
+10006696,Richard Dunn Sports Centre,,Rooley Avenue,Odsal,,Bradford,West Yorkshire                ,England                       ,BD6 1EZ,Wider Public Sector,Private Sector Enabler,False
+10006694,Pulborough Brooks Nature Reserve,,Wiggonholt,Uppertons Barn Visitors Centre,,Pulborough,West Yorkshire                ,England                       ,RH20 2EL,Wider Public Sector,Private Sector Enabler,False
+10006688,Park Lane College,,Horsforth Centre,Harehills Lane,,Leeds,West Yorkshire                ,England                       ,LS18 4RQ,Wider Public Sector,Colleges of Further Education,False
+10006687,Outward Bound Trust,,33 Station Road,Low Ackworth,,Pontefract,West Yorkshire                ,England                       ,WF7 7LU,Wider Public Sector,Private Sector Enabler,False
+10006684,Northern School of Contemporary Dance,,98 Chapeltown Road,,,Leeds,West Yorkshire                ,England                       ,LS7 4BH,Wider Public Sector,Private Sector Enabler,False
+10006665,Leeds College of Technology,,Cookridge Street,,,Leeds,West Yorkshire                ,England                       ,LS2 8BL,Wider Public Sector,Colleges of Further Education,False
+10006659,Kingswood Catering,,Room 207 Chantry House,123 Kirkgate,,Wakefield,West Yorkshire                ,England                       ,WF1 1YG,Wider Public Sector,Private Sector Enabler,False
+10006658,Keighley Leisure Centre,,Victoria Pk,Hardings Road,,Keighley,West Yorkshire                ,England                       ,BD21 3JN,Wider Public Sector,Private Sector Enabler,False
+10006655,Huddersfield Technical College,,New North Road,,,Huddersfield,West Yorkshire                ,England                       ,HD1 5NN,Wider Public Sector,Colleges of Further Education,False
+10006652,Housing Improvements (Halifax),,Fountain Chambers,Fountain Street,,Halifax,West Yorkshire                ,England                       ,HX1 1LR,Wider Public Sector,Private Sector Enabler,False
+10006642,Harrogate Trust,,19 Wetherby Road,,,Harrogate,West Yorkshire                ,England                       ,HA2 7SX,Wider Public Sector,Private Sector Enabler,False
+10006638,Government Office for Yorkshire and Humberside,,Lateral,8 City Walk,,Leeds,West Yorkshire                ,England                       ,LS11 9AT,Central Government,NDPB,False
+10006637,Gipton Supported Independent Living,,27-33 Brander Street,Gipton,,Leeds,West Yorkshire                ,England                       ,LS9 6QH,Wider Public Sector,Private Sector Enabler,False
+10006636,Donaldsons,,St Paul's House,23 Park Square South,,Leeds,West Yorkshire                ,England                       ,LS1 2ND,Wider Public Sector,Private Sector Enabler,False
+10006634,Victim Support Dewsbury and District,,Batley Police Station,Market Place,,Batley,West Yorkshire                ,England                       ,WF17 5DG,Wider Public Sector,Charity,False
+10006626,Carmel Sixth Form College,,New North Road,,,Huddersfield,West Yorkshire                ,England                       ,HD1 5NN,Wider Public Sector,Colleges of Higher Education,False
+10006612,Bradford Excellence Challenge,,Westgate Hill Street,,,Bradford,West Yorkshire                ,England                       ,BD4 6NR,Central Government,,False
+10006599,4th Battalion The Parachute Regiment,,Thornbury Barracks,,,Pudsey,West Yorkshire                ,England                       ,LS28 8HH,Central Government,,False
+10006598,Easthorpe Visual Arts,,Huddersfield Road,,,Mirfield,West Yorkshire                ,England                       ,WF14 8AT,Wider Public Sector,Private Sector Enabler,False
+10006589,Southwick Community Association,,24 Southwick Street,,,Southwick,West Sussex                   ,England                       ,BN42 4TZ,Wider Public Sector,Private Sector Enabler,False
+10006569,West Sussex Health and Social Care,,9 College Lane,,,Chichester,West Sussex                   ,England                       ,PO19 6FX,Wider Public Sector,Private Sector Enabler,False
+10006565,West Chiltington Community School,,East Street,West Chiltington,,Pulborough,West Sussex                   ,England                       ,RH20 2JY,Wider Public Sector,Private Sector Enabler,False
+10006564,Weald and Downland Open Air Museum,,Singleton,,,Nr Chichester,West Sussex                   ,England                       ,PO18 0EU,Wider Public Sector,Private Sector Enabler,False
+10006559,Pines The,,Faraday Close,Durrington,,Worthing,West Sussex                   ,England                       ,BN13 3RB,Wider Public Sector,Private Sector Enabler,False
+10006555,Sussexdown Nursing Home,,The RAF Association,Washington Road,,Storrington,West Sussex                   ,England                       ,RH20 4DA,Wider Public Sector,Private Sector Enabler,False
+10006548,Shoreham and District Mental Health Association,,The Old School House,Ham Road,,Shoreham by Sea,West Sussex                   ,England                       ,BN43 6PA,Wider Public Sector,Private Sector Enabler,False
+10006544,Rustington Convalescent Home,,Sea Rd,Rustington,,Littlehampton,West Sussex                   ,England                       ,BN16 2LZ,Wider Public Sector,Private Sector Enabler,False
+10006541,Royal Air Forces Association,,Washington Road,Storrington,,Pulborough,West Sussex                   ,England                       ,RH20 4DA,Wider Public Sector,Private Sector Enabler,False
+10006540,Rowfant House Ltd,,Rowfant House Wallage Lane,Rowfant,,Crawley,West Sussex                   ,England                       ,RH10 4NG,Wider Public Sector,Private Sector Enabler,False
+10006538,Raystede Centre For Animal Welfare,,27 Brighton Road,,,Crawley,West Sussex                   ,England                       ,RH10 6AE,Wider Public Sector,Private Sector Enabler,False
+10006536,Queen Alexandra Hospital Home,,Boundary Rd,,,Worthing,West Sussex                   ,England                       ,BN11 4LJ,Wider Public Sector,Private Sector Enabler,False
+10006535,Pulborough Medical Group,,Barnhouse Surgery,Barnhouse Close,,Pulborough,West Sussex                   ,England                       ,RH20 2HQ,Wider Public Sector,Private Sector Enabler,False
+10006534,Princess Marina House,,The Royal Air Force benevolent Fund,Seafield Road,,Rustington,West Sussex                   ,England                       ,BN16 2JG,Wider Public Sector,Private Sector Enabler,False
+10006533,Police Scientific Development Branch,,Langhurst House,Langhurstwood Road,,Horsham,West Sussex                   ,England                       ,RH12 4WX,Wider Public Sector,Private Sector Enabler,False
+10006531,Outreach Three Way,,Ifield Hall,Ifield Avenue,,Crawley,West Sussex                   ,England                       ,RH11 0JX,Wider Public Sector,Private Sector Enabler,False
+10006522,Lodgehill Residential Centre,,London Rd,Watersfield,,Pulborough,West Sussex                   ,England                       ,RH20 1LZ,Wider Public Sector,Private Sector Enabler,False
+10006521,Littlehampton Sportsfield Charitable Trust,,Littlehampton Sportsfield,St Floras Road,,Littlehampton,West Sussex                   ,England                       ,BN17 6RD,Wider Public Sector,Private Sector Enabler,False
+10006517,Lady Superior St  Georges Retreat,,Ditchling Common,,,Burgess Hill,West Sussex                   ,England                       ,RH15 0SQ,Wider Public Sector,Private Sector Enabler,False
+10006516,Kingdom Faith Church Trust,,Roffry Place,Old Crawley Road Faygate,,Horsham,West Sussex                   ,England                       ,RH12 4RU,Wider Public Sector,Private Sector Enabler,False
+10006512,Humanity at Heart,,22/24 Keymer Road,,,Hassocks,West Sussex                   ,England                       ,BN6 8AN,Wider Public Sector,Private Sector Enabler,False
+10006509,Holy Trinity Church,,TitmusDrive,,,Crawley,West Sussex                   ,England                       ,RH10 5EU,Wider Public Sector,Private Sector Enabler,False
+10006506,Heatherley Nursing Home,,Effingham lane,,,Copthorne,West Sussex                   ,England                       ,RH10 3HS,Wider Public Sector,Private Sector Enabler,False
+10006505,Heatherley Cheshire Home,,Effingham Lane,Copthorne,,Crawley,West Sussex                   ,England                       ,RH10 3HS,Wider Public Sector,Private Sector Enabler,False
+10006499,Guild Care,,North Street,,,Worthing,West Sussex                   ,England                       ,BN11 1DU,Wider Public Sector,Housing Associations,False
+10006497,Global CPG Ltd,,Metro House,Northgate,,Chichester,West Sussex                   ,England                       ,PO19 1BE,Wider Public Sector,Private Sector Enabler,False
+10006496,Gerald Daniel Sailing Club,,Youth Sailing Centre,Chidham,,Chichester,West Sussex                   ,England                       ,PO18 8TE,Wider Public Sector,Private Sector Enabler,False
+10006490,Downland Retirement Homes Ltd,,51 Fishbourne Road,,,Chichester,West Sussex                   ,England                       ,PO19 3HZ,Wider Public Sector,Private Sector Enabler,False
+10006487,Downland General,,1 Little London,,,Chichester,West Sussex                   ,England                       ,PO19 1PP,Wider Public Sector,Private Sector Enabler,False
+10006486,Dolphin Leisure Centre,,Pasture Hill Road,,,Haywards Heath,West Sussex                   ,England                       ,RH16 1LY,Wider Public Sector,Private Sector Enabler,False
+10006483,Crossways Trust,,19 Parkfield Road,,,Worthing,West Sussex                   ,England                       ,BN13 1EN,Wider Public Sector,Private Sector Enabler,False
+10006475,Christ For The Nations Uk,,Dodsley Lane,Eastburne,,Midhurst,West Sussex                   ,England                       ,GV29 0AD,Wider Public Sector,Private Sector Enabler,False
+10006455,Apuldram Centre,,Common Farm,Appledram Lane,,Chichester,West Sussex                   ,England                       ,PO20 7PE,Wider Public Sector,Private Sector Enabler,False
+10006452,Abbeyfield East Grinstead S Ltd,,Oakwood,Woodbury Close,,East Grinstead,West Sussex                   ,England                       ,RH19 3UA,Wider Public Sector,Private Sector Enabler,False
+10006443,Warwickshire P.C.C,,PO Box 4 Leek Wootton,Warwick,Warwickshire,Warwick,Warwickshire,England,CV35 7QB,Wider Public Sector,Police Service,False
+10006439,Shakespear Hospice The,,Church Lane,Shottery,,Stratford Upon Avon,Warwickshire                  ,England                       ,CV37 9UL,Wider Public Sector,Private Sector Enabler,False
+10006429,Rugby Parents Centre,,Benn Education Centre,Claremont Road,,Rugby,Warwickshire                  ,England                       ,CV21 3LU,Wider Public Sector,Private Sector Enabler,False
+10006428,Rugby Mayday Trust,,75 Albert Street,,,Rugby,Warwickshire                  ,England                       ,CV21 2SN,Wider Public Sector,Private Sector Enabler,False
+10006423,Royal Agricultural Society of England,,Stonleigh Park,,,Nr Coventry,Warwickshire                  ,England                       ,CV8 2LZ,Wider Public Sector,Private Sector Enabler,False
+10006418,Parkwood Holdings plc,,25 Greenhill Street,,,Stratford Upon Avon,Warwickshire                  ,England                       ,CV37 6LE,Wider Public Sector,Private Sector Enabler,False
+10006417,NWA,,Ashcroft Gable Close,Bilton,,Rugby,Warwickshire                  ,England                       ,CV22 7NS,Wider Public Sector,Private Sector Enabler,False
+10006411,New Homelands Ltd,,6 Lillington Avenue,,,Leamington Spa,Warwickshire                  ,England                       ,CV32 5UJ,Wider Public Sector,Private Sector Enabler,False
+10006395,Elm Bank Corporate Training Centre,,Mile Lane,,,Coventry,Warwickshire                  ,England                       ,CV1 2LQ,Wider Public Sector,Private Sector Enabler,False
+10006393,Coventry Sports Centre,,Sports & Parks DSO,Fairfax Street,,Coventry,Warwickshire                  ,England                       ,CV1 5RY,Wider Public Sector,Private Sector Enabler,False
+10006372,Worcestershire Health Information,,Princess of Wales Community Health Trust,Stourbridge Road,,Bromsgrove,Worcestershire                ,England                       ,B61 0BB,Wider Public Sector,Private Sector Enabler,False
+10006364,Welsh Assembly,,Civic Centre,Queen Elizabeth Drive,,Pershore,Worcestershire                ,England                       ,WR10 1PT,Wider Public Sector,Private Sector Enabler,False
+10006352,Redditch Benefit Agency,,St Stephens House,Prospect Hill,,Redditch,Worcestershire                ,England                       ,B97 4DP,Wider Public Sector,Private Sector Enabler,False
+10006351,RAF Summerfield,,Summerfield,Shenstone,,Kidderminster,Worcestershire                ,England                       ,DY10 4BL,Central Government,RAF,False
+10006333,Hereford and Worcester SOC,,West Mercia Constabulary,Hindlip Hall,,Droitwich,Worcestershire                ,England                       ,WR9,Wider Public Sector,Private Sector Enabler,False
+10006321,Bromsgrove Schools,,Worcester Road,,,Bromsgrove,Worcestershire                ,England                       ,B61 7DU,Wider Public Sector,Private Sector Enabler,False
+10006300,West Midlands Co-operative Society,,PO Box 8,10 Hatherton Road,,Walsall,West Midlands                 ,England                       ,WS1 1JH,Wider Public Sector,Private Sector Enabler,False
+10006285,University of Central England,,"4th Floor, Feeney Building",Franchise Street,Perry Barr,Birmingham,West Midlands                 ,England                       ,B42 2SU,Wider Public Sector,Universities,False
+10006282,University Hospital Birmingham NHS Trust,,"Trust HQ, PO Box 9551",Queen Elizabeth Medical Centre,Edgbaston,Birmingham,West Midlands                 ,England                       ,B15 2TH,Wider Public Sector,Acute Trust,False
+10006281,United Churches,,318 Hamstead Road,Handsworth,,Birmingham,West Midlands                 ,England                       ,B20 2RA,Wider Public Sector,Private Sector Enabler,False
+10006275,Towers DG,,Cape Hill Medical Centre,Raglan Road,,Smethwick,West Midlands                 ,England                       ,B66 3NR,Wider Public Sector,Private Sector Enabler,False
+10006273,Swimming Teachers Organisation The,,Anchor House,Birch Street,,Walsall,West Midlands                 ,England                       ,WS2 8HZ,Wider Public Sector,Private Sector Enabler,False
+10006269,Tenby Consultancy Group,,Aston Science Park,Love Lane,,Birmingham,West Midlands                 ,England                       ,B7 4BJ,Wider Public Sector,Private Sector Enabler,False
+10006259,Springfields Co-Operative Ltd,,44/45 Queens Road,,,Coventry,West Midlands                 ,England                       ,CV1 3EH,Wider Public Sector,Private Sector Enabler,False
+10006256,NHS South Birmingham,,Trust HQ,Moseley Hall Hospital,Alcester Road,Birmingham,West Midlands                 ,England                       ,B13 8JL,Wider Public Sector,PCT - Commissioning,False
+10006250,Solihull Ice Rink,,103 Hobs Moat Road,,,Solihull,West Midlands                 ,England                       ,B92 8JN,Wider Public Sector,Private Sector Enabler,False
+10006249,Solihull Frail Ambulant,,1612 High Street,Knowle,,Solihull,West Midlands                 ,England                       ,B93 0JU,Wider Public Sector,Private Sector Enabler,False
+10006240,Sandwell and West Birmingham Hospitals,,Sandwell Hospital,Moor Lane,,Rowley Regis,West Midlands                 ,England                       ,B65 8DA,Wider Public Sector,Private Sector Enabler,False
+10006239,Sandwell Evening Mail,,Shaftesbury House,402 High Street,,West Bromwich,West Midlands                 ,England                       ,B70 9NH,Wider Public Sector,Private Sector Enabler,False
+10006230,Rowley Regis and Tipton PCG,,Kingston House,438 High Street,,West Bromwich,West Midlands                 ,England                       ,B70 9LD,Wider Public Sector,Private Sector Enabler,False
+10006226,Penns Education Trust,,91 - 97 Mount Street,Nechells,,Birmingham,West Midlands                 ,England                       ,B7 5RT,Wider Public Sector,Private Sector Enabler,False
+10006225,Paddock H Co-Op Ltd,,67 Walhouse Road,,,Walsall,West Midlands                 ,England                       ,WS1 2BL,Wider Public Sector,Private Sector Enabler,False
+10006223,Old Swinford Hospital School,,Heath Lane,,,Stourbridge,West Midlands                 ,England                       ,DY8 1QX,Wider Public Sector,Private Sector Enabler,False
+10006215,Midlands Eventide Home Trust,,67 Valentine Road,Kings Heath,,Birmingham,West Midlands                 ,England                       ,B14 7AJ,Wider Public Sector,Private Sector Enabler,False
+10006213,Midland DBC,,Five Way House,Islington Row Middleway,,Birmingham,West Midlands                 ,England                       ,B15 1SL,Wider Public Sector,Private Sector Enabler,False
+10006208,Lench's Trust,,118 Conybere Street,,,Birmingham,West Midlands                 ,England                       ,B12 0YJ,Wider Public Sector,Private Sector Enabler,False
+10006207,Langley Swimming Centre,,Vicarage Rd,Oldbury,,Warley,West Midlands                 ,England                       ,B68 8HS,Wider Public Sector,Private Sector Enabler,False
+10006203,Josiah Mason Sixth Form College,,Slade Road,Erdington,,Birmingham,West Midlands                 ,England                       ,B23 7JH,Wider Public Sector,Colleges of Higher Education,False
+10006201,International Convention Centre,,Broad St,,,Birmingham,West Midlands                 ,England                       ,B1 2EA,Wider Public Sector,Private Sector Enabler,False
+10006186,Government Office for the West Midlands,,5 St. Philips Place,,,Birmingham,West Midlands                 ,England                       ,B3 2PW,Central Government,NDPB,False
+10006185,Good Hope Hospital NHS Trust,,1st Floor Block 15,Rectory Road,,Sutton Coldfield,West Midlands                 ,England                       ,B75 7RR,Wider Public Sector,Acute Trust,False
+10006184,Fuel Savers/Birmingham Settlement,,Aston Council House,Albert Road Aston,,Birmingham,West Midlands                 ,England                       ,B6 5NQ,Wider Public Sector,Private Sector Enabler,False
+10006173,Dudley Partnership for Achievement,,Education Action Zone,Saltwells EDC,Bowling Green Road Netherton,Dudley ,West Midlands                 ,England                       ,DY2 9LY,Wider Public Sector,Private Sector Enabler,False
+10006158,Condor Sales,,24 Ermington Crescent,,,Birmingham,West Midlands                 ,England                       ,B36 8AP,Wider Public Sector,Private Sector Enabler,False
+10006157,Civil Service Sports Club,,Main Office,,,Solihull,West Midlands                 ,England                       ,B91,Wider Public Sector,Private Sector Enabler,False
+10006156,City of Birmingham,,Finance Department,Revenues,1 Lancaster Circus,Birmingham,West Midlands                 ,England                       ,B4 7AB,Wider Public Sector,Private Sector Enabler,False
+10006155,Chadd,,98-99 Dixons Green Road,,,Dudley,West Midlands                 ,England                       ,DY2 7DJ,Wider Public Sector,Private Sector Enabler,False
+10006152,BSMHT,,Ardenleigh,Kingsbury Road,Erdington,Birmingham,West Midlands                 ,England                       ,B24 9SA,Wider Public Sector,Private Sector Enabler,False
+10006143,Birmingham Vehicle Testing Station (VI),,Garrett Green Industrial Estate,,,Birmingham,West Midlands                 ,England                       ,B33 0SS,Wider Public Sector,Private Sector Enabler,False
+10006141,Birmingham Co-Op Hsg Services,,The Bond Company,"180-182 Fazeley Street,Digbeth",,Birmingham,West Midlands                 ,England                       ,B5 5SE,Wider Public Sector,Private Sector Enabler,False
+10006138,Birmingham Building Service,,38 Borrowdale Road,,,Birmingham,West Midlands                 ,England                       ,B31 5QR,Wider Public Sector,Private Sector Enabler,False
+10006137,Bethany Guild Homes,,3 Nuthurst Grove,Bentley Heath,,Solihull,West Midlands                 ,England                       ,B93 8PD,Wider Public Sector,Housing Associations,False
+10006134,British Educational Communications and Technology Agency,BECTA,Millburn Hill Road,Science Park,,Coventry,West Midlands                 ,England                       ,CV4 7JJ,Central Government,NDPB,False
+10006131,Bafpa,,86 Prestbury Road,,,Birmingham,West Midlands                 ,England                       ,B6 6EE,Wider Public Sector,Private Sector Enabler,False
+10006117,Recruiting and Liasion Staff Scotland,,Scotland Army HQ,Craigiehall,,South Queensferry,West Lothian                  ,Scotland                      ,EH30 9TN,Central Government,Army,False
+10006113,HQ 2nd DIV,,Annandale Block,Craigiehall,,South Queensferry,West Lothian                  ,Scotland                      ,EH30 9TN,Central Government,,False
+10006110,Royal Artillery Range,,Hebrides,,,Isle Of Benbecula,Western Isles                 ,Scotland                      ,HS7 5LA,Wider Public Sector,Private Sector Enabler,False
+10006109,QinetiQ,,Balivanich,A1 Building,Ively Road,Isle Of Benbecula,Western Isles                 ,Scotland                      ,HS7 5LA,Wider Public Sector,Private Sector Enabler,False
+10006104,BADCOCK K,,Gable House Surgery,46 High Street,,Malmesbury,Wiltshire                     ,England                       ,SN16 9AT,Wider Public Sector,Private Sector Enabler,False
+10006095,Wiltshire Emergency Services,,Police Headquarters,London Road,,Devizes,Wiltshire                     ,England                       ,SN10  2DN,Wider Public Sector,Private Sector Enabler,False
+10006094,Wiltshire County Council,,County Hall,Bythesea Road,,Trowbridge,Wiltshire                     ,England                       ,BA14 8JJ,Wider Public Sector,Region:South West,False
+10006088,West Wiltshire District Council,,Council Offices,Bradley Road,,Trowbridge,Wiltshire                     ,England                       ,BA14 0RD,Wider Public Sector,District Council,False
+10006087,Water Research Centre,,Blagrove,Frankland Road,,Swindon,Wiltshire                     ,England                       ,SN1,Wider Public Sector,Private Sector Enabler,False
+10006086,Warminster Training Centre,,Building 97,Imber Road,,Warminster,Wiltshire                     ,England                       ,BA12 CDJ,Wider Public Sector,Private Sector Enabler,False
+10006085,Warminster and Cotswold Detachment Royal Logistics Corps,,LPO QM(T),Warminster Training Centre,,Warminster,Wiltshire                     ,England                       ,BA12 0DJ,Wider Public Sector,Private Sector Enabler,False
+10006076,Consortium The,,Hammond Way,,,Trowbridge,Wiltshire                     ,England                       ,BA14 8RR,Wider Public Sector,Private Sector Enabler,False
+10006074,Taw Hill Medical Practice,,Queen Elizabeth Drive,,,Swindon,Wiltshire                     ,England                       ,SN25 1WL,Wider Public Sector,Private Sector Enabler,False
+10006073,Swindon Womens Refuge,,119-129 Cranmore Avenue,,,Swindon,Wiltshire                     ,England                       ,SN3 2EW,Wider Public Sector,Private Sector Enabler,False
+10006060,South Wiltshire Grammar School For Girls,,Stratford Road,,,Salisbury,Wiltshire                     ,England                       ,SP1 3JJ,Wider Public Sector,Private Sector Enabler,False
+10006057,Shaw Trust,,Shaw House Epsom Sq,White Horse Business Park,,Trowbridge,Wiltshire                     ,England                       ,BA14 0XJ,Wider Public Sector,Private Sector Enabler,False
+10006056,Services Cotswold Centre,,Lypiatt,Neston,,Corsham,Wiltshire                     ,England                       ,SN13 9TU,Wider Public Sector,Private Sector Enabler,False
+10006055,Schal Project Management,,5 Milston View,Durrington,,Near Salsbury,Wiltshire                     ,England                       ,SP4 8HN,Wider Public Sector,Private Sector Enabler,False
+10006053,Salisbury Plain Training Area,,Westdown Camp,Tilshead,,Nr Salisbury,Wiltshire                     ,England                       ,SP3 4RS,Wider Public Sector,Private Sector Enabler,False
+10006051,Salisbury District Council,,Council House,Bourne Hill,,Salisbury,Wiltshire                     ,England                       ,SP1 3UZ,Wider Public Sector,District Council,False
+10006049,Salisbury and District Citizens Advice Bureau,,18 College Street,,,Salisbury,Wiltshire                     ,England                       ,SP1 3AL,Wider Public Sector,Charity,False
+10006047,Royal School Of Artillery,,Stirling Barracks,Larkhill,,Salisbury,Wiltshire                     ,England                       ,SP4 8QT,Central Government,Private Sector Enabler,False
+10006046,Royal Military College Of Science,,Building 15,Shrivenham,,Swindon,Wiltshire                     ,England                       ,SN6 8LA,Central Government,,False
+10006043,Rowden Medical Partnership,,Rowden Surgery,Rowden Hill,,Chippenham,Wiltshire                     ,England                       ,SN15 2SB,Wider Public Sector,Private Sector Enabler,False
+10006042,Research Council Procurement Organisation,,"C/o Natural Environment Rc, Room DP1046A Polaris House North Star Avenue",Swindon,Wiltshire,Swindon,Wiltshire,England,SN2 1EU,Central Government,NDPB,False
+10006041,Regular Commisions Board,,Leighton House,Warminster Road,,Westbury,Wiltshire                     ,England                       ,BA13 3PX,Wider Public Sector,Private Sector Enabler,False
+10006040,Ramsden,,Building 30 9 Supply Regiment,Hulavington Barracks,,Chippenham,Wiltshire                     ,England                       ,SM14 6BT,Wider Public Sector,Private Sector Enabler,False
+10006039,RAF Rudloe Manor,,Main Office,,,Hawthorne,Wiltshire                     ,England                       ,SN13 0PQ,Central Government,RAF,False
+10006036,Quartermasters Department,,Battlesbury Barracks,2 Royal Anglian,,Warminster,Wiltshire                     ,England                       ,BA12 9DT,Wider Public Sector,Private Sector Enabler,False
+10006030,Oasis Leisure Centre,,North Star Avenue,,,Swindon,Wiltshire                     ,England                       ,SN2 1EP,Wider Public Sector,Private Sector Enabler,False
+10006029,NSC Training Organisation,,Spur 12 Block E,Ensleigh,,Bath,Wiltshire                     ,England                       ,BA1 5AB,Wider Public Sector,Private Sector Enabler,False
+10006028,Nsc Copenacre,,Room 222,Hawthorne,,Corsham,Wiltshire                     ,England                       ,SN13 0PW,Wider Public Sector,Private Sector Enabler,False
+10006026,North Wiltshire District Council,,Housing & Property Services,Bank House,Bath Road,Chippenham,Wiltshire                     ,England                       ,SN15 2SU,Wider Public Sector,District Council,False
+10006023,NAAFI,,London Road,Amesbury,,Salisbury,Wiltshire                     ,England                       ,SP4 7EN,Wider Public Sector,Private Sector Enabler,False
+10006020,MOD Defence Housing Executive,,25 St Wilfrids Road,Strensall Camp,,York,Wiltshire                     ,England                       ,YO3 5SJ,Central Government,,False
+10006016,MOD Army,,19 Tank Transporter Sqn R,Ward Barracks Bulford Camp,Bessbrook,Salisbury,Wiltshire                     ,England                       ,SP4 9LT,Central Government,,False
+10006013,Milford Manor Residential Care Home,,Milford Manor Gardens,,,Salisbury,Wiltshire                     ,England                       ,SP1 2RN,Wider Public Sector,Private Sector Enabler,False
+10006007,Logistic Support Services,,Cowan Camp,Watchfield,,Swindon,Wiltshire                     ,England                       ,SN6 8LA,Central Government,,False
+10006001,Kennet District Council,,Browfort,Bath Road,Bath Road,Devizes,Wiltshire                     ,England                       ,SN10 2AT,Wider Public Sector,District Council,False
+10006000,Joint Service Parachute Centre,,Airfield Camp,Netheravon,,Salisbury,Wiltshire                     ,England                       ,SP4 9SF,Central Government,Army,False
+10005984,Headlands School,,Headlands Grove,,,Swindon,Wiltshire                     ,England                       ,SN2 7HS,Wider Public Sector,School Other,False
+10005982,Halcrow Transportation Infrastructure,,Burderop Park,,,Swindon,Wiltshire                     ,England                       ,SN4 0QD,Wider Public Sector,Private Sector Enabler,False
+10005981,Halcrow Group Ltd,,Burderop Park,,,Swindon,Wiltshire                     ,England                       ,SN4 0QD,Wider Public Sector,Private Sector Enabler,False
+10005974,Freelance,,New Barn,Ansty,,Salisbury,Wiltshire                     ,England                       ,SP3 5PX,Wider Public Sector,Private Sector Enabler,False
+10005973,Fairfield Opportunity Farm,,High Street,Dilton Marsh,,Westbury,Wiltshire                     ,England                       ,BA13 4DL,Wider Public Sector,Private Sector Enabler,False
+10005971,EPSRC,,Polaris House,North Star Avenue,,Swindon,Wiltshire                     ,England                       ,SN2 1ET,Wider Public Sector,Private Sector Enabler,False
+10005970,Environmental Services Dept,,County Hall,,,Trowbridge,Wiltshire                     ,England                       ,BA14,Wider Public Sector,Private Sector Enabler,False
+10005969,Environment Research Centre,,1st Floor Polaris House,North Star Avenue,,Swindon,Wiltshire                     ,England                       ,SN2 1EU,Wider Public Sector,Private Sector Enabler,False
+10005967,Eng and Physical Sciences Research Council,,Polaris House,North Star Avenue,,Swindon,Wiltshire                     ,England                       ,SN2 1ET,Wider Public Sector,Private Sector Enabler,False
+10005962,DSTC,,St Thomas' Hospital,Shaw Heath,Fort Halstead,Stockport,Wiltshire                     ,England                       ,SK3 8BL,Wider Public Sector,Private Sector Enabler,False
+10005961,DSCA,,Basil Hill Barracks,Park Lane,Park Lane,Corsham,Wiltshire                     ,England                       ,SN13 9NR,Wider Public Sector,Private Sector Enabler,False
+10005957,Directorate Of Naval Recruiting,,Wroughton Airfield,,,Swindon,Wiltshire                     ,England                       ,SN4 0ST,Wider Public Sector,Private Sector Enabler,False
+10005953,Defence Logistics Organisation,,Alpine Gardens,Fosseway  Ensleigh,RAF Brampton,Bath,Wiltshire                     ,England                       ,BA1 5PB,Central Government,Executive Agency,False
+10005942,Cherry Orchard Surgery,,Codford,St.Mary,,Warminster,Wiltshire                     ,England                       ,BA12 0PW,Wider Public Sector,Private Sector Enabler,False
+10005941,Centre for Applied Microbiology and Research,,Porton Down,,,Salisbury,Wiltshire                     ,England                       ,SP4 0JG,Wider Public Sector,Private Sector Enabler,False
+10005940,CATC HQ,,Main Office,,,Warminster,Wiltshire                     ,England                       ,BA12 0DJ,Wider Public Sector,Private Sector Enabler,False
+10005939,Care Rowde,,Furlong Close,Rowde,,Devizes,Wiltshire                     ,England                       ,SN10 2TQ,Wider Public Sector,Private Sector Enabler,False
+10005938,Calne Vehicle Testing Station,,Porte Marsh Road,,,Calne,Wiltshire                     ,England                       ,SN11 9BW,Wider Public Sector,Private Sector Enabler,False
+10005936,AWSM,,Westdown Camp (Building 101),Tilshead,,Nr Salisbury,Wiltshire                     ,England                       ,SP3 4RS,Wider Public Sector,Private Sector Enabler,False
+10005931,Amport House,,Amport,,,Near Andover,Wiltshire                     ,England                       ,SP11 8BG,Wider Public Sector,Private Sector Enabler,False
+10005923,Dewi Sant Housing Association,,Dewi Sant House,Harvey Crescent,Aberavon,Port Talbot,West Glamorgan                ,Wales                         ,SA12 6DE,Wider Public Sector,Not for Profit,False
+10005921,West Glamorgan Probation Service,,Pearl Assurance House,119 London Road,,Neagh,West Glamorgan                ,Wales                         ,SA11 1HL,Wider Public Sector,Private Sector Enabler,False
+10005896,Llantwit Major Youth Centre,,Station Road,,,Llantwit Major,Vale of Glamorgan             ,Wales                         ,CF61 1ST,Wider Public Sector,Private Sector Enabler,False
+10005894,Jane Hodge Resort Hotel,,Trerhyngll,,,Cowbridge,Vale of Glamorgan             ,Wales                         ,CF71 7TN,Wider Public Sector,Private Sector Enabler,False
+10005892,Defence Aviation Repair Agency,,1st Floor,B13,DARA Sealand,Deeside,Vale of Glamorgan             ,Wales                         ,CH5 2LS,Central Government,Executive Agency,False
+10005887,Weston Health and Social Services Board,,Tyrone & Farmagh Hospital,,,Tyrone Omagh,County Tyrone                 ,Northern Ireland              ,BT79 0NS,Wider Public Sector,Private Sector Enabler,False
+10005885,Ulster American Folk Park,,Castletown,,,Omagh,County Tyrone                 ,Northern Ireland              ,BT78 5QY,Wider Public Sector,Private Sector Enabler,False
+10005882,Sperrin Lakeland Health and Social Care NHS Trust,,Hotel services Department,Tyrone and Fermanagh Hospital,1 Donaghnie Road,Omagh,County Tyrone                 ,Northern Ireland              ,BT79 0NS,Wider Public Sector,Health,False
+10005880,Omagh District Council,,Council Offices,The Grange,Mountjoy Road,Omagh,County Tyrone                 ,Northern Ireland              ,BT79 7BL,Wider Public Sector,Local Government,False
+10005877,Dungannon and South Tyrone Borough Council,,Council Offices Circular Road,Dungannon,County Tyrone,Dungannon,County Tyrone,Northern Ireland,BT71 6DT,Wider Public Sector,Local Government,False
+10005873,Bensham Community Economic Development,,103 Bewick Road,,,Gateshead,Tyne and Wear                 ,England                       ,NE8 1TY,Wider Public Sector,Private Sector Enabler,False
+10005871,Elpinay School,,Chervaux Terrace,,,Jarrow,Tyne and Wear                 ,England                       ,NE32 5UP,Wider Public Sector,School Other,False
+10005862,YWCA Trustees Ltd,,Jesmond House,Clayton Road,,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE2 1UJ,Wider Public Sector,Private Sector Enabler,False
+10005858,Wessington Way Dental Practice,,Hylton Park Road,,,Sunderland,Tyne and Wear                 ,England                       ,SR5 3XQ,Wider Public Sector,Private Sector Enabler,False
+10005851,Tyne and Wear Emergency Planning Unit,,Floor 3 Pennine House,District 1,,Washington,Tyne and Wear                 ,England                       ,NE37 1LY,Wider Public Sector,Private Sector Enabler,False
+10005849,Council of Borough of South Tyneside The,,Town Hall,Civic Offices,Westoe Road,South Shields,Tyne and Wear                 ,England                       ,NE33 2RL,Wider Public Sector,Private Sector Enabler,False
+10005839,St Clare's Hopice,,Primrose Ter,,,Jarrow,Tyne and Wear                 ,England                       ,NE32 5HA,Wider Public Sector,Private Sector Enabler,False
+10005837,Square Building Trust Ltd,,19 Patterdale Gardens,,,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE7 7QX,Wider Public Sector,Private Sector Enabler,False
+10005828,Royal Victoria Infirmary,,Estates Stores,Queen Victoria Road,Queen Victoria Road,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE1 4LP,Wider Public Sector,Private Sector Enabler,False
+10005826,Resource North East,,81 Coatsworth Road,,,Gateshead,Tyne and Wear                 ,England                       ,NE8 1QL,Wider Public Sector,Private Sector Enabler,False
+10005825,Red House Farm H Co-Op Ltd,,39 Gleneagles Court,Red House Farm,,Whitley Bay,Tyne and Wear                 ,England                       ,NE25 9NA,Wider Public Sector,Private Sector Enabler,False
+10005822,Old Vicarage,,Nursing Home,East Rainton,,Houghton-Le-Spring,Tyne and Wear                 ,England                       ,DH5 9QT,Wider Public Sector,Private Sector Enabler,False
+10005813,Norcare,,Third Floor,Portman House Portland Road,Shieldfield,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE2 1AQ,Wider Public Sector,Private Sector Enabler,False
+10005804,New Prospects Association Ltd,,33a Front Street,Monkseaton,,Whitley Bay,Tyne and Wear                 ,England                       ,NE25 8AQ,Wider Public Sector,Private Sector Enabler,False
+10005799,Little Sisters Of The Poor St Joseph's,,Westmorland Road,,,Newcastle-Upon-Tyne,Tyne and Wear                 ,England                       ,NE4 7QA,Wider Public Sector,Private Sector Enabler,False
+10005797,Jewish Teacher Training Centre,,50 BewickRoad,,,Gateshead,Tyne and Wear                 ,England                       ,NE8 4HB,Wider Public Sector,Private Sector Enabler,False
+10005796,Jewish Communinty Council of Gateshead,,81 Bewick Road,,,Gateshead,Tyne and Wear                 ,England                       ,NE8 1RR,Wider Public Sector,Private Sector Enabler,False
+10005793,Institute for Ageing and Health,,Wolfson Research Centre,Newcastle General Hospital,Westgate Road,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE4 6BE,Wider Public Sector,Private Sector Enabler,False
+10005792,Impact,,51 Nile Street,,,North Shields,Tyne and Wear                 ,England                       ,NE29 0BG,Wider Public Sector,Private Sector Enabler,False
+10005786,Government Office for the North East,,6th Floor,Wellbar House,Gallowgate,Newcastle,Tyne and Wear                 ,England                       ,NE1 4TD,Central Government,NDPB,False
+10005781,Gateshead Jewish Academy For Girls,,3 Oxford Terrace,,,Gateshead,Tyne and Wear                 ,England                       ,NE8 1RQ,Wider Public Sector,Private Sector Enabler,False
+10005771,District Probate Registry,,2nd Floor Plummer House,Croft St,,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE1 6NP,Wider Public Sector,Private Sector Enabler,False
+10005767,Cityworks,,2-10 Archbold Terrace,,,Newcastle-Upon-Tyne,Tyne and Wear                 ,England                       ,NE2 1BZ,Wider Public Sector,Private Sector Enabler,False
+10005762,Child Benefit Centre (Washington),,W6019,,,Newcastle Upon Tyne,Tyne and Wear                 ,England                       ,NE88 1AA,Wider Public Sector,Private Sector Enabler,False
+10005759,Central Library,,Borough Road,,,Sunderland,Tyne and Wear                 ,England                       ,SR1 1PP,Wider Public Sector,Private Sector Enabler,False
+10005750,Albemarle Barracks,,Harlow Hill,,,Newcastle-Upon-Tyne,Tyne and Wear                 ,England                       ,NE15 ORH,Central Government,Army,False
+10005742,Central Supplies Organisation,,The Polo Grounds,,,Pontypool,Torfaen                       ,Wales                         ,NP4 0YA,Wider Public Sector,Private Sector Enabler,False
+10005727,Winged Fellowship Trust,,Netley Waterside House,Abbey Hill,,Netley,South Yorkshire               ,England                       ,SO31 5FA,Wider Public Sector,Private Sector Enabler,False
+10005726,Thorne House Services For Autisim,,Fieldside Court,3 Field Road Thorne,,Doncaster,South Yorkshire               ,England                       ,DN8 4AG,Wider Public Sector,Private Sector Enabler,False
+10005713,Sheffield City Trust,,St Peters House,12 Hartshead,,Sheffield,South Yorkshire               ,England                       ,S1 2EL,Wider Public Sector,Private Sector Enabler,False
+10005710,Sandhill Second Co-Operative,,28 Coronation Road,Rawmarsh,,Rotherham,South Yorkshire               ,England                       ,S62 5LL,Wider Public Sector,Private Sector Enabler,False
+10005707,Rotherham Priority Health Mental Health,,Rotheram General Hospital,Moorgate Road,,Rotherham,South Yorkshire               ,England                       ,S60 2UD,Wider Public Sector,Private Sector Enabler,False
+10005701,Rother Valley College,,Doe Quarry Lane,Dinnington,,Sheffield,South Yorkshire               ,England                       ,S25 2NF,Wider Public Sector,Colleges of Further Education,False
+10005689,Hesley Group,,The Coach House,"Hesley Hall,Tickhill",,Doncaster,South Yorkshire               ,England                       ,DN11 9HH,Wider Public Sector,Private Sector Enabler,False
+10005674,Rotherham Doncaster and South Humber Mental Health NHS Foundation Trust,,Purchasing Dept Walnut Lodge,St. Catherine's Hospital Tickhill Road,Balby,Doncaster,South Yorkshire               ,England                       ,DN4 8QN,Wider Public Sector,Mental Health Trust,False
+10005652,Sector Skills Development Agency,,3 Callflex Business Park,Golden Smithies Lane,,Wath-upon-Dearne,South Yorkshire               ,England                       ,S53 7ER,Central Government,NDPB,False
+10005649,Jameah Islameah,,6 Westheath Ave,Evington,,Leicester,Sussex                        ,England                       ,LE5 6SR,Wider Public Sector,Private Sector Enabler,False
+10005637,Disability Advice  Information for Runnymede  Spel,,12-13 The Sainsbury Centre,,,Chertsey,Surrey                        ,England                       ,KT16 9AG,Wider Public Sector,Private Sector Enabler,False
+10005634,RADAR Promotions,,7th Floor,Sunley House,4 Bedford Park,Croydon ,Surrey                        ,England                       ,CR0 2AP,Wider Public Sector,Private Sector Enabler,False
+10005633,Band of Royal Logistics Corps The,,Princess Royal Barracks,Deepcut,,Old Coulsdon,Surrey                        ,England                       ,GU16 6RW,Wider Public Sector,Private Sector Enabler,False
+10005628,XKO Group Plc,,Systems House 2nd Floor Foundary Court,Gogmore Lane,,Chertsey,Surrey                        ,England                       ,KT9 2DL,Wider Public Sector,Private Sector Enabler,False
+10005623,Woodmansterne Baptist Church,,Pine Walk,Woodmansterne,,Woodmansterne,Surrey                        ,England                       ,SM7 3QA,Wider Public Sector,Private Sector Enabler,False
+10005611,Weyvalley House,,Mike Hawthorne Drive,Farnham,,Farnham,Surrey                        ,England                       ,GU9 7UQ,Wider Public Sector,Private Sector Enabler,False
+10005604,Walton Weybridge and Hersham Citizens Advice Bureau,,Elmgrove,Hersham Road,,Walton on Thames,Surrey                        ,England                       ,KT12 1LH,Wider Public Sector,Private Sector Enabler,False
+10005603,Walton Charity,,Mayfield,74 Hersham Road,,Walton-On-Thames,Surrey                        ,England                       ,KT12 5NU,Wider Public Sector,Private Sector Enabler,False
+10005600,Transmedical Ambulance Service,,21 Oakenshaw Close,,,Surbiton,Surrey                        ,England                       ,KT6 6EA,Wider Public Sector,Private Sector Enabler,False
+10005592,Royal Star and Garter Home The,,Richmond Hill,Richmond Hill,,Richmond,Surrey                        ,England                       ,TW10 6RR,Wider Public Sector,Private Sector Enabler,False
+10005585,Guild of Freeman of City of London The,,PO Box 1202,,,Kingston upon Thames,Surrey                        ,England                       ,KT2 7XB,Wider Public Sector,Private Sector Enabler,False
+10005584,Grange Centre The,,Rectory Lane,,,Bookham,Surrey                        ,England                       ,KT23 4DZ,Wider Public Sector,Private Sector Enabler,False
+10005583,Childrens Trust The,,Tadworth Court,,,Tadworth,Surrey                        ,England                       ,KT20 5RU,Wider Public Sector,Private Sector Enabler,False
+10005578,Telephone Preference Service,,Lansdowne Building,Lansdowne Road,Heburn,Croydon,Surrey                        ,England                       ,CR0 2BX,Wider Public Sector,Private Sector Enabler,False
+10005576,Tanbridge Leisure Pool,,Hoskins Road,,,Osted,Surrey                        ,England                       ,RH8 9HT,Wider Public Sector,Private Sector Enabler,False
+10005573,Surrey Private Hospitals,,Mount Alvernia Hospital,46 Harvey Road,,Guildford,Surrey                        ,England                       ,GU1 3LX,Wider Public Sector,Private Sector Enabler,False
+10005569,Surrey Libraries and Leisure Service,,The Drill Hall,West Street,,Dorking,Surrey                        ,England                       ,RH4 1DD,Wider Public Sector,Private Sector Enabler,False
+10005561,Surrey Ambulance Service Commercial Services,,Grosvenor House,London Square,Cross Lanes,Guildford,Surrey                        ,England                       ,GU1 1FA,Wider Public Sector,Private Sector Enabler,False
+10005556,St Piers Lingfield,,St. Piers Lane,,,Lingfield,Surrey                        ,England                       ,RH7 6PW,Wider Public Sector,Private Sector Enabler,False
+10005551,St Georges Retreat,,Burgess Hill,Ditchling Common,,Guildford,Surrey                        ,England                       ,RH15 0SQ,Wider Public Sector,Private Sector Enabler,False
+10005548,St Anne's Roman Catholic Church,,10 Highfield Road,,,Chertsey,Surrey                        ,England                       ,KT16 9AP,Wider Public Sector,Private Sector Enabler,False
+10005545,Sons Of Divine Providence,,Head Office,13 Lower Teddington Road,Hampton Wick,Kingston-Upon-Thames,Surrey                        ,England                       ,KT1 4HB,Wider Public Sector,Private Sector Enabler,False
+10005544,Solus Homes Ltd,,51 Sheen Road,,,Richmond,Surrey                        ,England                       ,TW9 1YQ,Wider Public Sector,Private Sector Enabler,False
+10005541,Serco Investments Ltd,,Thrid Floor,Palm Court,4 Heron Sqaure,Richmond-upon-Thames,Surrey                        ,England                       ,TW9 1EW,Wider Public Sector,Private Sector Enabler,False
+10005540,Securicor Custodial Services,,Copsthall House  1-9 The Pav,Grove Road,,Sutton,Surrey                        ,England                       ,SM1 1DA,Wider Public Sector,Private Sector Enabler,False
+10005536,Royal School For The Blind,,56-66 Highlands Road,Wavertree,,Leatherhead,Surrey                        ,England                       ,KT22 8NR,Wider Public Sector,Private Sector Enabler,False
+10005534,Royal Military Academy,,ACCN ACCTS SQM RMAS,Sandhurst,,Camberley,Surrey                        ,England                       ,GU15 4PQ,Wider Public Sector,Private Sector Enabler,False
+10005529,Royal Association for Disability and Rehabilitation,,Promotions 7th Floor,Sunley House,4 Bedford Park,Croydon ,Surrey                        ,England                       ,CR0 2AP,Wider Public Sector,Private Sector Enabler,False
+10005528,Royal Alfred Seafarers' Society,,Weston Acres,Woodmansterne Lane,,Banstead,Surrey                        ,England                       ,SM7 3HB,Wider Public Sector,Private Sector Enabler,False
+10005518,Rarde (Chertsey),,Chobham Lane,Longcross,,Chertsey,Surrey                        ,England                       ,KT16 0EE,Wider Public Sector,Private Sector Enabler,False
+10005516,Queens Hospital,,Queens Road,,,Croydon,Surrey                        ,England                       ,CR9 2PR,Wider Public Sector,Education,False
+10005513,Pyrford Centre,,Englief Lane,Pyrford,,Woking,Surrey                        ,England                       ,GU22 8SU,Wider Public Sector,Private Sector Enabler,False
+10005509,Products and Services,,121 Pyrcroft Road,,,Chertsey,Surrey                        ,England                       ,KT16 9ET,Wider Public Sector,Private Sector Enabler,False
+10005508,Prison Enterprise Services,,15 Wellesley Road,,,Croydon,Surrey                        ,England                       ,CR0 2AG,Wider Public Sector,Private Sector Enabler,False
+10005507,Priory Healthcare,,2 Commonside,Woodlands Road,,Epsom,Surrey                        ,England                       ,KT18 7HT,Wider Public Sector,Private Sector Enabler,False
+10005497,Parish Church Children's Club,,Parish Church School,Warrington Road,,Croydon,Surrey                        ,England                       ,CR0 4BH,Wider Public Sector,Private Sector Enabler,False
+10005494,Orchard Court (Resource Centre),,East Grinstead Road,,,Lingfield,Surrey                        ,England                       ,RH7 6ET,Wider Public Sector,Private Sector Enabler,False
+10005493,Odyssey,,Florence House,Lucas Green Road,West End,Woking,Surrey                        ,England                       ,GU24 9LD,Wider Public Sector,Private Sector Enabler,False
+10005491,Nurses Memorial To King Edward V11,,58 Reigate Road,,,Reigate,Surrey                        ,England                       ,RH2 0RD,Wider Public Sector,Private Sector Enabler,False
+10005490,Nuffield Nursing Homes Trust,,1-4 The Crescent,,,Surbiton,Surrey                        ,England                       ,KT6 4BN,Wider Public Sector,Private Sector Enabler,False
+10005488,North-Coombes DP,,Chertsey Health Centre,Stepgates,,Chertsey,Surrey                        ,England                       ,KT15 3SD,Wider Public Sector,Private Sector Enabler,False
+10005481,Nexus Health Finance Ltd,,Alexandra House,Alexandra Terrace,,Guildford,Surrey                        ,England                       ,GU1 3DA,Wider Public Sector,Private Sector Enabler,False
+10005479,New Malden Baptist Church,,25 Overdale Avenue,,,New Malden,Surrey                        ,England                       ,KT3 3UE,Wider Public Sector,Private Sector Enabler,False
+10005478,Nepal Leprosy Trust,,15 Duncan Road,,,Richmond,Surrey                        ,England                       ,TW9 2JD,Wider Public Sector,Private Sector Enabler,False
+10005477,National Grid Co plc,,Kelvin Avenue,,,Leatherhead,Surrey                        ,England                       ,KT22 7ST,Wider Public Sector,Energy,False
+10005475,Mott Macdonald Group Ltd,,St. Anne House,20-26 Wellesley Road,,Croydon,Surrey                        ,England                       ,CR9 2UL,Wider Public Sector,Private Sector Enabler,False
+10005461,Marbally District Council,,Marbally Community Alarm Centre,Wesley House Annex,Bullhill,Leatherhead,Surrey                        ,England                       ,KT22 7BH,Wider Public Sector,District Council,False
+10005452,Leatherhead United Charities,,Homefield,5 Fortyfoot Road,,Leatherhead,Surrey                        ,England                       ,KT22 8RP,Wider Public Sector,Housing Associations,False
+10005450,Leatherhead Leisure Centre,,Guildford Rd,,,Leatherhead,Surrey                        ,England                       ,KT22 9BL,Wider Public Sector,Private Sector Enabler,False
+10005448,Kingston Voluntary Action,,Siddeley House,50 Canbury Park Road,,Kingston,Surrey                        ,England                       ,KT2 6LX,Wider Public Sector,Private Sector Enabler,False
+10005446,Kingston United Charities,,The Briary,"Highfield Lane,Thursley",,Godalming,Surrey                        ,England                       ,GU8 6QQ,Wider Public Sector,Private Sector Enabler,False
+10005444,Kingston IT Education Service,,Blakes Lane,,,New Malden,Surrey                        ,England                       ,KT3 5NU,Wider Public Sector,Private Sector Enabler,False
+10005428,Home of Compassion,,58 High Street,,,Thames Ditton,Surrey                        ,England                       ,KT7 0TT,Wider Public Sector,Private Sector Enabler,False
+10005420,HMF,,Pirbright Camp,Brookwood,,Woking,Surrey                        ,England                       ,GU24 0QQ,Wider Public Sector,Private Sector Enabler,False
+10005416,Hewitt Homes For Gentle Poor,,E. C Associates Ltd,Park House,5 Bridgefield,Farnham,Surrey                        ,England                       ,GU9 8AN,Wider Public Sector,Housing Associations,False
+10005414,Hedworth Housing,,Ivy Mill Lane,,,Godstone,Surrey                        ,England                       ,RH9 8NR,Wider Public Sector,Private Sector Enabler,False
+10005410,Haig Homes,,Alban Dobson House,Green Lane,,Morden,Surrey                        ,England                       ,SM4 5NS,Wider Public Sector,Housing Associations,False
+10005409,Guildford Sunset Homes,,The Estate Office,Thrupp House,Merrow Street,Guildford,Surrey                        ,England                       ,GU4 7DE,Wider Public Sector,Private Sector Enabler,False
+10005408,Guildford Diocesan Board of Education,,The Cathedral,,,Guildford,Surrey                        ,England                       ,GU2 5UP,Wider Public Sector,Private Sector Enabler,False
+10005403,Grange Centre For People With Disabilities,,The Grange Centre,Rectory Lane,,Leatherhead,Surrey                        ,England                       ,KT23 4BN,Wider Public Sector,Private Sector Enabler,False
+10005402,Government Office for the South East,,1 Walnut Tree Close,,,Guildford,Surrey                        ,England                       ,GU1 4GA,Central Government,NDPB,False
+10005399,Glyn AD T Technology School,,The Kingsway,,,Ewell,Surrey                        ,England                       ,KT17 1NB,Wider Public Sector,Private Sector Enabler,False
+10005397,G P Group,,99 Station Road,,,Redhill,Surrey                        ,England                       ,RH1 9EB,Wider Public Sector,Private Sector Enabler,False
+10005394,Fort Tea Rooms,,Boxhill Servery,Boxhill Rd,,Tadworth,Surrey                        ,England                       ,KT20 7LB,Wider Public Sector,Private Sector Enabler,False
+10005390,Fellowship Houses Trust Home For Aged,,High Rd,Byfleet,,West Byfleet,Surrey                        ,England                       ,KT14 7RN,Wider Public Sector,Private Sector Enabler,False
+10005388,Ex Sevices Mental Welfare Society,,Oaklawn Road,Oaklawn Road,,Leatherhead,Surrey                        ,England                       ,KT22 0BX,Wider Public Sector,Private Sector Enabler,False
+10005387,Ewell Sports and Social Club,,Banstead Road,Ewell,,Epsom,Surrey                        ,England                       ,KT17 3HJ,Wider Public Sector,Private Sector Enabler,False
+10005381,Ellel Ministries,,Frensham,,,Fareham,Surrey                        ,England                       ,GU10 3DL,Wider Public Sector,Private Sector Enabler,False
+10005380,Elizabeth Fitzroy Support,,Caxton House,Lower Street,,Haslemere,Surrey                        ,England                       ,GU27 2PE,Wider Public Sector,Private Sector Enabler,False
+10005373,Duke St Baptist Church,,Quadrant Road,,,Richmond,Surrey                        ,England                       ,TW9 1DH,Wider Public Sector,Private Sector Enabler,False
+10005370,Dorking Residential Care Homes,,Haybarn House,118 South Street,,Dorking,Surrey                        ,England                       ,RH4 2EZ,Wider Public Sector,Private Sector Enabler,False
+10005369,Dorking Charities,,Homefield,5 Fortyfoot Road,,Leatherhead,Surrey                        ,England                       ,KT22 8RP,Wider Public Sector,Private Sector Enabler,False
+10005366,Croydon Voluntary Action,,96 High Street,,,Thornton Heath,Surrey                        ,England                       ,CR7 8RY,Wider Public Sector,Private Sector Enabler,False
+10005357,Crown Agent for Overseas Governments,,St Nicholas House,St Nicholas Road,,Sutton,Surrey                        ,England                       ,SM1 1EL,Wider Public Sector,Private Sector Enabler,False
+10005356,Crimestoppers Trust,,Apollo House,66A London Road,,Morden,Surrey                        ,England                       ,SM4 5BE,Wider Public Sector,Private Sector Enabler,False
+10005354,Coulsdon Purley and District,,Browside,12 Foxley Lane,,Purley,Surrey                        ,England                       ,CR8 3ED,Wider Public Sector,Private Sector Enabler,False
+10005352,CLN,,119 Send Road,Send,,Woking,Surrey                        ,England                       ,GU23 7HN,Wider Public Sector,Private Sector Enabler,False
+10005350,Client Services,,Education Officers,123 Blackborough Road,,Reigate,Surrey                        ,England                       ,RH2 7DL,Wider Public Sector,Private Sector Enabler,False
+10005348,City of London Freemans School,,Park Lane,,,Ashtead,Surrey                        ,England                       ,KT21 1ET,Wider Public Sector,School Other,False
+10005347,Churchill Training Ltd,,7 St James's Park,,,Croydon,Surrey                        ,England                       ,CR0 2UT,Wider Public Sector,Private Sector Enabler,False
+10005346,Church of the Good Shepherd,,Carshalton Barracks,Queen Marys Avenue,,Carshalton,Surrey                        ,England                       ,SM5 4NP,Wider Public Sector,Private Sector Enabler,False
+10005345,Church Of Jesus Christ Of Latter Day Saints,,West Park Rd,Newchapel,,Lingfield,Surrey                        ,England                       ,RH7 6HW,Wider Public Sector,Private Sector Enabler,False
+10005344,Cheshire Home,,Westcott Road,,,Dorking,Surrey                        ,England                       ,RH4 3AE,Wider Public Sector,Private Sector Enabler,False
+10005342,Chertsey Street Baptist Church,,Chertsey Street,,,Guildford,Surrey                        ,England                       ,GU1 4HL,Wider Public Sector,Private Sector Enabler,False
+10005340,Cheam Family Practice,,The Knoll,Parkside,,Sutton,Surrey                        ,England                       ,SM3 8BS,Wider Public Sector,Private Sector Enabler,False
+10005339,Central Veterinary Laboratory,,Woodham Lane,New Haw,,Addlestone,Surrey                        ,England                       ,KT15 3NB,Wider Public Sector,Private Sector Enabler,False
+10005337,Case,,30 Freelands Road,,,Cobham,Surrey                        ,England                       ,KT11 2ND,Wider Public Sector,Private Sector Enabler,False
+10005334,BPSS South West Area,,Guildford Pupil Referral Unit,Pewley Hill,,Guildford,Surrey                        ,England                       ,GU1 3SQ,Wider Public Sector,Private Sector Enabler,False
+10005320,Ayr Health,,29 Clarence Avenue,,,New Malden,Surrey                        ,England                       ,KT3 3TZ,Wider Public Sector,Private Sector Enabler,False
+10005313,NCH Thames Anglia,,Evelyn House B,Lannades Business Park,,Kentford,Suffolk                       ,England                       ,CB8 7PN,Wider Public Sector,Private Sector Enabler,False
+10005302,Uplands Community Middle School,,York Road,,,Sudbury,Suffolk                       ,England                       ,CO10 1NG,Wider Public Sector,Private Sector Enabler,False
+10005301,United States Air Force,,48 Civil Engineering Squadron,Building 1107 Raf Lakenheath,,Brandon,Suffolk                       ,England                       ,IP27 9PP,Wider Public Sector,Private Sector Enabler,False
+10005299,Health Centre The,,St Marys Road,,,Beccles,Suffolk                       ,England                       ,NR34 9NQ,Wider Public Sector,Private Sector Enabler,False
+10005289,Suffolk County Catering,,"St Andrews Home ,",County Home,,Ipswich,Suffolk                       ,England                       ,IP4 14J,Wider Public Sector,Private Sector Enabler,False
+10005287,Suffolk New College,,Rope Walk,,,Ipswich,Suffolk                       ,England                       ,IP4 1LT,Wider Public Sector,Colleges of Further Education,False
+10005283,St Elizabeth Hospice,,565 Foxhall Road,,,Ipswich,Suffolk                       ,England                       ,IP3 8LX,Wider Public Sector,Private Sector Enabler,False
+10005281,St Andrews Pre-School Group,,108 Ranelagh Road,,,Felixstowe,Suffolk                       ,England                       ,IP11 7HU,Wider Public Sector,Private Sector Enabler,False
+10005277,RAF North Pool,,Station Building 443,Mildenhall,,Bury St. Edmunds,Suffolk                       ,England                       ,IP28 8NG,Central Government,RAF,False
+10005261,KCC,,C/O 48 London Road,Kessingland,,Lowestoft,Suffolk                       ,England                       ,NR33 7PW,Wider Public Sector,Private Sector Enabler,False
+10005258,Ipswich Furniture Project,,Hogarth Road,,,Ipswich,Suffolk                       ,England                       ,IP3 0EY,Wider Public Sector,Private Sector Enabler,False
+10005255,Hubbard,,Hillview,Otley,,Ipswich,Suffolk                       ,England                       ,IP6 9NP,Wider Public Sector,Private Sector Enabler,False
+10005246,Felixstowe Hospitals,,Constable Road,,,Felixstowe,Suffolk                       ,England                       ,IP11 7HJ,Wider Public Sector,Private Sector Enabler,False
+10005242,District Valuer and Valuation Officer,,Legal & General House,190 Armada Way,,Plymouth,Suffolk                       ,England                       ,PL1 1EG,Wider Public Sector,Private Sector Enabler,False
+10005241,Crown Pools,,Crown Street,,,Ipswich,Suffolk                       ,England                       ,IP1 3JA,Wider Public Sector,Private Sector Enabler,False
+10005240,Community Association,,62 Heldhaw Road,Morton,,Bury St Edmunds,Suffolk                       ,England                       ,IP32 7ES,Wider Public Sector,Private Sector Enabler,False
+10005227,Apex Foam Ltd,,16-18 Hollands Road,,,Haverhill,Suffolk                       ,England                       ,CB9 8PP,Wider Public Sector,Private Sector Enabler,False
+10005224,Acc Stores Wood,,C/O 4 Friston Road,Sutton,,Woodbridge,Suffolk                       ,England                       ,IP12 3TW,Wider Public Sector,Private Sector Enabler,False
+10005213,Scottish Agricultural College,,Auchincruive,Bucksburn,,Ayr,Strathclyde                   ,Scotland                      ,KA6 5HW,Wider Public Sector,Education,False
+10005212,Renfrew-Strathclyde Regional Council,,Legal House,101 Gorbals Street,,Glasgow,Strathclyde                   ,Scotland                      ,G5 9DW,Wider Public Sector,Private Sector Enabler,False
+10005207,Maranatha Centre,,Glencairn Street,,,Motherwell,Lanarkshire                   ,Scotland                      ,ML1 1TT,Wider Public Sector,Not for Profit,False
+10005192,Bell College,,Almada Street,,,Hamilton,Strathclyde                   ,Scotland                      ,ML3 0JB,Wider Public Sector,Education,False
+10005190,Adelphi Management Company Ltd,,Adelphi Centre,12 Commercial Road,,Glasgow,Strathclyde                   ,Scotland                      ,G5 0PQ,Wider Public Sector,Private Sector Enabler,False
+10005189,Royal Scottish National Hospital and Community National Health Service Trust,,Old Denny Road,Larbert,,Falkirk,Stirlingshire                 ,Scotland                      ,FK5 4SD,Wider Public Sector,Private Sector Enabler,False
+10005187,Randolphfield Police HQ,,Randolphfield,,,Stirling,Stirlingshire                 ,Scotland                      ,FK8 2HD,Wider Public Sector,Private Sector Enabler,False
+10005185,Gartmoor House Conference Centre,,Gartmoor,,,Aberfoyle,,England                       ,SKA 3RS,Wider Public Sector,Private Sector Enabler,False
+10005183,Forth Valley Health,,Bellsdyke Hospital  Bellsdyke Road,Larbert,,Falkirk,Stirlingshire                 ,Scotland                      ,FK5 4SF,Wider Public Sector,Private Sector Enabler,False
+10005181,Falkirk Council Local Authority,,Lorne Rd,,,Larbert,Stirlingshire                 ,Scotland                      ,FK5 4AT,Wider Public Sector,Private Sector Enabler,False
+10005176,Central Regional Council Water Services,,Woodlands,St Ninians Road,,Stirling,Stirlingshire                 ,Scotland                      ,FK8 2HB,Wider Public Sector,Private Sector Enabler,False
+10005158,Tamworth and Lichfield College,,Croft Street,Upper Gungate,,Tamworth,Staffordshire                 ,England                       ,B79 8AE,Wider Public Sector,Colleges of Further Education,False
+10005157,Swynnerton TC,,Cold Meece,,,Stone,Staffordshire                 ,England                       ,ST15 0QN,Wider Public Sector,Private Sector Enabler,False
+10005155,Stoke On Trent College,,Cauldon Campus Stoke Road Shelton,Stoke-On-Trent,Staffordshire,Stoke-On-Trent,Staffordshire,England,ST6 1JJ,Wider Public Sector,Colleges of Further Education,False
+10005153,Stoke on Trent Citizens Advice Bureau,CAB,Advice House,Cheapside,Hanley,Stoke-On-Trent,Staffordshire                 ,England                       ,ST1 1HL,Central Government,Charity,False
+10005152,Stoke Workshops,SW,211 City Road,Fenton,,Stoke-On-Trent,Staffordshire                 ,England                       ,ST4 2PN,Wider Public Sector,Private Sector Enabler,False
+10005150,Staffordshire Social Services,,1 St Chads Place,,,Stafford,Staffordshire                 ,England                       ,ST16 2LR,Wider Public Sector,Private Sector Enabler,False
+10005133,Rodbaston College,,Rodbaston,,,Penkridge,Staffordshire                 ,England                       ,ST19 5PH,Wider Public Sector,Colleges of Further Education,False
+10005124,Newcastle Under Lyme College,,Liverpool Road,Newcastle-Under-Lyme,Staffordshire,Newcastle-Under-Lyme,Staffordshire,England,ST5 2DF,Wider Public Sector,Colleges of Further Education,False
+10005121,Moorlands Housing,,Eaton House,Buxton Road,,Leek,Staffordshire                 ,England                       ,ST13 6EQ,Wider Public Sector,Housing Associations,False
+10005120,Mid Staffordshire NHS Foundation Trust,,Staffordshire General Hospital,Weston Road,,Cannock,Staffordshire,England,ST16 3SA,Wider Public Sector,Acute Trust,False
+10005093,CBTS,,Ida Road,,,Walsall,Staffordshire                 ,England                       ,WS2 9SS,Wider Public Sector,Private Sector Enabler,False
+10005091,Cameo Residential Home,,14 Hopleys Close,Glascote,,Tamworth,Staffordshire                 ,England                       ,B77 3JU,Wider Public Sector,Private Sector Enabler,False
+10005084,ATR Lichfield,,Whittington Barracks,,,Lichfield,Staffordshire                 ,England                       ,WS14 9PY,Central Government,,False
+10005074,Wessex Group Valuation and Tribunrals,,Ground Floor,Parkside,Grove Road,Weston-Super-Mare,Somerset                      ,England                       ,BS23 2AR,Wider Public Sector,Private Sector Enabler,False
+10005067,Taunton Association For The Homeless,,Alfred House,Alfred Street,,Taunton,Somerset                      ,England                       ,TA1 3HU,Wider Public Sector,Private Sector Enabler,False
+10005059,St Michaels Cheshire Homes,,Cheddar Road,,,Axbridge,Somerset                      ,England                       ,BS26 2DW,Wider Public Sector,Private Sector Enabler,False
+10005057,St Dunstans Community School,,Wells Road,,,Glastonbury,Somerset                      ,England                       ,BA6 9BY,Wider Public Sector,Private Sector Enabler,False
+10005056,South West Regional Assembly,,Dennett House,11 Middle Street,,Taunton,Somerset                      ,England                       ,TA1 1SH,Wider Public Sector,Private Sector Enabler,False
+10005049,Somerset Fire and Rescue Service,,Hestercombe House,Cheddon Fitzpaine,,Taunton,Somerset                      ,England                       ,TA2 8LQ,Wider Public Sector,Fire and Rescue Services,False
+10005045,Somerset Careers Limited,,Crescent House,The Mount,,Taunton,Somerset                      ,England                       ,TA1 3TT,Wider Public Sector,Private Sector Enabler,False
+10005036,Royal Ordnance Factory,,Woolavington Road,Puriton,,Bridgwater,Somerset                      ,England                       ,TA7,Wider Public Sector,Private Sector Enabler,False
+10005035,Royal Naval Association Yeovilton,,Urgashay,,,Yeovil,Somerset                      ,England                       ,BA22 8HH,Wider Public Sector,Private Sector Enabler,False
+10005032,Robert Burton Trust,,3 Silver Street,,,Glastonbury,Somerset                      ,England                       ,BA6 8BS,Wider Public Sector,Private Sector Enabler,False
+10005030,Red Gables Nursing Home,,1 Pinnocks Croft,Berrow,,Burnham-On-Sea,Somerset                      ,England                       ,TA8 2NF,Wider Public Sector,Private Sector Enabler,False
+10005020,Laurels Residential Home For The Eld,,Westfield Lane,Draycott,,Cheddar,Somerset                      ,England                       ,BS27 3TN,Wider Public Sector,Private Sector Enabler,False
+10005013,Hillcrest Surgery,,Wellow Lane,,,Peasedown St John,Somerset                      ,England                       ,BA2 8JQ,Wider Public Sector,Private Sector Enabler,False
+10005009,Fona Hq,,.,,,Yeovilton,Somerset                      ,England                       ,BA22 8HL,Wider Public Sector,Private Sector Enabler,False
+10005007,ES (AIR) VL,,Repro Room   Gazelle House,RNAS Yeovilton,,Yeovil,Somerset                      ,England                       ,BA22 8HJ,Wider Public Sector,Private Sector Enabler,False
+10005006,East Somerset Research Consortium,,Westlake Surgery,West Coker,,Yeovil,Somerset                      ,England                       ,BA22 9AH,Wider Public Sector,Private Sector Enabler,False
+10005003,DCSA LAIPT(A) CONFIG 4,,PAU 516 Unicorn House,Yeovilton,,Yeovil,Somerset                      ,England                       ,BA22 8HW,Wider Public Sector,Private Sector Enabler,False
+10004995,Clevedon Library,,37 Old Church Road,,,Clevedon,Somerset                      ,England                       ,BS21 6NN,Wider Public Sector,Private Sector Enabler,False
+10004991,Camelot Self Build Hc Ltd,,Manor Farm Cottage,"Kitchens Lane,Lopen",,South Petherton,Somerset                      ,England                       ,TA13 5JN,Wider Public Sector,Private Sector Enabler,False
+10004977,Application Service Provider,,Room 16,Unicorn House,,Yeovilton,Somerset                      ,England                       ,BA22 8HW,Wider Public Sector,Private Sector Enabler,False
+10004974,Girl Guides Somerset,,Laurelyvan,Fort Street,,West Carmel,Somerset                      ,England                       ,BA22 7QW,Wider Public Sector,Private Sector Enabler,False
+10004970,Wellington Medical Centre,,Bulford,,,Wellington,Somerset                      ,England                       ,TA21 8PW,Wider Public Sector,Private Sector Enabler,False
+10004968,Heathfield Community School,,School Road,Monkton Heathfield,,Taunton,Somerset                      ,England                       ,TA2 8PD,Wider Public Sector,Private Sector Enabler,False
+10004966,Scunthorpe County Court,,Government Buildings,Comforts Avenue,,Scunthorpe,South Humberside              ,England                       ,DN15 6PR,Wider Public Sector,Private Sector Enabler,False
+10004963,Castle House School Trust,,Chetwynd End,,,Newport,Shropshire                    ,England                       ,TF10 7JE,Wider Public Sector,Private Sector Enabler,False
+10004957,West Midlands Area Office,,PO Box 458,HMP Shrewsbury,The Dana,Shrewsbury,Shropshire                    ,England                       ,SY1 2WB,Wider Public Sector,Private Sector Enabler,False
+10004955,Wellington Cottage Healthcare,,Haygate Rd,Wellington,,Telford,Shropshire                    ,England                       ,TF1 2BJ,Wider Public Sector,Private Sector Enabler,False
+10004952,Old Ben Homes The,,3 The Old Hall,Church Road,,Newport,Shropshire                    ,England                       ,TF10 9JA,Wider Public Sector,Private Sector Enabler,False
+10004943,South Shropshire District Council,,Council Offices,Stone House,Corve Street,Ludlow,Shropshire                    ,England                       ,SY8 1DG,Wider Public Sector,District Council,False
+10004942,Shropshire Social Services,,The Shirehall,Abbey Foregate,,Shrewsbury,Shropshire                    ,England                       ,SY2 3DN,Wider Public Sector,Private Sector Enabler,False
+10004941,Shropshire Purchasing Consortium,,Supplies Department,Shelton Hospital,Bicton Heath,Shrewsbury,Shropshire                    ,England                       ,SY3 8DN,Wider Public Sector,Private Sector Enabler,False
+10004939,Shropshire County Primary Care Trust,,William Farr House,Mytton Oak Road,,Shrewsbury,Shropshire                    ,England                       ,SY3 8XL,Wider Public Sector,PCT - Commissioning,False
+10004938,Shropshire County Council,,The Shirehall,Abbey Foregate,,Shrewsbury,Shropshire                    ,England                       ,SY2 6ND,Wider Public Sector,Region: West Midlands,False
+10004937,Shropshire Careers Service Ltd,,Victoria Quay,"Victoria Avenue,Welshbridge",,Shrewsbury,Shropshire                    ,England                       ,SY1 1HH,Wider Public Sector,Private Sector Enabler,False
+10004936,Shropshire Association for Sheltered Housing,,4 Saltney Close,,,Shrewsbury,Shropshire                    ,England                       ,SY2 6SQ,Wider Public Sector,Private Sector Enabler,False
+10004935,Shropshire and Mid Wales Hospice,,Bicton Heath,,,Shrewsbury,Shropshire                    ,England                       ,SY3 8HS,Wider Public Sector,Private Sector Enabler,False
+10004931,Shrewsbury and Atcham Borough Council,,The Guildhall,Frankwell Quay,,Shrewsbury,Shropshire                    ,England                       ,SY3 8HQ,Wider Public Sector,District Council,False
+10004922,Prestfelde Preparatory School For Boys,,London Road,,,Shrewsbury,Shropshire                    ,England                       ,SY2 6NZ,Wider Public Sector,Private Sector Enabler,False
+10004919,Oswestry Borough Council,,Council Offices,Castle View,,Oswestry,Shropshire                    ,England                       ,SY11 1JR,Wider Public Sector,District Council,False
+10004917,North Shropshire District Council,,Edinburgh House,New Street,Wem,Shrewsbury,Shropshire                    ,England                       ,SY4 5DB,Wider Public Sector,District Council,False
+10004916,North Shropshire College,,College Road,Oswestry,Shropshire,Oswestry,Shropshire,England,SY11 2SA,Wider Public Sector,Colleges of Further Education,False
+10004915,No 6 Dental Group Radc HQ,,Venning Barracks,Donnington,,Telford,Shropshire                    ,England                       ,TF2 8QD,Central Government,,False
+10004902,Ludlow Assembly Rooms,,1 Mill Street,,,Ludlow,Shropshire                    ,England                       ,SY8 1AZ,Wider Public Sector,Private Sector Enabler,False
+10004901,Lilleshall Sports and Conference Centre,,Main Office,,,Newport,Shropshire                    ,England                       ,TF10 9AT,Wider Public Sector,Private Sector Enabler,False
+10004900,Lilleshall National Sports and Conf Centre,,Main Office,,,Newport,Shropshire                    ,England                       ,TF10 9AT,Wider Public Sector,Private Sector Enabler,False
+10004899,JDM Accord Ltd,,107 Loneden Road,,,Shrewsbury,Shropshire                    ,England                       ,SY3 9DT,Wider Public Sector,Private Sector Enabler,False
+10004898,Ironbridge Gorge Museum Trust Ltd,,The Wharfage,Ironbridge,,Telford,Shropshire                    ,England                       ,TF8 7AW,Wider Public Sector,Private Sector Enabler,False
+10004896,Hope House Childrens Hospice,,Nant Lane,Morda,, Nr Oswestry,Shropshire                    ,England                       ,SY10 9BX,Wider Public Sector,Private Sector Enabler,False
+10004894,HM Prison Shrewsbury,,The Dana,,,Shrewsbury,Shropshire                    ,England                       ,SY1 2HR,Central Government,,False
+10004890,G4 Estate,,Hq 143 (Wm) Bde,Copthorne Barracks,,Shrewsbury,Shropshire                    ,England                       ,SY3 8LZ,Wider Public Sector,Private Sector Enabler,False
+10004889,Eurest/Uni Of Wolverhampton,,Shropshire Campus,Priorslee,,Telford,Shropshire                    ,England                       ,TF,Wider Public Sector,Private Sector Enabler,False
+10004888,ESPPA,,EB3A Saphire House,Stafford Park 10,,Telford,Shropshire                    ,England                       ,TF3 3AD,Wider Public Sector,Private Sector Enabler,False
+10004885,DSDC Donnington,DSDA,HQ Building,,,Telford,Shropshire                    ,England                       ,TF2 8JT,Central Government,Cross Service,False
+10004876,Bridgnorth District Council,,West Gate,Bridge North,,Bridgnorth,Shropshire                    ,England                       ,WV16 5AA,Wider Public Sector,District Council,False
+10004875,Bourneville Property Care,,Unit G8 Court Works Industrial estate,Bridgnorth Road  Madeley,,Telford,Shropshire                    ,England                       ,TF7 4JB,Wider Public Sector,Private Sector Enabler,False
+10004870,Apex Engineers,,Park Heath House,Cheswardine,,Market Drayton,Shropshire                    ,England                       ,TF9 2NP,Wider Public Sector,Private Sector Enabler,False
+10004868,Ambulance Service Union,,354 Longmoor Lane,Aintree,,Liverpool,Merseyside                    ,England                       ,L9 9DG,Wider Public Sector,Private Sector Enabler,False
+10004867,5 Division Copthorne Barracks HQ,,Copthorne Road,,,Shrewsbury,Shropshire                    ,England                       ,SY3 8AZ,Central Government,,False
+10004864,Viewforth House,,13 Burgh Road,,,Lerwick,Shetland                      ,Scotland                      ,ZE1 OLA,Wider Public Sector,Private Sector Enabler,False
+10004862,Shetland Library,,Lower Hillhead,,,Lerwick,Shetland                      ,Scotland                      ,ZE1 0EL,Wider Public Sector,Private Sector Enabler,False
+10004856,WS Atkins,,Building 159 West Camp RAF,RAF St Athan,Vale of Glamorgan,Barry,South Glamorgan               ,Wales                         ,CF62 4WA,Wider Public Sector,Private Sector Enabler,False
+10004851,University of Wales Cardiff,,53 Park Place,Haematology Department,Heath Park,Cardiff,South Glamorgan               ,Wales                         ,CF10 3AT,Wider Public Sector,Education,False
+10004841,National Sports Centre For Wales,,Sophia Gardens,,,Cardiff,South Glamorgan               ,Wales                         ,CF10 9SW,Wider Public Sector,Private Sector Enabler,False
+10004838,Ministry Of Defence HQ Cardiff Station,,Maindy Barracks,Whitchurch Road,,Cardiff,South Glamorgan               ,Wales                         ,CF4 3YE,Central Government,,False
+10004832,Care Standards in Wales,,4-5 Charnwood Court,Heol Billingsly,Park Nant Garw,Cardiff,South Glamorgan               ,Wales                         ,CF15 7QZ,Wider Public Sector,Private Sector Enabler,False
+10004830,Cardiff Community Housing,,15-17 Moria Terrace,,,Cardiff,South Glamorgan               ,Wales                         ,CF24 1EJ,Wider Public Sector,Private Sector Enabler,False
+10004823,St Andrews Convent,,Stirches,,,Hawick,Roxburghshire                 ,Scotland                      ,TD9 7NS,Wider Public Sector,Private Sector Enabler,False
+10004816,University of Paisley,,67 High Street,,,Paisley,Renfrewshire                  ,Scotland                      ,PA1 2BE,Wider Public Sector,Education,False
+10004809,Little Sisters Of The Poor,,43 Gilmore Place,52 Plymouth Grove West,South Lambeth,Edinburgh,Renfrewshire                  ,Scotland                      ,EH3 9NG,Wider Public Sector,Private Sector Enabler,False
+10004808,Kibble Education and Care Centre,,Goudie St,,,Paisley,Renfrewshire                  ,Scotland                      ,PA3 2LG,Wider Public Sector,Private Sector Enabler,False
+10004803,Inverclyde and Renfrew Priority Services,,Merchiston Hospital,Brookfield,,Johnstone,Renfrewshire                  ,Scotland                      ,PA5 8TY,Wider Public Sector,Private Sector Enabler,False
+10004795,Nuclear Accident Response Organisation,,Almondbank,Fleetlands,,Perth,Perthshire                    ,Scotland                      ,PH1 3NQ,Wider Public Sector,Private Sector Enabler,False
+10004793,DARA,,Almondbank,Fareham Road,RAF St Athan,Perth,Perthshire                    ,Scotland                      ,PH1 3NQ,Wider Public Sector,Private Sector Enabler,False
+10004786,Rural Inspectorate for Wales Branch,,National Assembly for Wales,Government Buildings,Spa Road East,Llandrindod Wells,Powys                         ,Wales                         ,LD1 5HA,Wider Public Sector,Private Sector Enabler,False
+10004785,Rhayader Day Care Centre,,Hafan,Maesderi,,Rhayaderi,Powys                         ,Wales                         ,LD6 5DF,Wider Public Sector,Private Sector Enabler,False
+10004781,Park Day Centre,,Park Street,,,Newtown,,England                       ,SY16 1EG,Wider Public Sector,Private Sector Enabler,False
+10004774,Coleg Powys,,Spa Road,,,Llanddrindod,Powys                         ,Wales                         ,LD1 5ES,Wider Public Sector,Private Sector Enabler,False
+10004773,Christ College,,Main Office,,,Brecon,Powys                         ,Wales                         ,LD3 8AF,Wider Public Sector,Education,False
+10004770,West Wales Women's Aid,,PO Box 201,,,Haverfordwest,Pembrokeshire                 ,Wales                         ,SA61 1BF,Wider Public Sector,Private Sector Enabler,False
+10004769,St Davids Care in the Community,,Fairfield,St Davids Road,,St Davids,Pembrokeshire                 ,Wales                         ,SA62 6QH,Wider Public Sector,Private Sector Enabler,False
+10004766,Pembrokeshire Local Health Board,,Unit 5,Winch Lane,,Haverfordwest,Pembrokeshire                 ,Wales                         ,SA61 1SB,Wider Public Sector,Private Sector Enabler,False
+10004764,Pembrokeshire Contract Services,,Unit 23,Thornton Business Park,,Milford Haven,Pembrokeshire                 ,Wales                         ,SA73 2RR,Wider Public Sector,Private Sector Enabler,False
+10004763,Pembrokeshire Coast National Park Authority,,Winch Lane,,,Haverfordwest,Pembrokeshire                 ,Wales                         ,SA61 1PY,Wider Public Sector,Private Sector Enabler,False
+10004760,(Closed) Defence Storage and Distribution Agency,,Ploughley Road Lower Arncott,Bicester,Oxfordshire,Bicester,Oxfordshire,England,OX6 0LD,Central Government,MoD - DE&S,False
+10004754,Women's Royal Voluntary Service,,Garden House,Milton Hill ,,Abingdon,Oxfordshire                   ,England                       ,OX13 6AD,Wider Public Sector,Private Sector Enabler,False
+10004748,Waste and Resources Action Programme,,The Old Academy,21 Horse Fair,,Banbury,Oxfordshire                   ,England                       ,OX16 0AH,Wider Public Sector,Private Sector Enabler,False
+10004742,Porch The,,All Saints Convent,St Mary's Road,,Oxford,Oxfordshire                   ,England                       ,OX4 1RU,Wider Public Sector,Private Sector Enabler,False
+10004735,Surestock Health Services,,Unipart House,,,Cowley,Oxfordshire                   ,England                       ,OX4 2PJ,Wider Public Sector,Private Sector Enabler,False
+10004734,Style Acre Friends,,High Road,Brightwell-Cum-Sotwell,,Wallingford,Oxfordshire                   ,England                       ,OX10 0PT,Wider Public Sector,Private Sector Enabler,False
+10004733,Stenoak Associated Services Plc,,Highlands Lane,,,Henley-on-thames,Oxfordshire                   ,England                       ,RG9 4PS,Wider Public Sector,Private Sector Enabler,False
+10004728,Rycotewood College,,Priest End,,,Thame,Oxfordshire                   ,England                       ,OX9 2AF,Wider Public Sector,Colleges other,False
+10004725,Resources and Development Office,,A27 HQ DFDC,E15 Estates,,Oxford,Oxfordshire                   ,England                       ,OX6 OLD,Wider Public Sector,Private Sector Enabler,False
+10004723,Red Kite Farms,,Turville Court Estate,Turville Heath,,Henley on Thames,Oxfordshire                   ,England                       ,RG9 6JT,Wider Public Sector,Private Sector Enabler,False
+10004721,QM DLSA,,Block 5,Vauxhall Barracks,,Didcot,Oxfordshire                   ,England                       ,OX11 7ES,Wider Public Sector,Private Sector Enabler,False
+10004720,Purchasing Services,,County Hall,New Road,,Oxford,Oxfordshire                   ,England                       ,OX1 1ND,Wider Public Sector,Private Sector Enabler,False
+10004718,Police Rehabilitation Centre,,Flint House,Reading Road,,Goring-on-Thames,Oxfordshire                   ,England                       ,RG8 0LL,Wider Public Sector,Private Sector Enabler,False
+10004705,Oxford Diocesan Board Of Education,,Diocesan Church House,North Hinksey,,Oxford,Oxfordshire                   ,England                       ,OX2 0NB,Wider Public Sector,Private Sector Enabler,False
+10004704,Oxford Community School,,Glanville Road,,,Oxford,Oxfordshire                   ,England                       ,OX4 2AU,Wider Public Sector,Private Sector Enabler,False
+10004702,Oxford College of Further Education,,City Centre Campus,Oxpens Road,,Oxford,Oxfordshire                   ,England                       ,OX1 1SA,Wider Public Sector,Colleges of Further Education,False
+10004698,Oxford Centre for Molecular Sciences,,University of Oxford,South Parks Road,,Oxford,Oxfordshire                   ,England                       ,OX1 3QT,Wider Public Sector,Private Sector Enabler,False
+10004691,OCCIMT,,Gateway House,RAF Brize Norton,,Carterton,Oxfordshire                   ,England                       ,OX18 3LX,Wider Public Sector,Private Sector Enabler,False
+10004687,Non-Project Procurement Office,,Caversfield,Room 66 Spur 11 F Block,Foxhill,Bicester,Oxfordshire                   ,England                       ,OX6 9TS,Wider Public Sector,Private Sector Enabler,False
+10004684,N Oxfordshire and S  Northamptonshire,,Primary Care Group,Oxford Lodge,Warwick Road,Banbury,Oxfordshire                   ,England                       ,OX16 7AQ,Wider Public Sector,Private Sector Enabler,False
+10004680,Lenthall House,,Church Lane,,,Burford,Oxfordshire                   ,England                       ,OX18 4SD,Wider Public Sector,Private Sector Enabler,False
+10004673,HR Wallingford Ltd,,Howbery Park,,,Wallingford,Oxfordshire                   ,England                       ,OX10 8BA,Wider Public Sector,Private Sector Enabler,False
+10004661,Harwell Dental Practice,,Curie Avenue,Harwell,,Didcot,Oxfordshire                   ,England                       ,OX11 0QQ,Wider Public Sector,Private Sector Enabler,False
+10004659,Grace Baptist Mission,,12 Abbey Close,,,Abingdon,Oxfordshire                   ,England                       ,OX14 3JD,Wider Public Sector,Private Sector Enabler,False
+10004657,Fraser Walker Associates,,33 Banbury Road,,,Kidlington,Oxfordshire                   ,England                       ,OX5 1AQ,Wider Public Sector,Private Sector Enabler,False
+10004655,Etb Pp,,Netcen,Culham Laboratory,,Abingdon,Oxfordshire                   ,England                       ,OX14 3DB,Wider Public Sector,Private Sector Enabler,False
+10004654,ESSIPT,,Building 42,DLO Caversfield,Skimmingdish Lane,Bicester,Oxfordshire                   ,England                       ,OX27 8TS,Wider Public Sector,Private Sector Enabler,False
+10004651,DSDC Bicester,,Room 5 C3 Annexe,,,Bicester,Oxfordshire                   ,England                       ,OX25 2PE,Wider Public Sector,Private Sector Enabler,False
+10004650,DLO HQ Bicester Garrison,,Ploughley Road,Lower Arncott,,Bicester,Oxfordshire                   ,England                       ,OX25 2LD,Wider Public Sector,Private Sector Enabler,False
+10004649,DLO Caversfield,,Skimmingdish Lane,,,Bicester,Oxfordshire                   ,England                       ,OX27 8TS,Wider Public Sector,Private Sector Enabler,False
+10004648,DKSA,,Block 1,Vauxhall Barracks,,Didcot,Oxfordshire                   ,England                       ,OX15 4TL,Wider Public Sector,Private Sector Enabler,False
+10004646,Defence Clothing and Textiles Agency,,B42,Skimmingdish Lane,,Bicester,Oxfordshire                   ,England                       ,OX6 9TS,Central Government,Executive Agency,False
+10004645,DCTA QPS 22b,,Purchas Road,,,Didcot,Oxfordshire                   ,England                       ,OX11 7HG,Wider Public Sector,Private Sector Enabler,False
+10004644,Dcta (Gs1b),,Caversfield,,,Bicester,Oxfordshire                   ,England                       ,OX6 9TS,Wider Public Sector,Private Sector Enabler,False
+10004643,Cre Cairfields,,RAF Benson,,,Wallingford,Oxfordshire                   ,England                       ,OX10 6A,Wider Public Sector,Private Sector Enabler,False
+10004642,Country Houses Association,,Aynhoe Park,Aynho,,Banbury,Oxfordshire                   ,England                       ,OX17 3BQ,Wider Public Sector,Private Sector Enabler,False
+10004635,Central England Audit and Consultant,,The Old Tannery,Hensington Road,,Woodstock,Oxfordshire                   ,England                       ,OX20 1JL,Wider Public Sector,Private Sector Enabler,False
+10004618,Abingdon Hospital,,Marcham Road,,,Abingdon,Oxfordshire                   ,England                       ,OX14 1AG,Wider Public Sector,Acute Trust,False
+10004614,Logistics Information Systems Agency (LISA),,Ministry of Defence,Arnott,,Bicester,Oxfordshire                   ,England                       ,OX6 0LP,Wider Public Sector,Private Sector Enabler,False
+10004612,Huntleigh National Care,,31 Nuffeild Way,Ashville Trading Estate,,Avingdon,Oxfordshire                   ,England                       ,OX14 1RL,Wider Public Sector,Private Sector Enabler,False
+10004611,Residential Home For The Elderly,,St Peters House,Bark Road,,Stromness,Orkney                        ,Scotland                      ,KW16 3DZ,Wider Public Sector,Private Sector Enabler,False
+10004609,Orkney Health Board,,Balfour Hospital,1 New Scapa Road,Kirkwall,Orkney,Orkney                        ,Scotland                      ,KW15 1BH,Wider Public Sector,Private Sector Enabler,False
+10004599,Yorkshire Ass For Disabled People,,St Georges House,7-9 Harlow Oval,,Harrogate,North Yorkshire               ,England                       ,HG2 0AA,Wider Public Sector,Private Sector Enabler,False
+10004594,York Diocesan Board Of Education,,Diocesan House,Aviator Court Clifton Moor,,York,North Yorkshire               ,England                       ,YO30 4WJ,Wider Public Sector,Private Sector Enabler,False
+10004591,Wathgill Army Training Camp,,Downholme,,,Richmond,North Yorkshire               ,England                       ,DL11 6AH,Central Government,Army,False
+10004586,Tadcaster Medical Centre,,Crab Garth,,,Tadcaster,North Yorkshire               ,England                       ,LS24 8HD,Wider Public Sector,Private Sector Enabler,False
+10004580,Serco Aerospace,,RAF Fylingdales,,,Pickering,North Yorkshire               ,England                       ,YO18 7NT,Wider Public Sector,Private Sector Enabler,False
+10004579,Selby United Charities,,1 Court Drive,Leeds Road,,Selby,North Yorkshire               ,England                       ,YO8 0JJ,Wider Public Sector,Private Sector Enabler,False
+10004578,Selby Leisure Services,,Abbey Leisure Centre,Scott Road,,Selby,North Yorkshire               ,England                       ,YO8 0BL,Wider Public Sector,Private Sector Enabler,False
+10004573,Scarborough Enterprise Agency,,Scarborough Business Centre,Arborough Street,,Scarborough,North Yorkshire               ,England                       ,YO11 1HP,Wider Public Sector,Private Sector Enabler,False
+10004560,QM 1 Kings Own Royal Border Regt,,Bourlon Barracks,,,Catterick Garrison,North Yorkshire               ,England                       ,DL9 3AN,Wider Public Sector,Private Sector Enabler,False
+10004551,Mowlem F M Hms Forest Moor,,Darley,,,Harrogate,North Yorkshire               ,England                       ,HG3 2RE,Wider Public Sector,Private Sector Enabler,False
+10004550,MOD 38 Engineer Regiment,,Deverell/Claro Barracks,Chatham Road,,Ripon,North Yorkshire               ,England                       ,HG4 2RB,Central Government,,False
+10004537,HMS Forest Moor,,Stores Office,Darley,,Harrogate,North Yorkshire               ,England                       ,HG3 2RE,Central Government,Navy,False
+10004536,High Hall,,Bainbridge,,,Leyburn,North Yorkshire               ,England                       ,DL8 3EL,Wider Public Sector,Private Sector Enabler,False
+10004524,Elder's Day Centre,,Elders St,,,Scarborough,North Yorkshire               ,England                       ,YO11 1DZ,Wider Public Sector,Private Sector Enabler,False
+10004523,Duchess Of Kents Military Hospital,,Catterick Garrison,Horne Road,,Catterick,North Yorkshire               ,England                       ,DL9 4DF,Wider Public Sector,Private Sector Enabler,False
+10004521,Dishforth Airfield,,Dhe Office,22 The Crescent,,Thirsk,North Yorkshire               ,England                       ,YO7 3YA,Central Government,Private Sector Enabler,False
+10004516,Central Science Laboratory,CSL,Sand Hutton,,,York,North Yorkshire               ,England                       ,YO4 1LZ,Central Government,Executive Agency,False
+10004515,CEDG York Ltd,,65 Hudson House,Toft Green,,York,North Yorkshire               ,England                       ,Y01 6HP,Wider Public Sector,Private Sector Enabler,False
+10004501,Carl A Godfrey - Dentist,,10A Grove Street,,,Retford,Nottinghamshire               ,England                       ,DN22 6JR,Wider Public Sector,Private Sector Enabler,False
+10004500,Mansfield and District Citizens Advice Bureau,,Queens Walk,Market Street,,Mansfield,Nottinghamshire               ,England                       ,NG18 1JX,Wider Public Sector,Charity,False
+10004497,Welbeck College,,Welbeck Abbey,Worksop,Nottinghamshire,Worksop,Nottinghamshire,England,S80 3LN,Wider Public Sector,Colleges other,False
+10004491,Special Hospital Service Authority,,Rampton Hospital,,,Retford,Nottinghamshire               ,England                       ,DN22 0PD,Wider Public Sector,Mental Health Trust,False
+10004487,Sherwood Junior,,Sherwood Street,,,Warsop,Nottinghamshire               ,England                       ,NG20 0JT,Wider Public Sector,Private Sector Enabler,False
+10004486,Sherwood Industries,,Nottinghamshire County Council,Southwell Road West,Rainworth,Mansfield,Nottinghamshire               ,England                       ,NG21 0HW,Wider Public Sector,Private Sector Enabler,False
+10004482,Ryton Park School,,Memorial Avenue,,,Worksop,Nottinghamshire               ,England                       ,S80 2BW,Wider Public Sector,School Other,False
+10004476,Quartermaster Proteus T Camp,,Ollerton,,,Newark,Nottinghamshire               ,England                       ,NG22 9DZ,Wider Public Sector,Private Sector Enabler,False
+10004475,Proteus Camp,,Ollerton,,,Newark,Nottinghamshire               ,England                       ,NG22 9DZ,Wider Public Sector,Private Sector Enabler,False
+10004471,People's College Nottingham The,,Maid Marion Way,,,Nottingham,Nottinghamshire               ,England                       ,NG1 6AB,Wider Public Sector,Colleges of Further Education,False
+10004460,Nottingham Open Door Ltd,,Holland House,1 Holland Street,Hyson Street,Nottingham,Nottinghamshire               ,England                       ,NG7 5DS,Wider Public Sector,Private Sector Enabler,False
+10004457,Nottingham High School for Girls,,Arboretum Street,,,Nottingham,Nottinghamshire               ,England                       ,NG1 4JB,Wider Public Sector,Private Sector Enabler,False
+10004449,Nottingham Ambulance Service,,Cowley Street,Basford,,Nottingham,Nottinghamshire               ,England                       ,NG8 2SW,Wider Public Sector,Private Sector Enabler,False
+10004435,Macedon Trust,,13 Pelham Road,,,Nottingham,Nottinghamshire               ,England                       ,NG5 1AP,Wider Public Sector,Private Sector Enabler,False
+10004433,Kings Mill Centre for Health Care Service,,Chestnut House,Mandsfield Road,,Sutton-In-Ashfield,Nottinghamshire               ,England                       ,NG17 4JL,Wider Public Sector,Private Sector Enabler,False
+10004431,Hostels Liaison Group,,21 Clarendon Street,,,Nottingham,Nottinghamshire               ,England                       ,NG1 5HR,Wider Public Sector,Private Sector Enabler,False
+10004426,Health Service,,Leongate,Queens Medical Centre,,Nottingham,Nottinghamshire               ,England                       ,NG17 2UH,Wider Public Sector,Private Sector Enabler,False
+10004425,Guide Association,,Guide Headquarters,16-18 Burton Road,Carlton,Nottingham,Nottinghamshire               ,England                       ,NG4 3DF,Wider Public Sector,Private Sector Enabler,False
+10004424,Government Office for the East Midlands,,The Belgrave Centre,Stanley Place,Talbot Street,Nottingham,Nottinghamshire               ,England                       ,NG1 5GG,Central Government,NDPB,False
+10004418,Dukeries Cheshire Home,,Hospital Rd,,,Retford,Nottinghamshire               ,England                       ,DN22 7BD,Wider Public Sector,Private Sector Enabler,False
+10004417,Driving Standards Agency,,The Axis Building 112 Upper Parliament Street,Nottingham,Nottinghamshire,Nottingham,Nottinghamshire,England,NG1 6LP,Central Government,Executive Agency,False
+10004416,Doncaster Bassetlaw Hospital and Communit,,NHS Trust Headquarters,Barrowby House Highland Grove,,Worksop,Nottinghamshire               ,England                       ,S81 0JN,Wider Public Sector,Private Sector Enabler,False
+10004406,Broxtowe College,,High Road,Chilwell,Beeston,Nottingham,Nottinghamshire               ,England                       ,NG9 4AH,Wider Public Sector,Colleges of Further Education,False
+10004383,WCTA Ltd,,6 Common Place,,,Walsingham,Norfolk                       ,England                       ,NR22 6BW,Wider Public Sector,Private Sector Enabler,False
+10004379,College of West Anglia The,,Tennyson Avenue,Kings Lynn,Norfolk,Kings Lynn,Norfolk,England,PE30 2QW,Wider Public Sector,Colleges of Further Education,False
+10004378,Benjamin Foundation The,,Hall Farm,School Road,,Edingthorpe,Norfolk                       ,England                       ,NR28 9SY,Wider Public Sector,Private Sector Enabler,False
+10004369,Roman Catholic National Shrine,,Pilgrim Bureau,Friday Market,,Walsingham,Norfolk                       ,England                       ,NR22 6EG,Wider Public Sector,Private Sector Enabler,False
+10004358,NPS Property Consultants Ltd,,County Hall,Martineau Lane,,Norwich,Norfolk                       ,England                       ,NR1 2SF,Wider Public Sector,Private Sector Enabler,False
+10004352,Norwich Consolidated Charities,,10 Golden Dog Lane,,,Norwich,Norfolk                       ,England                       ,NR3 1BP,Wider Public Sector,Housing Associations,False
+10004350,Norwich Combined Court,,Bishopgate,,,Norwich,Norfolk                       ,England                       ,NR3 1UR,Wider Public Sector,Private Sector Enabler,False
+10004347,Norwich Arts Trust,,Assembley House,The Theatre Street,,Norwich,Norfolk                       ,England                       ,NR2 1RQ,Wider Public Sector,Private Sector Enabler,False
+10004327,Logistic Support Unit RLC,,building 5 West Tofts Camp,,,Thetford,Norfolk                       ,England                       ,IP26 5EP,Central Government,,False
+10004318,Institute Of Food Research,,Colney La,Colney,,Norwich,Norfolk                       ,England                       ,NR4 7UA,Wider Public Sector,Private Sector Enabler,False
+10004309,Feilden and Mawson Llp,,1 Ferry Road,,,Norwich,Norfolk                       ,England                       ,NR1 1SU,Wider Public Sector,Private Sector Enabler,False
+10004307,Elizabeth Fitzroy Homes Trust,,Maedow Cottage,14HIgh Street,Overstrand,Cromer,Norfolk                       ,England                       ,NR27 0AB,Wider Public Sector,Private Sector Enabler,False
+10004302,Domestic Supply,,50 Fifers La,,,Norwich,Norfolk                       ,England                       ,NR6 6HW,Wider Public Sector,Private Sector Enabler,False
+10004298,Construction Industry Training Board,,Bircham Newton,,,Kings Lynn,Norfolk,England,PE31 6RH,Central Government,Sector Skills Agency,False
+10004286,Anglian Harbours NHS Trust,,Astley Cooper House,Estcourt Road,,Great Yarmouth,Norfolk                       ,England                       ,NR30 4JH,Wider Public Sector,Mental Health Trust,False
+10004285,Circle Housing Group,,Anglia House 6 Central Avenue St Andrews Business Park,Norwich,Norfolk,Norwich,Norfolk,England,NR7 0HR,Wider Public Sector,TBA,False
+10004284,Union of UEA Students,,Union House,University of East Anglia,,Norwich,Norfolk                       ,England                       ,NR4 7TJ,Wider Public Sector,Private Sector Enabler,False
+10004276,Burton Fire Protection,,7 Thatchers Gardens,Burton Latimer,,Kettering,Northamptonshire              ,England                       ,NN15 5LS,Wider Public Sector,Private Sector Enabler,False
+10004275,TURNER DC,,Woodsend Medical Centre,School Place,,Corby,Northamptonshire              ,England                       ,NN18 0QP,Wider Public Sector,Private Sector Enabler,False
+10004273,WILCZYNSKI PJG,,Lakeside Surgery,Cottingham Road,,Corby,Northamptonshire              ,England                       ,nn17 2ur,Wider Public Sector,Private Sector Enabler,False
+10004272,ONEILL JD,,WILLOWBROOK HEALTH CENTRE,COTTINGHAM ROAD,,CORBY,Northamptonshire              ,England                       ,NN17 2UR,Wider Public Sector,Private Sector Enabler,False
+10004269,Willmott Dixon Management,,HMP Wellingborough,Millers Park   Doddington Road,,Wellingborough,Northamptonshire              ,England                       ,NN8 2NH,Wider Public Sector,Private Sector Enabler,False
+10004238,Longhurst Housing Association Limited,,1 Crown Court,Crown Way,,Rushden,Northamptonshire              ,England                       ,NN10 6BS,Wider Public Sector,Housing Associations,False
+10004234,KELSO RD,,The Medical Centre,Link Way,,Towcester,Northamptonshire              ,England                       ,NN12 6HH,Wider Public Sector,Private Sector Enabler,False
+10004232,Hubbard Rex,,25 Rectory Close,Crick,,Northampton,Northamptonshire              ,England                       ,NN6 7SY,Wider Public Sector,Private Sector Enabler,False
+10004228,Harrington Lodge,,5 Harrington Road,Desborough,,Kettering,Northamptonshire              ,England                       ,NN14 2NH,Wider Public Sector,Private Sector Enabler,False
+10004219,Direct Services Daventry District Counci,,Contracts House,High March,,Daventry,Northamptonshire              ,England                       ,NN11 4HB,Wider Public Sector,Private Sector Enabler,False
+10004218,Denton Village Surgery,,Orchard Lane,,Denton,Northampton,Northamptonshire              ,England                       ,NN7 1HT,Wider Public Sector,Private Sector Enabler,False
+10004211,Council for Ethnic Minority Comm Northam,,PO Box 5155,,,Northampton,Northamptonshire              ,England                       ,NN1 3ZQ,Wider Public Sector,Private Sector Enabler,False
+10004208,Care and Repair (Northampton),,7-15 St John's Terrace,,,Northampton,Northamptonshire              ,England                       ,NN1 1HA,Wider Public Sector,Private Sector Enabler,False
+10004191,Humber Bridge Board,,Ferriby Road,Hessle,,Hull,North Humberside              ,England                       ,HU13 0JG,Wider Public Sector,Private Sector Enabler,False
+10004190,Hull City Building Cleaning Services,,West Park,,,Hull,North Humberside              ,England                       ,HU3 6JU,Wider Public Sector,Private Sector Enabler,False
+10004187,HICA Specialised Care Homes,,1 Anchor Court Francis Street,Freetown Way,,Hull,North Humberside              ,England                       ,HU2 8DT,Wider Public Sector,Private Sector Enabler,False
+10004179,Boothferry Borough Council,,Stanhope St,,,Goole,North Humberside              ,England                       ,DN14 5BE,Wider Public Sector,District Council,False
+10004178,B-Line Industries,,460 Beverley Road,,,Hull,North Humberside              ,England                       ,HU5 1NP,Wider Public Sector,Private Sector Enabler,False
+10004159,Wansbeck District Council,WDC,Council Offices,Station Road,,Ashington,Northumberland                ,England                       ,NE63 8RX,Wider Public Sector,District Council,False
+10004149,Northumberland Care Trust,,Merley Croft,Loansdean,,Morpeth,Northumberland                ,England                       ,NE61 2DL,Wider Public Sector,Private Sector Enabler,False
+10004142,New and Renewable Energy Centre,,1st Floor,Eddie Ferguson House,Ridley Street,Blyth,Northumberland                ,England                       ,NE24 3AG,Wider Public Sector,Private Sector Enabler,False
+10004130,Castle Morpeth Borough Council,,Council Offices,The Kylins,Loansdean,Morpeth,Northumberland                ,England                       ,NE61 2EQ,Wider Public Sector,District Council,False
+10004129,Blyth Valley Borough Council,,Civic Centre,Renwick Road,,Blyth,Northumberland                ,England                       ,NE24 2BX,Wider Public Sector,District Council,False
+10004128,Berwick-Upon-Tweed Borough Council,,Council Offices,Wallace Green,,Berwick-Upon-Tweed,,Scotland                      ,TD15 1ED,Wider Public Sector,Local Government,False
+10004124,Alnwick District Council,,Allerburn House,,,Alnwick,Northumberland                ,England                       ,NE66 1YY,Wider Public Sector,District Council,False
+10004117,MOD Defence Housing,,Area 25 Kinloss Farm House,Kinloss,,Forres,Morayshire                    ,Scotland                      ,IV36 3WU,Central Government,,False
+10004105,Vehicle Registration Office,,2nd Floor Connect House,137 Alexander Road,,Wimbledon,,England                       ,SW19 7JY,Wider Public Sector,Private Sector Enabler,False
+10004100,Royal Pharmaceutical Society,,34 York Place,36 York Place,,Edinburgh,Mid Lothian                   ,Scotland                      ,EH1 3HU,Wider Public Sector,Private Sector Enabler,False
+10004099,Royal Commonwealth Pool,,21 Dalkeith Road,,,Edinburgh,Mid Lothian                   ,Scotland                      ,EH16 5BB,Wider Public Sector,Private Sector Enabler,False
+10004096,Northern Research Station,,Bush Est,,,Roslin,Mid Lothian                   ,Scotland                      ,EH25 9SY,Wider Public Sector,Private Sector Enabler,False
+10004093,Motor Licencing Department,,E2 Saughton House,Broomhouse Drive,,Edinburgh,Mid Lothian                   ,Scotland                      ,EH11 3XE,Wider Public Sector,Private Sector Enabler,False
+10004089,Hospital for Small Animals,,Easter Bush,,,Roslin,Mid Lothian                   ,Scotland                      ,EH25 9RG,Wider Public Sector,Private Sector Enabler,False
+10004085,Welsh Blood Service,,Ely Valley Road,Talbot Green,,Pontyclun,Mid Glamorgan                 ,Wales                         ,CF72 9WB,Wider Public Sector,Private Sector Enabler,False
+10004080,South and West Wales Trust Sup Consortium,,Avon Court,Cowbridge Road,,Bridgend,Mid Glamorgan                 ,Wales                         ,CF31 3SR,Wider Public Sector,Private Sector Enabler,False
+10004077,Rest Bay Convalescent Hotel,,Rest Bay,,,Porthcawl,Mid Glamorgan                 ,Wales                         ,CF36 3UP,Wider Public Sector,Private Sector Enabler,False
+10004073,North Glamorgan NHS Trust,,Block 10,Prince Charles Hospital,Upper Thomas Street,Merthyr Tydfil,Mid Glamorgan                 ,Wales                         ,CF47 9DT,Wider Public Sector,Health,False
+10004068,Bro Morgannwg NHS Trust,,Trust Headquarters,71 Quarella Rd,,Bridgend,Mid Glamorgan                 ,Wales                         ,CF31 1YE,Wider Public Sector,Health,False
+10004059,Nat. environ research Council (Bidston),,Proudman Oceanographic Laboratory,Bidston Observatory,,Prenton,Merseyside                    ,England                       ,CH43 7RA,Wider Public Sector,Private Sector Enabler,False
+10004058,YPHA Ltd,,7th Floor,"Wellington Buildings,The Strand",,Liverpool,Merseyside                    ,England                       ,L2 0PP,Wider Public Sector,Private Sector Enabler,False
+10004054,Wirral Society of the Blind,,Ashville Lodge,Ashville Road,,Birkenhead,Merseyside                    ,England                       ,CH41 8AU,Wider Public Sector,Private Sector Enabler,False
+10004048,Wirral Grammar School For Girls,,Heath Road,,,Bebington,Merseyside                    ,England                       ,CH63 3AF,Wider Public Sector,Private Sector Enabler,False
+10004047,Wirral Grammar School For Boys,,Cross Lane,,,Liverpool,Merseyside                    ,England                       ,CH63 3AQ,Wider Public Sector,Private Sector Enabler,False
+10004034,St Thomas Becket,,Longview Drive,Huyton with Roby,,Liverpool,Merseyside                    ,England                       ,L36 6EG,Wider Public Sector,Private Sector Enabler,False
+10004022,Southport and Formby Community Health Service,,The Hesketh Centre,51-55 Albert Road,,Southport,Merseyside                    ,England                       ,PR9 0LT,Wider Public Sector,Private Sector Enabler,False
+10004020,Royal Marine Reserve (Merseyside),,East Brunswick Dock,,,Liverpool,Merseyside                    ,England                       ,L3 4DZ,Wider Public Sector,Private Sector Enabler,False
+10004013,Redbank Community Home,,Winwick Road,,,Newton-Le-Willows,Merseyside                    ,England                       ,WA12 8EA,Wider Public Sector,Private Sector Enabler,False
+10004012,Ravenscroft Rebuild,,Housing Co-Op Ltd,"26 St Andrews View,Tower Hill",,Kirkby,Merseyside                    ,England                       ,L33 1ZF,Wider Public Sector,Private Sector Enabler,False
+10004011,Radio Investigation Service,,Lodge Lane,,,Newton-Le-Willows,Merseyside                    ,England                       ,WA12 0NP,Wider Public Sector,Private Sector Enabler,False
+10004009,Prolog,,Unit 34,Andrews Road,,St Helens,Merseyside                    ,England                       ,WA11 9XY,Wider Public Sector,Private Sector Enabler,False
+10004004,Parr Community High School,,Fleet Lane Parr,,,St Helens,Merseyside                    ,England                       ,WA9 2RT,Wider Public Sector,Private Sector Enabler,False
+10004001,Nugent Care Society,,Kelton Training Centre,Woodlands Road,Woodlands Road,Liverpool,Merseyside                    ,England                       ,L17 0AN,Wider Public Sector,Private Sector Enabler,False
+10003983,Lodge Lane East Co-Op Housing,,97 Lodge Lane,,,Liverpool,Merseyside                    ,England                       ,L8 0QF,Wider Public Sector,Private Sector Enabler,False
+10003980,Liverpool Libraries,,Liverpool Central Library,William Brown Street,,Liverpool,Merseyside                    ,England                       ,L3 8EW,Wider Public Sector,Private Sector Enabler,False
+10003975,Liverpool Diocesan Board of Education,,3rd Floor Church House,1 Hanover Street,,Liverpool,Merseyside                    ,England                       ,L1 3DW,Wider Public Sector,Private Sector Enabler,False
+10003971,Leasowe Trust Limited,,Leasowe Millennium Centre,Twickenham Drive,,Leasowe,Merseyside                    ,England                       ,CH46 1PQ,Wider Public Sector,Private Sector Enabler,False
+10003966,Hoylake Chapel,,39 Ennisdale Drive,,,West Kirby,Merseyside                    ,England                       ,CH48 9UE,Wider Public Sector,Private Sector Enabler,False
+10003962,Halewood CCS Adult Education,,The Avenue,Wood Road,,Halewood,Merseyside                    ,England                       ,L26 1UU,Wider Public Sector,Private Sector Enabler,False
+10003959,Government Office for the North West,GONW,Cunard Building,Pier Head,Water Street,Liverpool,Merseyside                    ,England                       ,L3 1QB,Central Government,NDPB,False
+10003958,Garston Leisure Centre,,Gaston Leisure Centre,Long Lane,Garston,Liverpool,Merseyside                    ,England                       ,L19 6PE,Wider Public Sector,Private Sector Enabler,False
+10003956,English Partnerships,,110 Buckingham Palace Road,Lodge Lane,,London,,England                       ,SW1W 9SA,Central Government,NDPB,False
+10003955,Elderholme Nursing Home,,Clatterbridge Road,,,Bebington,Merseyside                    ,England                       ,CH63 4JY,Wider Public Sector,Private Sector Enabler,False
+10003954,Duldzin Buddhist Centre,,25 Aigburth Drive,,,Liverpool,Merseyside                    ,England                       ,L17 4JH,Wider Public Sector,Private Sector Enabler,False
+10003952,Co-op Schemes for the Elderly Ltd,,19 Devonshire Road,,,Liverpool,Merseyside                    ,England                       ,L8 3TX,Wider Public Sector,Private Sector Enabler,False
+10003949,City Of Liverpool,,Upper Ground Floor,11 Dale Street,,Liverpool,Merseyside                    ,England                       ,L2 2SH,Wider Public Sector,Private Sector Enabler,False
+10003947,Childwall Centre,,156 Childwall Valley Road,,,Liverpool,Merseyside                    ,England                       ,L16 5EA,Wider Public Sector,Private Sector Enabler,False
+10003946,Cheshire Education Services,,Raby Park Rd,,,Neston,Merseyside                    ,England                       ,CH64 9NH,Wider Public Sector,Private Sector Enabler,False
+10003945,CDS (Liverpool) Ltd,,13-15 Rodney Street,,,Liverpool,Merseyside                    ,England                       ,L1 9EF,Wider Public Sector,Private Sector Enabler,False
+10003943,BSML,,33 Brownmoor Lane,Crosby,,Liverpool,Merseyside                    ,England                       ,L23 0TD,Wider Public Sector,Private Sector Enabler,False
+10003941,Bromborough Vehicle Testing Station,,Dock Road South,,,Bromborough,Merseyside                    ,England                       ,L62 4SH,Wider Public Sector,Private Sector Enabler,False
+10003933,Sutton Credit Union Ltd,,36 Junction Lane,Sutton,,St Helens,Merseyside                    ,England                       ,WA9 3JN,Wider Public Sector,Private Sector Enabler,False
+10003932,Offshore Safety Division,,Room 302 Merton House,Stanley Road,,Bootle,Merseyside                    ,England                       ,L20 3DL,Wider Public Sector,Private Sector Enabler,False
+10003931,ROYAL LIVERPOOL CHILDRENS NHS TRUST,,Alder Hey Hospital,Eaton Road,,Liverpool,Merseyside                    ,England                       ,L12 2AP,Wider Public Sector,Acute Trust,False
+10003924,CLEAPSS,,Brunel University,,,Uxbridge,Middlesex                     ,England                       ,UB8 3PH,Wider Public Sector,Private Sector Enabler,False
+10003919,Whitewebbs Museum Of Transport and Industry,,Whitewebbs Rd,,,Enfield,Middlesex                     ,England                       ,EN2 9HW,Wider Public Sector,Private Sector Enabler,False
+10003912,Uuicorn Consultancy Services Ltd,,Cavalary Barracks Building 5  Room 101,Beavers Lane,,Hounslow,Middlesex                     ,England                       ,TW4 6JB,Wider Public Sector,Private Sector Enabler,False
+10003911,Ultra Electronics,,417 Bridport Road,,,Greenford,Middlesex                     ,England                       ,UB6 8UA,Wider Public Sector,Private Sector Enabler,False
+10003910,n-flame Charitable Trust The,,102A Watling Avenue,Burnt Oak,,Edgeware,Middlesex                     ,England                       ,HA8 0LN,Wider Public Sector,Private Sector Enabler,False
+10003908,Tear Fund,,100 Church Rd,,,Teddington,Middlesex                     ,England                       ,TW11 8QE,Wider Public Sector,Private Sector Enabler,False
+10003907,Taylor Woodrow Ltd,,Taywood House,345 Ruislip Road,,Southall,Middlesex                     ,England                       ,UB1 2QX,Wider Public Sector,Private Sector Enabler,False
+10003904,St Luke`s Hospice,,Kenton Grange,Kenton Road,,Harrow,Middlesex                     ,England                       ,HA3 0YG,Wider Public Sector,Private Sector Enabler,False
+10003900,Spelthorne College,,Church Road,,,Ashford,Middlesex                     ,England                       ,TW1S 2X,Wider Public Sector,Colleges of Further Education,False
+10003897,SMC,,Lavender House,P O Box 12,,Enfield,Middlesex                     ,England                       ,EN2 ORS,Wider Public Sector,Private Sector Enabler,False
+10003896,Silverlands Nursing Home,,36-38 Wellington Road,Hatch End,,Pinner,Middlesex                     ,England                       ,HA5 4NW,Wider Public Sector,Private Sector Enabler,False
+10003895,Serco Group Plc,,Dolphin House,Windmill Road,,Sunbury-on-Thames,Middlesex                     ,England                       ,TW16 7HT,Wider Public Sector,Private Sector Enabler,False
+10003892,Royal Military School Of Music,,Knellar Hall,,,Twickenham,Middlesex                     ,England                       ,TW2 7DU,Central Government,Private Sector Enabler,False
+10003891,Royal Air Force,,"268 Bentley Priory,The Common",Prince Sultan Air Base,,Stanmore,Middlesex                     ,England                       ,HA7 3HH,Wider Public Sector,Private Sector Enabler,False
+10003888,Residential Care Home,,46-53 Main Avenue,Bush Hill Park,,Anfield,Middlesex                     ,England                       ,EN1 1DS,Wider Public Sector,Private Sector Enabler,False
+10003883,Pinner House Society Ltd,,Pinner House,Church Lane,,Pinner,Middlesex                     ,England                       ,HA5 3AA,Wider Public Sector,Private Sector Enabler,False
+10003882,Parkside Hotel Services,,Wembley Community Hospital,Fairview Av,,Wembley,Middlesex                     ,England                       ,HA0 4UH,Wider Public Sector,Private Sector Enabler,False
+10003880,Oak Lodge Medical Centre,,234 Burnt Oak Broadway,,,Edgware,Middlesex                     ,England                       ,HA8 0AP,Wider Public Sector,Private Sector Enabler,False
+10003879,Norwood Ravenswood,,80 - 82 The Broadway,,,Stanmore,Middlesex                     ,England                       ,HA7 4HB,Wider Public Sector,Private Sector Enabler,False
+10003876,New Life Bible Church,,1 Graham Road,Wealdstone,,Harrow,Middlesex                     ,England                       ,HA3 5RP,Wider Public Sector,Private Sector Enabler,False
+10003873,National Physical Laboratory,,Building 2 Queens Road,,,Teddington,Middlesex                     ,England                       ,TW11 0LW,Central Government,Private Sector Enabler,False
+10003861,Licensed Victuallers National Homes,,Denham Garden Village,"Denham Green Lane,Denham",,Uxbridge,Middlesex                     ,England                       ,UB9 5LB,Wider Public Sector,Private Sector Enabler,False
+10003859,John Mowlem and Co Plc,,White Lion Court,Swan Street,,Isleworth,Middlesex                     ,England                       ,TW7 6RN,Wider Public Sector,Private Sector Enabler,False
+10003852,Hounslow Homes,,St Catherines House,2 Hanworth Road,,FELTHAM ,Middlesex                     ,England                       ,TW13 5AB,Wider Public Sector,Private Sector Enabler,False
+10003851,Hounslow and Spelthorne Community and Mental,,Flat 3 Thelma Golding Health Centre,92 Bath road,,Hounslow,Middlesex                     ,England                       ,TW3 3EL,Wider Public Sector,Private Sector Enabler,False
+10003844,Hillingdon Action Group,,Old Bank House,64 High Street,,Uxbridge,Middlesex                     ,England                       ,UB8 1JP,Wider Public Sector,Private Sector Enabler,False
+10003840,Harrow Teachers Centre,,Tudor Road,Wealdstone,,Harrow,Middlesex                     ,England                       ,HA3 5PQ,Wider Public Sector,Private Sector Enabler,False
+10003838,Harrow and Hillingdon Health Care NHS Trust,,"Trust Headquarters Malt House,",285 Field End Road,,Eastcote,Middlesex                     ,England                       ,HA9 9NJ,Wider Public Sector,Acute Trust,False
+10003830,Gray Laboratory Cancer Research Trust,,PO BOX 100,Mount Vernon Hospital,,Northwood,Middlesex                     ,England                       ,HA6 2RN,Wider Public Sector,Private Sector Enabler,False
+10003829,G Amar Dass Society,,1a Clifton Road,,,Southall,Middlesex                     ,England                       ,UB2 5QP,Wider Public Sector,Private Sector Enabler,False
+10003826,First Turret Housing Association Ltd,,Premier House,52 London Road,,Twickenham,Middlesex                     ,England                       ,TW1 3RP,Wider Public Sector,Housing Associations,False
+10003816,Ealing Hospital NHS Trust,,Ealing Hospital,Uxbridge Road,,Southall,Middlesex                     ,England                       ,UB1 3HW,Wider Public Sector,Acute Trust,False
+10003810,Dormers Wells Lodge Ltd,,Telford Road,,,Southall,Middlesex                     ,England                       ,UB1 3JQ,Wider Public Sector,Private Sector Enabler,False
+10003808,DGIA,,Elmwood Ave,,,Feltham,Middlesex                     ,England                       ,TW13 7AH,Wider Public Sector,Private Sector Enabler,False
+10003805,Coolspan,,Unit 6j Caxton Trading Estate,Printing House,,Lane Hayes,Middlesex                     ,England                       ,UB3 1AP,Wider Public Sector,Private Sector Enabler,False
+10003804,Consortium of Local Education Authorities for the Provision of Science Services (CLEAPSS),,Brunel University,,,Uxbridge,Middlesex                     ,England                       ,UB8 3PH,Wider Public Sector,Private Sector Enabler,False
+10003803,Compass Group,,Millenium Dome Support Group,Mayfair House Belvue Road,,Northolt,Middlesex                     ,England                       ,UB5 5QJ,Wider Public Sector,Private Sector Enabler,False
+10003802,Colin and Treadway Assciates,,117 Pavilion Way,,,Ruislip,Middlesex                     ,England                       ,HA4 9JL,Wider Public Sector,Private Sector Enabler,False
+10003801,CMSS Skills Development Centre,,Wiltshire Lane,Northwood Hills,,Pinner,Middlesex                     ,England                       ,HA5 2NB,Wider Public Sector,Private Sector Enabler,False
+10003799,CIP Group,,CentreSpace,Treaty Centre,High Street,Hounslow,Middlesex                     ,England                       ,TW3 1ES,Wider Public Sector,Private Sector Enabler,False
+10003796,Chase Community School,,Churchbury Lane,,,Enfield,Middlesex                     ,England                       ,EN1 3HQ,Wider Public Sector,Private Sector Enabler,False
+10003788,BISTD Telecomms,,Status 2,Status Park,Noble Drive,Harlington ,Middlesex                     ,England                       ,UB3 5EY,Wider Public Sector,Private Sector Enabler,False
+10003784,Feltham City Learning Centre,,Browells Lane,,,Feltham,Middlesex                     ,England                       ,TW13 7EF,Wider Public Sector,Private Sector Enabler,False
+10003776,Stevenson College,,Bankhead Avenue,Sighthill,,Edinburgh,Lothian                       ,Scotland                      ,EH11 4DE,Wider Public Sector,Education,False
+10003773,Sheriff Clerk Office,,Council Buildings,23 Court Street,,Haddington,Lothian                       ,Scotland                      ,EH41 3HN,Wider Public Sector,Private Sector Enabler,False
+10003772,Scottish Parliament Office,,Corporate Policy Unit,The Scottish Parliament,375 High Street,Edinburgh,Lothian                       ,Scotland                      ,EH99 1SP,Wider Public Sector,Private Sector Enabler,False
+10003771,Scottish Nuclear,,Torness Power Station,,,Dunbar,Lothian                       ,Scotland                      ,EH42 1QS,Wider Public Sector,Private Sector Enabler,False
+10003770,Scottish Fisheries Protection Agency,,Room 525 Pentland House,47 Robbs Loan,,Edinburgh,Lothian                       ,Scotland                      ,EH14 1TY,Wider Public Sector,,False
+10003767,Royal Military Police,,5 RPM,The Castle,,Edinburgh,Lothian                       ,Scotland                      ,EH1 2YT,Wider Public Sector,Private Sector Enabler,False
+10003764,RMPTS,,5 RPM,The Castle,,Edinburgh,Lothian                       ,Scotland                      ,EH1 2YT,Wider Public Sector,Private Sector Enabler,False
+10003760,National Board for Nursing Midwifery and Health Visiting for Scotland,,22 Queen Street,,,Edinburgh,Lothian                       ,Scotland                      ,EH2 1NT,Wider Public Sector,Private Sector Enabler,False
+10003755,Jewel and Esk Valley College,JEVC,Milton Road Campus,24 Milton Road East,,Edinburgh,Lothian                       ,Scotland                      ,EH15 2PP,Wider Public Sector,Education,False
+10003747,Donaldson Trust,,48 Castle Street,,,Edinburgh,Lothian                       ,Scotland                      ,EH2 3LX,Wider Public Sector,Private Sector Enabler,False
+10003746,DEO,,Army H Q Scotland,Craigiehall,,South Queensferry,Lothian                       ,Scotland                      ,EH30 9TN,Wider Public Sector,Private Sector Enabler,False
+10003744,North East Institute of Further and Higher Education,,Ballymena Campuses,Trostan Avenue Building,,Ballymena,County Londonderry            ,Northern Ireland              ,BT43 7BN,Wider Public Sector,Education,False
+10003743,Magherafelt District Council,,Council Offices 50 Ballyronan Road,Magherafelt,County Londonderry,Magherafelt,County Londonderry,Northern Ireland,BT45 6EN,Wider Public Sector,Local Government,False
+10003741,Limavady Borough Council,,7 Connell Street 7 Connell Street,Limavady,County Londonderry,Limavady,County Londonderry,Northern Ireland,BT49 0HA,Wider Public Sector,Local Government,False
+10003740,G4 Estates (Wsm),,PO Box 15,,,Limavady,County Londonderry            ,Northern Ireland              ,BT49 9FL,Wider Public Sector,Private Sector Enabler,False
+10003735,Causeway Institute of Further and Higher Education,,Union Street,,,Coleraine,County Londonderry            ,Northern Ireland              ,BT52 1QA,Wider Public Sector,Education,False
+10003734,Causeway HSSTrust,,Coleraine Hospital,28a Mountsandel Road,,Coleraine,County Londonderry            ,Northern Ireland              ,BT52 1JA,Wider Public Sector,Private Sector Enabler,False
+10003726,Woodlands Trust,,Autumn Park,,,Grantham,Lincolnshire                  ,England                       ,NG31 9ED,Wider Public Sector,Private Sector Enabler,False
+10003706,South Lincolnshire Community and Mental Health Services,,Orchard House,Rauceby Hospital,,Sleaford,Lincolnshire                  ,England                       ,NG34 8PP,Wider Public Sector,Private Sector Enabler,False
+10003703,Skirbeck Court Home For The Elderly,,Skirbeck Court,55a Spilsby Road,,Boston,Lincolnshire                  ,England                       ,PE21 9NU,Wider Public Sector,Private Sector Enabler,False
+10003701,Rural Villages School Bucknall,,Main Road,Bucknall,,Woodhall Spa,Lincolnshire                  ,England                       ,LN10 5DT,Wider Public Sector,Private Sector Enabler,False
+10003696,NWA Healthcare Trust Stamford and Rutland,,Ryall Road,,,Stamford,Lincolnshire                  ,England                       ,PE9 1UA,Wider Public Sector,Private Sector Enabler,False
+10003679,Leicester Childrens Holiday Centre,,Quebel Road,,,Mablethorpe,Lincolnshire                  ,England                       ,LN12 1QY,Wider Public Sector,Private Sector Enabler,False
+10003670,Heritage Trust Of Lincolnshire,,Cameron St,Heckington,,Sleaford,Lincolnshire                  ,England                       ,NG34 9RW,Wider Public Sector,Private Sector Enabler,False
+10003665,GM Healthcare Limited,,Hotel Services Dept,Cliff Gardens,,Scunthorpe,Lincolnshire                  ,England                       ,DN15 7BH,Wider Public Sector,Private Sector Enabler,False
+10003661,Establishment Works Consultant,,Property Management Office,Raf Waddington,,Lincoln,Lincolnshire                  ,England                       ,LN5 9NB,Wider Public Sector,Private Sector Enabler,False
+10003656,DCRE,,RAF Brize Norton Carterton,,,Oxford,Lincolnshire                  ,England                       ,OX18 3LX,Wider Public Sector,Private Sector Enabler,False
+10003648,Boston Branch Carers UK,,78 Meridian Road,,,Boston,Lincolnshire                  ,England                       ,PE21 0LZ,Wider Public Sector,Private Sector Enabler,False
+10003639,Veterinary Investigation Centre,,College Road,Sutton Bonington,,Loughborough,Leicestershire                ,England                       ,LE12 5RB,Wider Public Sector,Private Sector Enabler,False
+10003636,Time Officer,,38 Tweedside Close,,,Hinckley,Leicestershire                ,England                       ,LE10 1TQ,Wider Public Sector,Private Sector Enabler,False
+10003632,Rutland Sixth Form College,,Barleythorpe Road,,,Oakham,Leicestershire                ,England                       ,LE15 6QH,Wider Public Sector,Colleges of Higher Education,False
+10003625,National Union Of Students,,Ashby Road,,,Loughborough,Leicestershire                ,England                       ,LE11 3TT,Wider Public Sector,Private Sector Enabler,False
+10003614,Lodge Trust,,Spring Close,Market Overton,,Oakham,Leicestershire                ,England                       ,LE15 7PT,Wider Public Sector,Private Sector Enabler,False
+10003597,Hollywell House,,56 Linden Road,,,Hinckley,Leicestershire                ,England                       ,LE10 1HL,Wider Public Sector,Private Sector Enabler,False
+10003593,HM Prison Ashwell,,Ashwell Road,Oakham,,Rutland,Leicestershire                ,England                       ,LE15 7LF,Central Government,,False
+10003585,East Midlands Retirement Homes Ltd,,Memorial Square,,,Coalville,Leicestershire                ,England                       ,LE67 3TU,Wider Public Sector,Private Sector Enabler,False
+10003584,DSU,,4 Newarke Close,,,Leicester,Leicestershire                ,England                       ,SW1P 2BN,Wider Public Sector,Private Sector Enabler,False
+10003583,Demontfort Student Union,,4 Newarke Close,Demontford University Student Union,,Leicester,Leicestershire                ,England                       ,LE2 7BJ,Wider Public Sector,Private Sector Enabler,False
+10003575,Charnwood Community Council,,John Storer House,Wards End,,Loughborough,Leicestershire                ,England                       ,LE11 3HA,Wider Public Sector,Private Sector Enabler,False
+10003573,Care and Repair (West Leicester),,Office A4,Springboard Centre Mantle Lane,,Coalville,Leicestershire                ,England                       ,LE67 3DW,Wider Public Sector,Private Sector Enabler,False
+10003572,Care and Repair (Leicester) Ltd,,166 Evington Road,,,Leicester,Leicestershire                ,England                       ,LE2 1HL,Wider Public Sector,Private Sector Enabler,False
+10003555,Lanarkshire Catering School,,19 High Road,,,Motherwell,Lanarkshire                   ,Scotland                      ,ML1 3HU,Wider Public Sector,Private Sector Enabler,False
+10003544,Woodlands Conference Centre,,Southport Road,,,Chorley,,England                       ,PR7 1QR,Wider Public Sector,Private Sector Enabler,False
+10003524,Veterinary Laboratories Agency,VLA,146A,Woodham Lane,New Haw,Addlestone,,England                       ,KT15 3NB,Central Government,Executive Agency,False
+10003515,Stamp Office The,,1422 The Parsonage,,,Manchester,,England                       ,M60 9BT,Wider Public Sector,Private Sector Enabler,False
+10003511,Strathaven Academy,,Crawford Street,,,Strathaven,Lanarkshire                   ,Scotland                      ,ML10 6AE,Wider Public Sector,Private Sector Enabler,False
+10003510,State Hospital Board for Scotland,,Lampits Road,,,Carstairs,Lanarkshire                   ,Scotland                      ,ML11 8RP,Wider Public Sector,Private Sector Enabler,False
+10003500,St Luke`s Church,,The Vicarage  22 Reedley Road,Reedley,,Burnley,,England                       ,BB10 2LU,Wider Public Sector,Private Sector Enabler,False
+10003494,St Catherines Hospice,,Lostock Lane,Lostock Hall,,Preston,,England                       ,PR5 5XU,Wider Public Sector,Private Sector Enabler,False
+10003492,Springs Tenant Management Co-Op,,55 Dorset Drive,Springs Estate,,Bury,,England                       ,BL9 9DN,Wider Public Sector,Private Sector Enabler,False
+10003484,Selcare (Gtr Manchester) Trust,,14-16 St Mary'S Place,,,Bury,,England                       ,BL9 0DZ,Wider Public Sector,Private Sector Enabler,False
+10003476,Royal Lancaster Infirmary,,Ashton Road,Gressingham Walk,,Lancaster,,England                       ,LA1 4RP,Wider Public Sector,Private Sector Enabler,False
+10003470,Rochdale Infirmary,,Whitehall Street,,,Rochdale,,England                       ,OL12 0NB,Wider Public Sector,Private Sector Enabler,False
+10003469,Rochdale Borough Chamber,,The Old Post Office,The Esplanade,,Rochdale,,England                       ,OL16 1AE,Wider Public Sector,Private Sector Enabler,False
+10003468,RNWS Inskip,,Inskip,,,Preston,,England                       ,PR4 0TN,Wider Public Sector,Private Sector Enabler,False
+10003462,PS Plus,,North West Area Office,Stirling House Ackhurst Business Park,Foxhole Road,Chorley,,England                       ,PR7 1NY,Central Government,NDPB,False
+10003458,Preston Care and Repair Limited,,77/79 Lancastria House,Lancaster Road,,Preston,,England                       ,PR1 2RH,Wider Public Sector,Private Sector Enabler,False
+10003457,Preston Bus Ltd,,Deepdale Rd,,,Preston,,England                       ,PR1 6NY,Wider Public Sector,Private Sector Enabler,False
+10003454,Pontypool Vehicle Testing,,Polo Ground Ind Est,New Inn,,Pontypool,,Wales                         ,NP4 0YN,Wider Public Sector,Private Sector Enabler,False
+10003448,Osd Training Services,,Lancaster Road,,,Preston,,England                       ,PR1 1DD,Wider Public Sector,Private Sector Enabler,False
+10003426,Mid Penine Arts Association,,Yorke Street,,,Burnley,,England                       ,BB11 1HD,Wider Public Sector,Private Sector Enabler,False
+10003423,Manchester Sports and Leisure Centres,,Belle Vue Athletic Centre,Pink Bank Lane,,Manchester,,England                       ,M12 5GL,Wider Public Sector,Private Sector Enabler,False
+10003416,Manchester Diocesan Board of Education,,Church House,90 Deansgate,,Manchester,,England                       ,M3 2GJ,Wider Public Sector,Private Sector Enabler,False
+10003415,Manchester Conference Centre,,Umist,Weston Building,,Manchester,,England                       ,M60 1QD,Wider Public Sector,Private Sector Enabler,False
+10003414,Manchester College of Arts and Technology,,Ashton Old Road,Openshaw,,Manchester,Greater Manchester            ,England                       ,M11 2WH,Wider Public Sector,Colleges of Further Education,False
+10003402,Law Hospital Microbiology,,Main Office,,,Carluke,Lanarkshire                   ,Scotland                      ,ML8 5ER,Wider Public Sector,Private Sector Enabler,False
+10003401,Lancs and Cumbria Est. Management Group,,Technical Support Services,Stone Row Head Quernmore Road,,Lancaster,,England                       ,LA1 3QZ,Wider Public Sector,Private Sector Enabler,False
+10003395,Lancashire Schools IT Centre,,Southport Road,,,Chorley,,England                       ,PR7 1NX,Wider Public Sector,Private Sector Enabler,False
+10003390,Lancashire County Catering Services,,Main Office,,,Preston,,England                       ,PR1 3JY,Wider Public Sector,Private Sector Enabler,False
+10003386,Lancashire CC Property Consultancy,,County Hall,PO Box 26,,Preston,,England                       ,PR1 8RE,Wider Public Sector,Private Sector Enabler,False
+10003378,Kords House Farm Trust,,Wilpshire Road,Rishton,,Blackburn,,England                       ,BB1 4AH,Wider Public Sector,Private Sector Enabler,False
+10003375,Hyndburn Homewise S Ltd,,3 Avenue Parade,,,Accrington,,England                       ,BB5 6PN,Wider Public Sector,Private Sector Enabler,False
+10003373,Horwich Leisure Centre,,Victoria Road,Horwich,,Bolton,,England                       ,BL6 5PY,Wider Public Sector,Private Sector Enabler,False
+10003371,Holcombe Moor Training Centre,,Hawkshaw,,,Bury,,England                       ,BL8 4JJ,Wider Public Sector,Private Sector Enabler,False
+10003367,HM Prison Lancaster Castle,,Castle Hill,,,Lancaster,,England                       ,LA1 1YL,Central Government,,False
+10003355,Hengstler,,Huddersfield Road,Delph,,Oldham,,England                       ,OL3 5DF,Wider Public Sector,Private Sector Enabler,False
+10003353,Hamilton College,,Bothwell Road,,,Hamilton,Lanarkshire                   ,Scotland                      ,ML3 0BB,Wider Public Sector,Education,False
+10003349,Gisburn Park Private Hospital,,Gisburn Park Est,Gisburn,,Clitheroe,,England                       ,BB7 4HX,Wider Public Sector,Private Sector Enabler,False
+10003344,Family Care Associates,,Centurion House Centurion Way,Farington,,Leyland,,England                       ,PR5 2GR,Wider Public Sector,Private Sector Enabler,False
+10003342,Environmental Health,,Town Hall,Broadway,,Accrington,,England                       ,BB5 1LA,Wider Public Sector,Private Sector Enabler,False
+10003340,Eccles College,,Chatsworth Road,Eccles,,Manchester,Greater Manchester            ,England                       ,M30 9FJ,Wider Public Sector,Colleges of Further Education,False
+10003338,East Lancashire UFI HUB,,Saturn Centre,Challenge Way,,Blackburn,,England                       ,BB1 5QB,Wider Public Sector,Private Sector Enabler,False
+10003328,Convent Of Notre Dame,,Lancaster Lane,Parbold,,Wigan,,England                       ,WN8 7HT,Wider Public Sector,Private Sector Enabler,False
+10003327,Community and Priority Services Unit,,Strathclyde Hospital,Airbles Road,,Motherwell,Lanarkshire                   ,Scotland                      ,ML1,Wider Public Sector,Private Sector Enabler,False
+10003324,Clough and Joshi Family Dental Practice,,57 Pickup Street,Clayton-le-Moors,,Accrington,,England                       ,BB5 5NS,Wider Public Sector,Private Sector Enabler,False
+10003321,Chadderton Test Station,,Oldham Broadway,Business Park,,Chadderton,,England                       ,OL9 9XA,Wider Public Sector,Private Sector Enabler,False
+10003317,Carluke Health Centre,,14 Market Place,,,Carluke,Lanarkshire                   ,Scotland                      ,ML8 4BP,Wider Public Sector,Private Sector Enabler,False
+10003315,Capernwray Missionary Fellowship of Torchbearers,,Capernwray Hall,,,Carnforth,,England                       ,LA6 1AG,Wider Public Sector,Private Sector Enabler,False
+10003249,Trinity and Moulding Methodist Churches,,16 Agincourt Street,,,Heywood,,England                       ,OL10 3EY,Wider Public Sector,Private Sector Enabler,False
+10003248,CMN Support Services,,16 Somerset Avenue,,,Hamilton,Lanarkshire                   ,Scotland                      ,ML3 9BS,Wider Public Sector,Private Sector Enabler,False
+10003243,Mid Kent Psychology Service,,Education Office,Kroner House,Eurogate Business Park,Ashford,Kent                          ,England                       ,TN24 8XU,Wider Public Sector,Private Sector Enabler,False
+10003242,Youth Offending Team,,London Borough of Bromley,Civic Centre,Stockwell Close,Bromley,Kent                          ,England                       ,BR1 3UH,Wider Public Sector,Private Sector Enabler,False
+10003241,Police National Search Centre,,Royal School of Military Engineering,Lodge Hill Camp,Chattendon,Rochester,Kent                          ,England                       ,ME3 8NZ,Wider Public Sector,Private Sector Enabler,False
+10003233,White Cliffs Countryside Properties,,1 Centenary Cottages,Langdon Cliffs,,Dover,Kent                          ,England                       ,CT16 1HJ,Wider Public Sector,Private Sector Enabler,False
+10003230,West Kent Shared Services Agency,,4 Abbey Wood Road,Kingshill,,West Malling,Kent                          ,England                       ,ME19 4AB,Wider Public Sector,Private Sector Enabler,False
+10003226,West Kent Area Education Office,,39 Grove Hill Rd,,,Tunbridge Wells,Kent                          ,England                       ,TN1 1SL,Wider Public Sector,Private Sector Enabler,False
+10003224,Warders Medical Centre,,East Street,,,Tonbridge,Kent                          ,England                       ,TN9 1LA,Wider Public Sector,Private Sector Enabler,False
+10003214,Tonbridge Grammar School for Girls,,Deakin Leas,,,Tonbridge,Kent                          ,England                       ,TN9 2JR,Wider Public Sector,Private Sector Enabler,False
+10003211,West Kent Council for Voluntary Service The,,19 Monson Road,,,Tunbridge Wells,Kent                          ,England                       ,TN1 1LS,Wider Public Sector,Private Sector Enabler,False
+10003208,Heart of Kent Hospice The,,Preston Hall,,,Aylesford,Kent                          ,England                       ,ME20 7PU,Wider Public Sector,Private Sector Enabler,False
+10003207,Grammar School for Girls Wilmington The,,Parsons Lane,,,Wilmington,Kent                          ,England                       ,DA2 7BB,Wider Public Sector,Private Sector Enabler,False
+10003200,Thames-Side Building and Safety Consultants,,100 Belmont Road,Northumberland Heath,,Erith,Kent                          ,England                       ,DA8 1LD,Wider Public Sector,Private Sector Enabler,False
+10003198,Territorial Auxiliary and Volunteer Reserve Associations,,25 Windsor Park,28 Alexandra Drive,,Belfast,,Northern Ireland              ,BT9 6FR,Wider Public Sector,Private Sector Enabler,False
+10003197,Telework Asociation,,Langdon Battery,Swingate,,Dover,Kent                          ,England                       ,CT15 5NA,Wider Public Sector,Private Sector Enabler,False
+10003195,Swale Housing Association Limited,,60 Bell Road,,,Sittingbourne,Kent                          ,England                       ,ME10 4HE,Wider Public Sector,Housing Associations,False
+10003191,Strode Park Foundation,,Strode Park House,Lower Herne Rd,,Herne Bay,Kent                          ,England                       ,CT6 7NE,Wider Public Sector,Private Sector Enabler,False
+10003186,St Marys Westbrook,,Ravenlea Road,,,Folkestone,Kent                          ,England                       ,CT20 2JU,Wider Public Sector,Private Sector Enabler,False
+10003184,St Mary The Virgin Church,,Church Street,Minster In Thanet,,Ramsgate,Kent                          ,England                       ,CT12 4BX,Wider Public Sector,Private Sector Enabler,False
+10003183,St Marks Church Parish Office,,The Old Vicarage,,,Gillingham,Kent                          ,England                       ,ME7 5JA,Wider Public Sector,Private Sector Enabler,False
+10003179,St John's RC Comprehensive,,Rochester Road,,,Gravesend,Kent                          ,England                       ,DA12 2JW,Wider Public Sector,Private Sector Enabler,False
+10003174,St Dunstans Church,,Mylen,Waterloo Road,,Cranbrook,Kent                          ,England                       ,TN17 3JJ,Wider Public Sector,Private Sector Enabler,False
+10003173,St Cecilias Cheshire Home,,32 Sundridge Avenue,,,Bromley,Kent                          ,England                       ,BR1 2PZ,Wider Public Sector,Private Sector Enabler,False
+10003167,Sobell Cheshire Home,,Mote Lodge,High Street   Staplehurst,,Tunbridge,Kent                          ,England                       ,TN12 0BJ,Wider Public Sector,Private Sector Enabler,False
+10003166,Sisters of Our Lady of the Missions,,Euphrasie Barbier Residential Home,Staines Hill,,Sturry,Kent                          ,England                       ,CT2 0HP,Wider Public Sector,Private Sector Enabler,False
+10003153,RPS Rainer,,Rectory Lodge,High Street,,Brasted,Kent                          ,England                       ,TN16 1JF,Wider Public Sector,Private Sector Enabler,False
+10003151,Royal London Society For The Blind,,Dorton House,Wilderness Avenue Seal,,Sevenoaks,Kent                          ,England                       ,TH15 0EB,Wider Public Sector,Private Sector Enabler,False
+10003149,Royal British Legion Industries,,Gavin Astor House  Nursing Home,Royal British Legion Village,,Aylesford,Kent                          ,England                       ,ME20 7NF,Wider Public Sector,Private Sector Enabler,False
+10003142,Regeneration Project Management Unit,,PO Box 9,3rd Floor Thanet District Council,,Margate,Kent                          ,England                       ,CT9 1BD,Wider Public Sector,Private Sector Enabler,False
+10003132,Queen Mary's Sidcup NHS Trust (South London Healthcare NHS Trust),,Queen Mary Hospital,Frognal Avenue,KENT,Sidcup,Kent                          ,England                       ,DA14 6LT,Wider Public Sector,Acute Trust,False
+10003127,Property Forum,,Seabourne Way,Dymchurch,,Romney Marsh,Kent                          ,England                       ,TN29 0PX,Wider Public Sector,Private Sector Enabler,False
+10003126,Probation and Bail Hostel,,32 Tunbridge Road,,,Maidstone,Kent                          ,England                       ,ME16 8SH,Wider Public Sector,Private Sector Enabler,False
+10003113,Oldborough Manor Community School,,Boughton Lane,,,Maidstone,Kent                          ,England                       ,ME15 9QL,Wider Public Sector,Private Sector Enabler,False
+10003112,Old Vicarage Residential Home,,The Old Vicarage,Tilmanston,,Nr Deal,Kent                          ,England                       ,CT14 0JG,Wider Public Sector,Private Sector Enabler,False
+10003102,Mortimer Society Ltd,,42 Hollywood Lane,Frindsbury,,Rochester,Kent                          ,England                       ,ME3 8AL,Wider Public Sector,Private Sector Enabler,False
+10003100,MOD DSSD,,Biulding H47,Fort Halstead,,Sevenoaks,Kent                          ,England                       ,TN14 7BP,Central Government,,False
+10003085,Maidstone Day Care Centre,,3 Forsham Cottages,Forsham Lane,,Maidstone,Kent                          ,England                       ,ME17 3EW,Wider Public Sector,Private Sector Enabler,False
+10003083,Maidstone and Malling CMC,,Ascot House,22-24 Albion Place,,Maidstone,Kent                          ,England                       ,ME14 5DZ,Wider Public Sector,Private Sector Enabler,False
+10003075,Little Oyster Residential Home,,Seaside Avenue,Minster,,Sheppey,Kent                          ,England                       ,ME12 2NJ,Wider Public Sector,Private Sector Enabler,False
+10003074,Lions Hospice,,Coldharbour Road,,,Northfleet,Kent                          ,England                       ,DA11 7HQ,Wider Public Sector,Private Sector Enabler,False
+10003072,Learning and Skills Council,,Cheylesmore House,Quinton Road,,Coventry,Warwickshire                  ,England                       ,CV1 2WT,Central Government,NDPB,False
+10003067,Kent Property Services,,Gibson Drive,Kings Hill,,West Malling,Kent                          ,England                       ,ME19 4QG,Wider Public Sector,Private Sector Enabler,False
+10003064,Kent Institute Of Art and Design,,Oakwood Raod,,,Maidstone,Kent                          ,England                       ,ME16 8AG,Wider Public Sector,Private Sector Enabler,False
+10003061,Kent Facilities Management,,Sessions House,County Hall,,Maidstone,Kent                          ,England                       ,ME14 1XQ,Wider Public Sector,Private Sector Enabler,False
+10003058,Kent Community Ht,,Bridgewood House,8 Laker Road,,Rochester,Kent                          ,England                       ,ME1 3QX,Wider Public Sector,Private Sector Enabler,False
+10003052,Kent and Medway Health Informatics Service,,Preston Hall,,,Aylesford,Kent                          ,England                       ,ME20 7NJ,Wider Public Sector,Private Sector Enabler,False
+10003048,Istedd Rise Community Association,,The Community Centre Worcester Close,Istedd Rise,,Gravesend,Kent                          ,England                       ,DA13 9LB,Wider Public Sector,Private Sector Enabler,False
+10003039,Hospice In The Weald,,Allen Gardiner House,Pembury Road,,Tunbridge Wells,Kent                          ,England                       ,TN2 3QU,Wider Public Sector,Private Sector Enabler,False
+10003015,High Hilden,,38 London Road,,,Tonbridge,Kent                          ,England                       ,TN10 3DD,Wider Public Sector,Private Sector Enabler,False
+10003012,Herne Bay Court,,Herne Bay Court,Canterbury Road,,Herne Bay,Kent                          ,England                       ,CT6 5TD,Central Government,NDPB,False
+10003011,Hayes Lane Baptist Church,,16 Murray Avenue,,,Bromley,Kent                          ,England                       ,BR1 3DQ,Wider Public Sector,Private Sector Enabler,False
+10003010,Harenc Preparatory School of Boys,,Church House,167 Rectory Lane,Footscray,Sidcup,Kent                          ,England                       ,DA14 5BU,Wider Public Sector,Private Sector Enabler,False
+10003001,Good Shepherd Sisters,,Cranbrook Road,Cranbrook Road,,Staplehurst,Kent                          ,England                       ,TN12 0ER,Wider Public Sector,Private Sector Enabler,False
+10003000,Godinton House Preservation Trust,,Godinton House,Godinton Park,,Ashford,Kent                          ,England                       ,TN23 3BP,Wider Public Sector,Private Sector Enabler,False
+10002994,FSM (Uk) Ltd,,42 Kingswood Road,42 Kingswood Road,,Bromley,Kent                          ,England                       ,BR2 0NF,Wider Public Sector,Private Sector Enabler,False
+10002990,Folkstone School For Girls,,Coolinge Lane,,,Folkestone,Kent                          ,England                       ,CT20 3RB,Wider Public Sector,Private Sector Enabler,False
+10002986,Employer Direct,,Unicorn House,2nd Floor,28 Elmfield Road,Bromley,Kent                          ,England                       ,BR1 1NX,Wider Public Sector,Private Sector Enabler,False
+10002973,Dorothy Kerin Trust,,Burrswood,Groombridge,,Tumbridge Wells,Kent                          ,England                       ,TN3 9PY,Wider Public Sector,Private Sector Enabler,False
+10002971,Directorate Of Social Services,,Kent County Council,Springfield,,Maidstone,Kent                          ,England                       ,ME14 2LW,Wider Public Sector,Private Sector Enabler,False
+10002970,Directeam,,1 Downham Lane,,,Bromley,Kent                          ,England                       ,BR1 4PQ,Wider Public Sector,Private Sector Enabler,False
+10002969,Direct Services Organisation,,2 Main Road,Sundridge,,Sevenoaks,Kent                          ,England                       ,TN14 6EP,Wider Public Sector,Private Sector Enabler,False
+10002964,Dartford Council for Voluntary Services,,Alzheimers & Dementia Support Services,Enterprise House,8 Essex Road,Dartford,Kent                          ,England                       ,DA1 2AU,Wider Public Sector,Private Sector Enabler,False
+10002961,Crown Court,,Barker Road,,,Maidstone,Kent                          ,England                       ,ME16 8EQ,Central Government,Private Sector Enabler,False
+10002956,Cinque Ports Training Areas HQ,,The Army Training Estate Building 21,HQ CPTA ,Hythe Ranges,Hythe,Kent                          ,England                       ,CT21 6QD,Wider Public Sector,Private Sector Enabler,False
+10002946,CES,,IRSME Regiment,Brompton Barracks,,Chatham,Kent                          ,England                       ,ME14 5NN,Wider Public Sector,Private Sector Enabler,False
+10002939,Calford Seaden,,St Johns House,1A Knoll Rise,,Orpington,Kent                          ,England                       ,BR6 0JX,Wider Public Sector,Private Sector Enabler,False
+10002934,Burnhill Business Centre,,e-Training,50 Burnhill Road,,Beckenham,Kent                          ,England                       ,BR3 3LA,Wider Public Sector,Private Sector Enabler,False
+10002928,Bromley Hospitals NHS Trust,,Trust Headquarters,Farnborough Hospital,Farnborough Common,Orpington,Kent                          ,England                       ,BR6 8ND,Wider Public Sector,Acute Trust,False
+10002927,Bromley Health Authority,,Global House,10 Station Approach Hayes,,Bromley,Kent                          ,England                       ,BR2 7EH,Wider Public Sector,GP Practice,False
+10002895,Ashford Police Training Centre,,Grovenor Hall Cemetary Road,Kennington,,Ashford,Kent                          ,England                       ,TN25 4AJ,Wider Public Sector,Private Sector Enabler,False
+10002893,Angel Leisure Centre,,Angel Lane,,,Tonbridge,Kent                          ,England                       ,TN9 1SF,Wider Public Sector,Private Sector Enabler,False
+10002891,Accommodation Services Account,,"11 Fieldworks Road,",Brompton Barracks,,Gillingham,Kent                          ,England                       ,ME7 5SN,Wider Public Sector,Private Sector Enabler,False
+10002889,220 1st Hq Field Ambulance V,,London Rd,Ditton,,Aylesford,Kent                          ,England                       ,ME20 6DB,Central Government,,False
+10002888,2 Inf Bde and Dover Shorncliffe Gar HQ,,Sir John Moore Barracks,Shorncliffe,,Folkestone,Kent                          ,England                       ,CT20 3HJ,Central Government,,False
+10002887,18 Tpt and Mov Sqn Rlc,,RASC Line,Shorncliffe,,Folkestone,Kent                          ,England                       ,CT20 3EZ,Central Government,,False
+10002881,Medway Adult and Community Learning Service (MACLS,,Gillingham Centre,Green Street,,Gillingham,Kent                          ,England                       ,ME7 5TJ,Wider Public Sector,Private Sector Enabler,False
+10002874,Friends Of Animals League,,Foal Farm,Jail Lane  Biggin Hill,,Biggin Hill,Kent                          ,England                       ,TN16 3AX,Wider Public Sector,Private Sector Enabler,False
+10002871,States of Jersey,,Cyril Le Marquand House,PO Box 140,,St Helier,Jersey                        ,Channel Islands               ,JE4 8QT,Wider Public Sector,,False
+10002870,St Martins School,,La Grande Route de St. Martin,,,St Martin,Jersey                        ,Channel Islands               ,JE3 6HW,Wider Public Sector,School Other,False
+10002869,St Johns Primary School,,La Rue de La Mare Ballam,,,St John,Jersey                        ,Channel Islands               ,JE3 4EJ,Wider Public Sector,Primary Schools,False
+10002868,Rouge Bouillon School,,Brighton Road,,,St Helier,Jersey                        ,Channel Islands               ,JE2 3YN,Wider Public Sector,School Other,False
+10002867,Les Landes School,,Rue Des Cosnets,Millais,,St Oven,,England                       ,JE3 8EL,Wider Public Sector,School Other,False
+10002866,Jersey Telecoms,,Main Office,,,Jersey,Jersey                        ,Channel Islands               ,JE4 8PB,Wider Public Sector,Private Sector Enabler,False
+10002864,Jersey Harbours,,Maritime House,La Route Du Port Elizabeth,,St Helier,Jersey                        ,Channel Islands               ,JE1 1HB,Wider Public Sector,Private Sector Enabler,False
+10002863,Jersey Airport,,Engineering Department,St Peter,,St Peter,Jersey                        ,Channel Islands               ,JE1 1BY,Wider Public Sector,Private Sector Enabler,False
+10002862,Housing Department,,Hilgrove Street,33 Victoria Street,,St.Helier,Jersey                        ,Channel Islands               ,JE4 8XT,Wider Public Sector,Private Sector Enabler,False
+10002861,Highlands College,,Po Box 1000,,,St Saviour,Jersey                        ,Channel Islands               ,JE4 9QA,Wider Public Sector,Education,False
+10002860,Agriculture and Fisheries Department States of Jersey,,PO Box 327,Howard Davis Farm,,St Helier,Jersey                        ,Channel Islands               ,JE4 8UF,Central Government,,False
+10002859,Nobles Hospital,,Westmoreland Road,,,Douglas,Isle of Man                   ,England                       ,IMI 4QA,Wider Public Sector,Health,False
+10002858,Isle of Man Water Authority,,The Drill Hall,,,Tromode,Isle of Man                   ,England                       ,IM2 5PA,Central Government,,False
+10002857,Isle of Man Treasury,,Government Office,Buck's Road,,Douglas,Isle of Man                   ,England                       ,IM1 3PZ,Central Government,,False
+10002856,Isle Of Man Prison Service,,99 Victoria Road,,,Douglas,Isle of Man                   ,England                       ,IM2 4RD,Wider Public Sector,,False
+10002854,Isle Of Man Health Services Board,,Crookall House,Demesne Road,,Douglas,Isle of Man                   ,England                       ,IM1 3QA,Wider Public Sector,GP Practice,False
+10002853,Isle of Man Government,,Information System Division,Treasury,Government Office,Douglas,Isle of Man                   ,England                       ,IM1 3PZ,Wider Public Sector,,False
+10002852,Education Office,,Murray House,5/11 Mount Havelock,,Douglas,Isle of Man                   ,England                       ,IM1 2SG,Wider Public Sector,Private Sector Enabler,False
+10002851,Douglas Corporation,,Po Box 2 Town Hall,Ridgeway Street,,Douglas,Isle of Man                   ,England                       ,IM99 1AD,Wider Public Sector,Private Sector Enabler,False
+10002850,Department Of Local Government And The Environment,,Office Of Architecture,Murry House,Mount Havelock,Douglas,Isle of Man                   ,England                       ,IM1 2SF,Central Government,,False
+10002849,Department of Health and Social Security,,ISDS Chief Executive's Office,Markwell House,Market Street,Douglas,Isle of Man                   ,England                       ,IM1 2RZ,Wider Public Sector,,False
+10002846,Wight Training and Enterprise,,Mill Court,Furrlongs,,Newport,Isle of Wight                 ,England                       ,PO30 2AA,Wider Public Sector,Private Sector Enabler,False
+10002841,UK Sailing Academy,,Artic Road,,,West Cowes,Isle of Wight                 ,England                       ,PO13 7QP,Wider Public Sector,Private Sector Enabler,False
+10002836,Preston Community Partnership,,Barry Lawrence Centre,29 Preston Close,,Ryde,Isle of Wight                 ,England                       ,PO33 1DA,Wider Public Sector,Private Sector Enabler,False
+10002833,League Of Friends Newport (Shropshire),,Day Centre,Upper Bar,,Newport,Isle of Wight                 ,England                       ,TF10 7EH,Wider Public Sector,Private Sector Enabler,False
+10002830,Isle Of Wight NHS Primary Care Trust,,St Marys Hospital,Parkhurst Road,,Newport,Isle of Wight                 ,England                       ,PO30 5TG,Wider Public Sector,PCT - Commissioning,False
+10002809,Harbour Farm Community Housing,,303 Greenwood Avenue,,,Hull,Humberside                    ,England                       ,HU6 9QD,Wider Public Sector,Private Sector Enabler,False
+10002807,Vulcan Naval Reactor Test Establishment,,Dounreay,,,Thurso,Highland                      ,Scotland                      ,KW14 7TY,Wider Public Sector,Private Sector Enabler,False
+10002773,Fire Training Services,,Westbourne House,Roman Road,,Hereford,Herefordshire                 ,England                       ,HR4 9QW,Wider Public Sector,Private Sector Enabler,False
+10002771,Emmaus St Albans,,6 Mardley Wood,,,Welwyn,Herefordshire                 ,England                       ,AL6 0UX,Wider Public Sector,Private Sector Enabler,False
+10002752,WFDS,,4 Chapel Row,Bendish,,Hitchin,Hertfordshire                 ,England                       ,SG4 8JH,Wider Public Sector,Private Sector Enabler,False
+10002743,Watford Grammar School for Boys,,Rickmansworth Road,,,Watford,Hertfordshire                 ,England                       ,WD17 1JF,Wider Public Sector,Private Sector Enabler,False
+10002738,Trestle Theatre Company Ltd,,Trestle Arts Base,Russet Drive,,St Albans,Hertfordshire                 ,England                       ,AL4 0RA,Wider Public Sector,Private Sector Enabler,False
+10002737,Total Logic Systems Ltd,,Pichiobury House,Pishiobury Drive,,Sawbridgeworth,Hertfordshire                 ,England                       ,CM21 0AF,Wider Public Sector,Private Sector Enabler,False
+10002735,Year in Industry The,,Unit 27A,Weltech Centre,Ridgeway,Welywn Garden City ,Hertfordshire                 ,England                       ,AL7 2AA,Wider Public Sector,Private Sector Enabler,False
+10002733,Royal Masonic School for Girls The,,Rickmansworth Park,,,Rickmansworth,Hertfordshire                 ,England                       ,WD3 4HF,Wider Public Sector,Private Sector Enabler,False
+10002721,St Josephs in the Park,,St Marys Lane,,,Hertingfordbury,Hertfordshire                 ,England                       ,SG14 2LX,Wider Public Sector,Private Sector Enabler,False
+10002720,St Elizabeth's Centre,,South End,,,Much Hadham,Hertfordshire                 ,England                       ,SG10 6EW,Wider Public Sector,Private Sector Enabler,False
+10002707,SBC,,Daneshill House,Danestrete,,Stevenage,Hertfordshire                 ,England                       ,SG1 1NH,Wider Public Sector,Private Sector Enabler,False
+10002702,Riversmead House Association,,36 Ware Road,,,Hertford,Hertfordshire                 ,England                       ,SG13 7HH,Wider Public Sector,Private Sector Enabler,False
+10002699,Reach Out Projects,,Holywell Lodge,41 Holywell Hill,,St Albans,Hertfordshire                 ,England                       ,AL7 4PJ,Wider Public Sector,Private Sector Enabler,False
+10002674,Life Opportunities Trust,,S Snng Oak Business Centre,Lye Lane Brickett Wood,,St Albans,Hertfordshire                 ,England                       ,AL2 2UG,Wider Public Sector,Private Sector Enabler,False
+10002673,Leyden House Day Centre,,Leyden Road,,,Stevenage,Hertfordshire                 ,England                       ,SG1 2BP,Wider Public Sector,Private Sector Enabler,False
+10002670,Kytes Trust,,Kytes House,"Kytes Estate,Garston",,Watford,Hertfordshire                 ,England                       ,WD2 6NT,Wider Public Sector,Private Sector Enabler,False
+10002668,International Society For Krishna Consciousness,,Hilfield Lane,Aldenham,,Watford,Hertfordshire                 ,England                       ,WD2 8EZ,Wider Public Sector,Private Sector Enabler,False
+10002667,Interface Europe Ltd,,Ashlyns Hall,Chesham Road,,Berkhamstead,Hertfordshire                 ,England                       ,HP4 2ST,Wider Public Sector,Private Sector Enabler,False
+10002662,Howard Cottage Society Ltd,,48 Station Road,,,Letchworth,Hertfordshire                 ,England                       ,SG6 3BE,Wider Public Sector,Private Sector Enabler,False
+10002657,Hertfordshire Private Hospitals,,Midway Surgery,93 Watford Road,,St. Albans,Hertfordshire                 ,England                       ,AL2 3JX,Wider Public Sector,Private Sector Enabler,False
+10002644,Hatfield Swim Centre,,Lemsford Rd,,,Hatfield,Hertfordshire                 ,England                       ,AL10 0EB,Wider Public Sector,Private Sector Enabler,False
+10002642,Haden Young Ltd,,44 Clarendon Road,,,Watford,Hertfordshire                 ,England                       ,WD17 1DR,Wider Public Sector,Private Sector Enabler,False
+10002639,Gascoyne Cecil Estates,,Hatfield Park Estate Office,Hatfield Park,,Hatfield,Hertfordshire                 ,England                       ,AL9 5NQ,Wider Public Sector,Private Sector Enabler,False
+10002638,Garden City Homes Ltd,,Weltech Centre,Ridgeway,,Welwyn Garden City,Hertfordshire                 ,England                       ,AL7 2AA,Wider Public Sector,Private Sector Enabler,False
+10002637,G T Railway Maintenance Ltd,,Clarendon Road,,,Watford,Hertfordshire                 ,England                       ,WD1 1DP,Wider Public Sector,Private Sector Enabler,False
+10002634,Form Fittings,,12 Oakfields Avenue,,,Knebworth,Hertfordshire                 ,England                       ,SG3 6NP,Wider Public Sector,Private Sector Enabler,False
+10002631,Fira International,,Maxwell Rd,,,Stevenage,Hertfordshire                 ,England                       ,SG1 2EW,Wider Public Sector,Private Sector Enabler,False
+10002625,Employment Services Agency,,4th Floor Companies House Crown Way,Maindy,17-21 Furnival Gate,Cardiff,,Wales                         ,CF4 3UW,Wider Public Sector,Private Sector Enabler,False
+10002624,Eleanor Palmer Trust,,106B Wood Street,,,Barnet,Hertfordshire                 ,England                       ,EN5 4BY,Wider Public Sector,Private Sector Enabler,False
+10002623,East of England Fire Authorities,,5 Patmore Close,,,Bishops Stortford,Hertfordshire                 ,England                       ,CM23 2PY,Wider Public Sector,Fire and Rescue Authority,False
+10002616,Crusaders Union,,2 Romeland Hill,,,St  Albans,Hertfordshire                 ,England                       ,ALB 4ET,Wider Public Sector,Private Sector Enabler,False
+10002615,CPP,,Heather Lane,,,Watford,Hertfordshire                 ,England                       ,WD2 6JD,Wider Public Sector,Private Sector Enabler,False
+10002612,Civic Centre,,Marlowes,,,Hemel Hempstead,Hertfordshire                 ,England                       ,HP1 1HH,Wider Public Sector,Private Sector Enabler,False
+10002569,WRMM,,Wardroom Mess,HMS Dolphin,,Gosport,Hampshire                     ,England                       ,PO12 2AB,Wider Public Sector,Private Sector Enabler,False
+10002566,Winchester Family Church,,Stanmore Lane,,,Winchester,Hampshire                     ,England                       ,SO22 4BT,Wider Public Sector,Private Sector Enabler,False
+10002562,Winchester Churches (Keystone) Ltd,,57 Romsey Road,,,Winchester,Hampshire                     ,England                       ,SO22 5DE,Wider Public Sector,Private Sector Enabler,False
+10002561,Winchester Cathedral,,The Visitors Centre,The Close,,Winchester,Hampshire                     ,England                       ,SO23 9LS,Wider Public Sector,Private Sector Enabler,False
+10002559,Wilverley Association,,Forest Oaks,The Rise,,Brockenhurst,Hampshire                     ,England                       ,SO42 7SJ,Wider Public Sector,Private Sector Enabler,False
+10002554,Wessex Property Services,,31-32 Parham Drive,Boyatt Wood,,Eastleigh,Hampshire                     ,England                       ,SO50 4NU,Wider Public Sector,Private Sector Enabler,False
+10002549,Tid Det Asu Rlc,,Tidworth Detachment,Aes Nadder Road,,Tidworth,Hampshire                     ,England                       ,SP9 7QA,Wider Public Sector,Private Sector Enabler,False
+10002548,Thorngate Almshouse Trust,,Administration Office,Clare House,Melrose Gardens,Gosport,Hampshire                     ,England                       ,PO12 3BZ,Wider Public Sector,Private Sector Enabler,False
+10002541,Elms Dental Practise The,,29 Elms Avenue,,,New Milton,Hampshire                     ,England                       ,BH25 6HE,Wider Public Sector,Private Sector Enabler,False
+10002536,T Colquhoun,,HMS Colingswood,Newgate Lane,,Fareham,Hampshire                     ,England                       ,PO14 1AS,Wider Public Sector,Private Sector Enabler,False
+10002532,Sports Trust,,Basingstoke Sports Centre,,,Basingstoke,Hampshire                     ,England                       ,RG21 7LE,Wider Public Sector,Private Sector Enabler,False
+10002527,Southampton Community Trust,,Lymington Hospital,Southampton Road,,Lymington,Hampshire                     ,England                       ,S041 9ZH,Wider Public Sector,Private Sector Enabler,False
+10002520,Solent Station Headquarters,,McMullen Barracks,Marchwood,,Southampton,Hampshire                     ,England                       ,SO40 4ZG,Wider Public Sector,Private Sector Enabler,False
+10002516,Sentinel Housing Group,,56 Kingsclere Road,Basingstoke,Hampshire,Basingstoke,Hampshire,England,RG21 6XG,Wider Public Sector,Housing Associations,False
+10002514,SDB Trustees,,Salesian College 119 Reading Road,,,Farnborough,Hampshire                     ,England                       ,GU14 6PA,Wider Public Sector,Private Sector Enabler,False
+10002513,School of Nursing and Midwifery,,Level B (11) South Block,Tremona Road,,Southampton,Hampshire                     ,England                       ,SO16 6YD,Wider Public Sector,Private Sector Enabler,False
+10002510,SCA Community Care Services,,Amplevine House,Dukes Road,,Southampton,Hampshire                     ,England                       ,SO14 0ST,Wider Public Sector,Private Sector Enabler,False
+10002502,Royal Army Pay Corps Depot and HQ,,"Bldg 158,Worthy Down",Worthy Down,,Winchester,Hampshire                     ,England                       ,SO21 2RG,Central Government,Army,False
+10002496,Reigate Pilgrims Trust,,c/o 19 Hilltop Road,,,Havant,Hampshire                     ,England                       ,RH2 7AL,Wider Public Sector,Private Sector Enabler,False
+10002494,Rainey Petrie Johns Ltd,,5 Cranbury Place,,,Southampton,Hampshire                     ,England                       ,SO14 0LG,Wider Public Sector,Private Sector Enabler,False
+10002493,Rah H Co-Op Ltd,,Unit 409,Victory Business Centre,Fratton,Portsmouth,Hampshire                     ,England                       ,PO1 1PJ,Wider Public Sector,Private Sector Enabler,False
+10002490,R&Ls (S) HQ,,Parsons House,Ordnance Road,,Aldershot,Hampshire                     ,England                       ,GU11 2AE,Wider Public Sector,Private Sector Enabler,False
+10002488,QMs Dept,,Fox Lines,Queens Avenue,,Aldershot,Hampshire                     ,England                       ,GU11 2LB,Wider Public Sector,Private Sector Enabler,False
+10002486,Power Station Complex,,Alison Road,Aldershot Garrison,,Aldershot,Hampshire                     ,England                       ,GU11 2BD,Wider Public Sector,Private Sector Enabler,False
+10002480,Portsmouth Diocesan Board Of Education,,Education Office,Cathedral House,,Portsmouth,Hampshire                     ,England                       ,PO1 2HA,Wider Public Sector,Private Sector Enabler,False
+10002477,Portsmouth and South East Hampshire Health Authroity,,Finchdean House,Milton Road,,Portsmouth,Hampshire                     ,England                       ,PO3 6DP,Wider Public Sector,GP Practice,False
+10002471,Parish Of Swaythling,,The Vicarage,357 Burgess Road,,Southampton,Hampshire                     ,England                       ,SO16 3BD,Wider Public Sector,Private Sector Enabler,False
+10002469,Offices Svcs Hq Qmg,,Building 300 DLO Andover,Monxton Road,,Andover,Hampshire                     ,England                       ,SP11 8HT,Wider Public Sector,Private Sector Enabler,False
+10002465,North Hampshire Loddon Community NHS Tru,,Community NHS Trust,Clock Tower House,Park Prewett,Basingstoke,Hampshire                     ,England                       ,RG24 9LZ,Wider Public Sector,Acute Trust,False
+10002464,Basingstoke and North Hampshire NHS Foundation Trust,,Aldermaston Road,,,Basingstoke,Hampshire                     ,England                       ,RG24 9NA,Wider Public Sector,Acute Trust,False
+10002456,MOD Tri Service Married Quarters,,Furniture Store  Royal Clarence Yard,Weevil Lane,,Gosport,Hampshire                     ,England                       ,PO12 1AY,Central Government,,False
+10002453,Ministry of Defence DLO Andover,,Building 300/2 Monxton Road,Andover,Hampshire,Andover,Hampshire,England,SP11 8HT,Central Government,MoD - Army,False
+10002435,IR Portsmouth Maritime,,316 Commercial Rd,,,Portsmouth,Hampshire                     ,England                       ,PO1 4TF,Wider Public Sector,Private Sector Enabler,False
+10002434,Independent Schools Bursars Association,,5 Chapel Close,Old Basing,,Basingstoke,Hampshire                     ,England                       ,RG24 7BZ,Wider Public Sector,Private Sector Enabler,False
+10002429,HMS Victory,,HM Navel Base,,,Portsmouth,Hampshire                     ,England                       ,PO1 3PZ,Central Government,Navy,False
+10002418,HM Detention Centre,,2 Dolphin Way,,,Gosport,Hampshire                     ,England                       ,PO12 2AW,Central Government,Private Sector Enabler,False
+10002414,Headquartermasters Quartermaster General,,Building 208,HQ Quartermaster General,,Andover,Hampshire                     ,England                       ,SP11 8HT,Wider Public Sector,Private Sector Enabler,False
+10002411,Havant Community Comprehensive School,,21 East Street,,,Havant,Hampshire                     ,England                       ,PO9 1AA,Wider Public Sector,Private Sector Enabler,False
+10002395,Guildhall Entertainments Management,,Guildhall Square,,,Portsmouth,Hampshire                     ,England                       ,PO1 2AB,Wider Public Sector,Private Sector Enabler,False
+10002389,Fort Blockhouse,,Main Office,,,Gosport,Hampshire                     ,England                       ,PO12 2AB,Wider Public Sector,Private Sector Enabler,False
+10002388,FMRO East Office Block,,Postal Point 81,HM Naval Base,,Portsmouth,Hampshire                     ,England                       ,PO1 3NJ,Wider Public Sector,Private Sector Enabler,False
+10002387,Fleet Methodist Church,,Reading Road South,,,Fleet,Hampshire                     ,England                       ,GU51 4LR,Wider Public Sector,Private Sector Enabler,False
+10002386,Flat Officer Surface Flotilla,,"301,2-6 The Parade",H M Naval Base,,Portsmouth,Hampshire                     ,England                       ,PO1 3NB,Wider Public Sector,Private Sector Enabler,False
+10002380,Estates and Engineering Services Organisat,,HM Navel Base,Murrays Lane,,Portsmouth,Hampshire                     ,England                       ,PO1 3L7,Wider Public Sector,Private Sector Enabler,False
+10002378,Enham Trust,,Cedar Park,Enham Alamein,,Andover,Hampshire                     ,England                       ,SP11 6HQ,Wider Public Sector,Private Sector Enabler,False
+10002377,Ektha Unity Housing Association Ltd,,C/O Fratton Community Centre,"Trafalgar Place,Fratton",,Portsmouth,Hampshire                     ,England                       ,PO1 5JJ,Wider Public Sector,Housing Associations,False
+10002371,DSSD,,170 Highstock,Dera,,Farnborough,Hampshire                     ,England                       ,GU14 0LX,Wider Public Sector,Private Sector Enabler,False
+10002369,DM Gosport,,F269 Building,Fareham Road,,Gosport,Hampshire                     ,England                       ,PO13 OAH,Wider Public Sector,Private Sector Enabler,False
+10002364,Defence Evaluation Research Agency,,Air Accidents Investigation Branch,Grd/G5 T75 DERA,,Farnborough,Hampshire                     ,England                       ,GU14 6TD,Central Government,Executive Agency,False
+10002362,DARA Fleetlands,,Eshstablishment Property Office,PP 34 Gosport,,Gosport,Hampshire                     ,England                       ,PO13 0AA,Central Government,Private Sector Enabler,False
+10002361,Cssg (Uk) HQ,,Buller Bks,,,Aldershot,Hampshire                     ,England                       ,GU16 6BB,Wider Public Sector,Private Sector Enabler,False
+10002359,Crestwood Community School,,Shakespeare Road,,,Eastleigh,Hampshire                     ,England                       ,SO50 4FZ,Wider Public Sector,Private Sector Enabler,False
+10002356,Comrfa,,Ivy Lane,H Mid Naval Base,,Portsmouth,Hampshire                     ,England                       ,PO1 3NH,Wider Public Sector,Private Sector Enabler,False
+10002355,Church Of England Soldiers',,1 Shakespeare Terrace,126 High Street,,Portsmouth,Hampshire                     ,England                       ,PO1 2RH,Wider Public Sector,Private Sector Enabler,False
+10002354,Chithurst Buddist Monastery,,Chithurst,,,Petersfield,Hampshire                     ,England                       ,GU31 5EU,Wider Public Sector,Private Sector Enabler,False
+10002348,Career Transition Partnership,,Gallwey Road,,,Aldershot,Hampshire                     ,England                       ,GU11 2DG,Wider Public Sector,Private Sector Enabler,False
+10002333,Baker FM,,Winchester House,19-23 Winchester Street,,Basingstoke,Hampshire                     ,England                       ,RG21 7EE,Wider Public Sector,Private Sector Enabler,False
+10002331,ASU,,Aes,Nadder Rd,,Tidworth,Hampshire                     ,England                       ,SP9 7QA,Wider Public Sector,Private Sector Enabler,False
+10002328,Army School of Catering,,RLC OFSD,St Omer Barracks,,Aldershot,Hampshire                     ,England                       ,GU11 2BN,Central Government,Army,False
+10002325,Andover Support Unit,,"Building 308 (Accn Stores) ,HQ QMG",Monxton Road,,Andover,Hampshire                     ,England                       ,SP11,Wider Public Sector,Private Sector Enabler,False
+10002313,Hampshire and Isle of Wight Practioner and Patient  Services Agency,,Coitbury House,Friarsgate,,WInchester,Hampshire                     ,England                       ,SO23 8EE,Wider Public Sector,Private Sector Enabler,False
+10002309,City of Coventry,,Plas Dol-y-Moch Outdoor Education Centre,Maentwrog,,Blaneau Ffestiniog,Gwynedd                       ,Wales                         ,LL41 3YT,Wider Public Sector,Private Sector Enabler,False
+10002308,Ysgol Edern,,Lon Rhos,Edern,,Pwllheli,Gwynedd                       ,Wales                         ,LL53 8YW,Wider Public Sector,Education,False
+10002307,Ysgol Duffryn Ogwen,,Coetmor Road,,,Bethesda,Gwynedd                       ,Wales                         ,LL57 3NN,Wider Public Sector,Education,False
+10002306,Ysgol Ardudwy,,Ffordd Y Traeth,,,Harlech,Gwynedd                       ,Wales                         ,LL46 2UH,Wider Public Sector,Education,False
+10002304,University of Wales Bangor,,College Road,,,Bangor,Gwynedd                       ,Wales                         ,LL57 2DG,Wider Public Sector,Education,False
+10002303,Tai Eryri,,Llanllyfni Rd,Penygroes,,Caernarfon,Gwynedd                       ,Wales                         ,LL54 6LY,Wider Public Sector,Private Sector Enabler,False
+10002300,Pen-Y-Pass Youth Hostel,,Nantgwynant,,,Caernarfon,Gwynedd                       ,Wales                         ,LL55 4NY,Wider Public Sector,Private Sector Enabler,False
+10002295,Croeso Welcome Bangor,,University of Wales Bangor,Bryn Haul,Victoria Drive,Bangor,Gwynedd                       ,Wales                         ,LL57 2EN,Wider Public Sector,Private Sector Enabler,False
+10002294,Coleg Menai,,Ffriddoedd Road,,,Bangor,Gwynedd                       ,Wales                         ,LL57 2TP,Wider Public Sector,Private Sector Enabler,False
+10002293,Coleg Meirion - Dwyfor,,Penrallt,,,Pwllheli,Gwynedd                       ,Wales                         ,LL53 5UB,Wider Public Sector,Private Sector Enabler,False
+10002291,Bryn Gwynant Youth Hostel,,Nant Gwynant,,,Caernarfon,Gwynedd                       ,Wales                         ,LL35 4NE,Wider Public Sector,Private Sector Enabler,False
+10002286,TFM Wales,,7th Floor Sovereign House,1 Kingsway,,Newport,Gwent                         ,Wales                         ,NP9 1WR,Wider Public Sector,Private Sector Enabler,False
+10002285,South Wales Ironmongers,,28-32 Victoria Street,,,Cwmbran,Gwent                         ,Wales                         ,NP44 3JN,Wider Public Sector,Private Sector Enabler,False
+10002283,QMs Dept 1rwf,,Beachley Barracks,,,Chepstow,Gwent                         ,Wales                         ,NP6 7YJ,Central Government,Army,False
+10002282,QM's Department,,1rwf Beachley Barracks,,,Chepstow,Gwent                         ,Wales                         ,NP6 7YG,Wider Public Sector,Private Sector Enabler,False
+10002279,Oakdale Comprehensive,,Oakdale,,,Blackwood,Gwent                         ,Wales                         ,NP12 0DT,Wider Public Sector,Private Sector Enabler,False
+10002273,Gwent Police Training Centre,,Greenmeadow Way,Greanmeadow,,Cwmbran,Gwent                         ,Wales                         ,NP44 3XA,Wider Public Sector,Private Sector Enabler,False
+10002263,Careers Wales Gwent,,Ty Glyn,Albion Road,,Pontypool,Gwent                         ,Wales                         ,NP4 6GE,Wider Public Sector,Private Sector Enabler,False
+10002261,States of Guernsey Education Council,,Grange Road,The Grange,St Peterfort,Guernsey,Guernsey                      ,Channel Islands               ,GY1 1RQ,Wider Public Sector,,False
+10002260,States of Guernsey Fire and Rescue Service,,Town Arsenal,,,St Peter Port,Guernsey                      ,Channel Islands               ,GY1 1UW,Wider Public Sector,Fire and Rescue Services,False
+10002259,States of Guernsey Board of Health,,Princess Elizabeth Hospital,Le Vauquiedor,,St Martins,Guernsey                      ,Channel Islands               ,GY4 6UU,Wider Public Sector,Private Sector Enabler,False
+10002258,States of Guernsey,,Sir Charles Frossard House,P.O. Box 43,La Charroterie,St Peter Port,Guernsey                      ,Channel Islands               ,GY1 1FH,Wider Public Sector,,False
+10002257,Mignot Memorial Hospital,,Route De Crabby,Alderney,,Guernsey,Guernsey                      ,Channel Islands               ,GY9 3XY,Wider Public Sector,GP Practice,False
+10002256,Les Beauchamps School,,School Office,,,St Martins,Guernsey                      ,Channel Islands               ,GY15 7DS,Wider Public Sector,School Other,False
+10002255,Guernsey Social Security Authority,,Edward T Wheadon House,Le Truchot,,St Peter Port,Guernsey                      ,Channel Islands               ,GY1 3WH,Wider Public Sector,,False
+10002254,RAF Buchan,,Main Office,,,Peterhead,Grampian                      ,Scotland                      ,AB4 7AR,Central Government,RAF,False
+10002252,Beis Soroh Schenierer Seminary,,474 Bury New Road,Salford,,Manchester,Greater Manchester            ,England                       ,M7 4NU,Wider Public Sector,Private Sector Enabler,False
+10002237,Pendleton College,,Dronfield Road,,,Salford,Greater Manchester            ,England                       ,M6 7FR,Wider Public Sector,Colleges of Further Education,False
+10002234,North Trafford College of Further Education,,Talbot Road Centre,Talbot Road,Stretford,Manchester,Greater Manchester            ,England                       ,M32 0XH,Wider Public Sector,Colleges of Further Education,False
+10002226,Eba Management Services Ltd,,Apex House,"266 Moseley Road,Levenshulme",,Manchester,Greater Manchester            ,England                       ,M19 2LH,Wider Public Sector,Private Sector Enabler,False
+10002225,Commercial Library,,"Manchester Central Library,",St Peter's Square,,Manchester,Greater Manchester            ,England                       ,M2 5PD,Wider Public Sector,Private Sector Enabler,False
+10002224,Collingwood Housing Association Ltd,,1 Outram House,Piccadilly Village,Great Ancoats Street,Manchester,Greater Manchester            ,England                       ,M4 7AA,Wider Public Sector,Housing Associations,False
+10002205,Command Scientific Support Branch,,CSSB,HQ PTC,RAF Innsworth,Gloucester,Gloucestershire               ,England                       ,GL3 1EZ,Wider Public Sector,Private Sector Enabler,False
+10002200,Winchcombe Youth and Community Centre,,8 Gretton Road,Winchcombe,,Cheltenham,Gloucestershire               ,England                       ,GL54 5EE,Wider Public Sector,Private Sector Enabler,False
+10002192,Tudor Lodge Self Build Co-Op Ltd,,42 Penhill Road,Matson,,Gloucester,Gloucestershire               ,England                       ,GL4 6AD,Wider Public Sector,Private Sector Enabler,False
+10002187,Stroud Museums Collection,,Units 26 & 28,Oldends Lane Industrial Estate,Stonedale,Stonehouse,Gloucestershire               ,England                       ,GL10,Wider Public Sector,Private Sector Enabler,False
+10002185,Stroud District Museum,,Lansdown,,,Stroud,Gloucestershire               ,England                       ,GL5 1DB,Wider Public Sector,Private Sector Enabler,False
+10002183,Stroud Court Community Trust,,Stroud Court,Longfords,Minchinhampton,Stroud,Gloucestershire               ,England                       ,GL6 9AN,Wider Public Sector,Private Sector Enabler,False
+10002180,St Lawrence's Hospital Charity,,Cirencester Park,,,Cirencester,Gloucestershire               ,England                       ,GL7 2BU,Wider Public Sector,Private Sector Enabler,False
+10002173,Royal Air Force Benevolent Fund,,Building 15,RAF Fairford,,Fairford,Gloucestershire               ,England                       ,GL7 4DL,Wider Public Sector,Private Sector Enabler,False
+10002166,Paradise Community,,Paradise House,,,Painswick,Gloucestershire               ,England                       ,GL6 6TN,Wider Public Sector,Private Sector Enabler,False
+10002163,Nazareth House,,London Road,Charlton Kings,,Cheltenham,Gloucestershire               ,England                       ,GL52 6YJ,Wider Public Sector,Private Sector Enabler,False
+10002159,MJN,,"Hanger 65,Duke Of Gloucester Barracks","29 Regiment,South Cerney",,Cirencester,Gloucestershire               ,England                       ,GL7 5PW,Wider Public Sector,Private Sector Enabler,False
+10002154,Lilian Faithfull house,,Norcroft House,Malvern Road,,Cheltenham,Gloucestershire               ,England                       ,GL50 2NH,Wider Public Sector,Private Sector Enabler,False
+10002153,LC Trading,,Quedgeley,,,Gloucester,Gloucestershire               ,England                       ,GL,Wider Public Sector,Private Sector Enabler,False
+10002151,Kelmscott Manor,,Kelmscott,,,Nr Lechlade,Gloucestershire               ,England                       ,GL7 3HJ,Wider Public Sector,Private Sector Enabler,False
+10002143,Grosvenor Youth and Community Centre,,Grosvenor Street,,,Cheltenham,Gloucestershire               ,England                       ,GL52 2SG,Wider Public Sector,Private Sector Enabler,False
+10002139,Gloucestershire Procurement Shared Service,,Victoria Warehouse,The Docks,,Gloucester,Gloucestershire               ,England                       ,GL1 2EL,Wider Public Sector,Private Sector Enabler,False
+10002130,Gloucestershire Care Homes,,Guild House,Denmark Road,,Gloucester,Gloucestershire               ,England                       ,GL1 3HW,Wider Public Sector,Private Sector Enabler,False
+10002120,Emmaus Gloucestershire,,201 Barnwood Road,The Reddings,,Gloucester,Gloucestershire               ,England                       ,GL4 3HP,Wider Public Sector,Private Sector Enabler,False
+10002119,DSDC Ashchurch,DSDA,Ministry of Defence,Ashchurch,,Tewkesbury,Gloucestershire               ,England                       ,GL20 8LZ,Central Government,Army,False
+10002118,Dene Magna Community School,,Abenhall Road,,,Mitcheldean,Gloucestershire               ,England                       ,GL17 0DU,Wider Public Sector,Private Sector Enabler,False
+10002117,Cotswold Vale Crime Prevention,,18 Hentley Tor,,,Wotton Under Edge,Gloucestershire               ,England                       ,GL12 7LE,Wider Public Sector,Private Sector Enabler,False
+10002113,Colonnade Care Ltd,,Cleeve Hill,,,Cheltenham,Gloucestershire               ,England                       ,GL52 3PZ,Wider Public Sector,Private Sector Enabler,False
+10002108,Church Of England Pensions Board,,Capel Ct; The Burgage,Prestbury,,Cheltenham,Gloucestershire               ,England                       ,GL52 3EL,Wider Public Sector,Private Sector Enabler,False
+10002106,Cheltenham Ladies College,,Bayshill Court,Parabola Road,,Cheltenham,Gloucestershire               ,England                       ,GL50 2AH,Wider Public Sector,Private Sector Enabler,False
+10002104,Cheltenham Community Projects,,Grove Street,,,Cheltenham,Gloucestershire               ,England                       ,GL50 3LZ,Wider Public Sector,Private Sector Enabler,False
+10002103,Cheltenham College,,Bath Road,,,Cheltenham,Gloucestershire               ,England                       ,GL53 7LD,Wider Public Sector,Colleges other,False
+10002097,CESG,,Room 10/4W26 GCHQ,Benhall,,Cheltenham,Gloucestershire               ,England                       ,GL52 6DA,Wider Public Sector,Private Sector Enabler,False
+10002095,Care and Repair (Stroud) Ltd,,Unit 9 New Mills Ind. Estate,Libby's Drive Slad Road,,Stroud,Gloucestershire               ,England                       ,GL5 1RN,Wider Public Sector,Private Sector Enabler,False
+10002094,Care and Repair (Cheltenham) Ltd,,3 Cambray Mews,Wellington Street,,Cheltenham,Gloucestershire               ,England                       ,GL50 1XZ,Wider Public Sector,Private Sector Enabler,False
+10002092,Bourton-on-the-Water Youth Centre,,Gloucestershire County Council,The Avenue,,Bourton-on-the-Water,Gloucestershire               ,England                       ,GL54 2BB,Wider Public Sector,Private Sector Enabler,False
+10002077,Viewforth Resource Centre,,Viewforth Street,,,Kirkcaldy,Fife                          ,Scotland                      ,KY1 3DH,Wider Public Sector,Private Sector Enabler,False
+10002072,Royal Naval Stores Depot,,Murray Road,,,Rosyth,Fife                          ,Scotland                      ,KY11 2XU,Wider Public Sector,Private Sector Enabler,False
+10002071,Royal Naval Armament Depot,,Bld 76,DM Crombie,,Dunfermline,Fife                          ,Scotland                      ,KY12 8LA,Wider Public Sector,Private Sector Enabler,False
+10002066,Linktown Church of Scotland,,Linktown Church,12 Glenbervie Road,,Kirkcaldy,Fife                          ,Scotland                      ,KY2 6HR,Wider Public Sector,Private Sector Enabler,False
+10002062,Glenrothes College,,Stenton Road,,,Glenrothes,Fife                          ,Scotland                      ,KY6 2RA,Wider Public Sector,Education,False
+10002060,Fife Primary Care Supplies,,1 Midfield Road,Unit 7 Mitchelston Industrial Estate,,Kirkcaldy,Fife                          ,Scotland                      ,KY1 3NL,Wider Public Sector,Private Sector Enabler,False
+10002055,Fife College of Further and Higher Education,,St Brycedale Avenue,,,Kirkcaldy,Fife                          ,Scotland                      ,KY1 1EX,Wider Public Sector,Education,False
+10002052,DM Crombie,,Building 76,Crombie,,Dunfermline,Fife                          ,Scotland                      ,KY12 8LA,Wider Public Sector,Private Sector Enabler,False
+10002051,Disposal Services Agency,,Building 2065,Hilton Road,2-12 Bloomsbury Way,Rosyth,Fife                          ,Scotland                      ,KY11 2XX,Wider Public Sector,Private Sector Enabler,False
+10002050,Book Exchange and Stationery Supplies,,St Marys Place,,,St. Andrews,Fife                          ,Scotland                      ,KY16 9UY,Wider Public Sector,Private Sector Enabler,False
+10002049,Western Health Board,,Erne Hospital,Cornagrave Road,12c Gransha Park,Enniskillen,Fermanagh                     ,Northern Ireland              ,BT74 6AI,Wider Public Sector,Private Sector Enabler,False
+10002047,St Patricks P. School - Mullanaskea,,Mullanaskea,Garvary,,Enniskillen,Fermanagh                     ,Northern Ireland              ,BT94 3AX,Wider Public Sector,Private Sector Enabler,False
+10002046,Fermanagh District Council,,Killyvilly Tempo Road,,,Enniskillen,Fermanagh                     ,Northern Ireland              ,BT74 7BA,Wider Public Sector,Local Government,False
+10002043,Discovery 80 Limited T/A Share,,Smith's Strand,,,Lisnaskea,Fermanagh                     ,Northern Ireland              ,BT92 0EQ,Wider Public Sector,Private Sector Enabler,False
+10002031,Riverside School,,Ainsty Street,Goole,East Yorkshire,Goole,East Yorkshire,England,DN14 5JS,Wider Public Sector,Local Authority Maintained School (All Types),False
+10002028,Humberside Training and Enterprise Council,,Silvester Square,,,Hull,East Yorkshire                ,England                       ,HU1,Wider Public Sector,Private Sector Enabler,False
+10002020,Easy York Community Healthcare,,Nhs Trust,"West House,Westwood Hospital",,Beverley,East Yorkshire                ,England                       ,HU,Wider Public Sector,Private Sector Enabler,False
+10002001,Vinehall School Ltd,,Vinehall Road ,Mountfield,,Robertsbridge,East Sussex                   ,England                       ,TN32 5JL,Wider Public Sector,Private Sector Enabler,False
+10001992,Toadhall Dental Surgery,,1 Upper Glen Road,,,St Leonards-on-Sea,East Sussex                   ,England                       ,TN37 7AX,Wider Public Sector,Private Sector Enabler,False
+10001991,Ticehurst House Private Clinic,,Ticehurst,,,Wadhurst,East Sussex                   ,England                       ,TN5 7HU,Wider Public Sector,Private Sector Enabler,False
+10001990,Priory Grange The,,Tottingworth Park,,,Heathfield,East Sussex                   ,England                       ,TN21 8UN,Wider Public Sector,Private Sector Enabler,False
+10001988,Anchorage The,,46 Collington Lane West,Cooden,,Bexhill-On -Sea,East Sussex                   ,England                       ,TN39 3TA,Wider Public Sector,Private Sector Enabler,False
+10001980,St Wilfrid's Hospice,,2 - 4 Mill Gap Road,,,Eastbourne,East Sussex                   ,England                       ,BN21 2HJ,Wider Public Sector,Private Sector Enabler,False
+10001979,St Peters and St James Hospice,,North Common Road,North Chailey,,Lewes,East Sussex                   ,England                       ,BN8 4ED,Wider Public Sector,Private Sector Enabler,False
+10001977,St Marys (Wrestwood) Educational Trust Ltd,,St Marys School,Wrestwood Road,,Bexhill-on-Sea,East Sussex                   ,England                       ,TN40 2LU,Wider Public Sector,Private Sector Enabler,False
+10001970,Shaa Retirement Homes Ltd,,5 Albion Street,,,Lewes,East Sussex                   ,England                       ,BN7 2ND,Wider Public Sector,Private Sector Enabler,False
+10001969,Seaside Medical Centre,,18 Sheen Road,,,Eastbourne,East Sussex                   ,England                       ,BN22 8DR,Wider Public Sector,Private Sector Enabler,False
+10001967,Saxon Homes Ltd,,Saxonwood,Saxonwood Road,,Battle,East Sussex                   ,England                       ,TN33 OEY,Wider Public Sector,Private Sector Enabler,False
+10001966,Rydon Group Ltd,,Rydon House,Forrest Row,, ,East Sussex                   ,England                       ,RH18 4DW,Wider Public Sector,Private Sector Enabler,False
+10001965,Rother Lifeline,,Rother District Council,The Watch Oak,,Battle,East Sussex                   ,England                       ,TN33 0YA,Wider Public Sector,Private Sector Enabler,False
+10001964,Rother Homes Ltd,,Watch Oak,,,Battle,East Sussex                   ,England                       ,TN33 0YA,Wider Public Sector,Private Sector Enabler,False
+10001955,Outlook House,,74 Redhill Drive,,,Brighton,East Sussex                   ,England                       ,BN1 5FL,Wider Public Sector,Private Sector Enabler,False
+10001949,NABS,,Peter House Retirement Homes,Church Street,,Bexhill-on-Sea,East Sussex                   ,England                       ,TN40 2HF,Wider Public Sector,Private Sector Enabler,False
+10001945,Llewellyn Group of Companies,,16-20 South Street,,,Eastbourne,East Sussex                   ,England                       ,BN21 4XE,Wider Public Sector,Private Sector Enabler,False
+10001943,Kings Church,,State Hall,Station Road,,Heathfield,East Sussex                   ,England                       ,TN21 8LD,Wider Public Sector,Private Sector Enabler,False
+10001936,Heathfield Leisure Centre,,Cade St,Old Heathfield,,Heathfield,East Sussex                   ,England                       ,TN22 8RJ,Wider Public Sector,Private Sector Enabler,False
+10001930,Hastings and St Leonards Education Action Zone,,Little Moreton,29 Boscobel Road,,St Leonards on Sea,East Sussex                   ,England                       ,TN38 0LX,Wider Public Sector,Private Sector Enabler,False
+10001924,Five Villages Home Assoc Ltd,,Five Villages House,Oast House Field,,Icklesham,East Sussex                   ,England                       ,TN36 4BQ,Wider Public Sector,Private Sector Enabler,False
+10001920,Ecovert Group Ltd,,Ecovert House,2 Bartholomews,,Brighton,East Sussex                   ,England                       ,BN1 1HG,Wider Public Sector,Private Sector Enabler,False
+10001919,EBEA (Economics and Business Education Association),,Main Office,,, ,,England                       ,OO,Wider Public Sector,Private Sector Enabler,False
+10001898,Coptic Orthodox Patriarchute,,St Mary & St Abraam Goptic Church,Davigdor Road,,Hove,East Sussex                   ,England                       ,BN3 1RF,Wider Public Sector,Private Sector Enabler,False
+10001893,Chichester Diocesan Board of Education,,Diocesan Church House,211 New Church Road,,Hove,East Sussex                   ,England                       ,BN3 4ED,Wider Public Sector,Private Sector Enabler,False
+10001892,Chailey Heritage,,Clinical Services,North Chainley,,Lewes,East Sussex                   ,England                       ,BM8 4JN,Wider Public Sector,Private Sector Enabler,False
+10001884,Boomerang Kids,,67 Chichester Drive West,Saltdean,Saltdean,Brighton,East Sussex                   ,England                       ,BN2 8SF,Wider Public Sector,Private Sector Enabler,False
+10001866,Hi Tech Crime Unit,HTCU,PO Box No 2,Headquarters,Springfield,Chelmsford,Essex                         ,England                       ,CM2 6DA,Central Government,NDPB,False
+10001857,Workforce Development Confederation,,Water Lane,Bridge End,Newport,Saffron Walden,Essex                         ,England                       ,CB11 3TH,Wider Public Sector,Private Sector Enabler,False
+10001849,Whipps Cross University Hospital NHS Trust,,Whipps Cross Hospital,Whipps Cross Road,,London,,England                       ,E11 1NR,Wider Public Sector,Acute Trust,False
+10001839,Tilbury Riverside Arts Activity Centre,,Thurrock Borough Council,Ferry Road,,Tilbury,Essex                         ,England                       ,RM18 7NH,Wider Public Sector,Private Sector Enabler,False
+10001836,Thurrock Mind,,152 Bridge Road,,,Grays,Essex                         ,England                       ,RM17 6DB,Wider Public Sector,Private Sector Enabler,False
+10001835,Thurrock Community Leisure Ltd,,Impulse Leisure,Blackshots Leisure Centre,Blackshots Lane,Grays,Essex                         ,England                       ,RM16 2JU,Wider Public Sector,Private Sector Enabler,False
+10001833,Thurrock Christian Fellowship,,The Corrigan Centre,Giffords Cross Road,,Corringham,Essex                         ,England                       ,SS17 7PZ,Wider Public Sector,Private Sector Enabler,False
+10001830,Thriftwood International Scout Campsite,,1 Thornridge,,,Brentwood,Essex                         ,England                       ,CM14 4YJ,Wider Public Sector,Private Sector Enabler,False
+10001827,Theydon Trusts Ltd,,25 Hemnall Street,,,Epping,Essex                         ,England                       ,CM16 4LX,Wider Public Sector,Private Sector Enabler,False
+10001814,Angle 4th Ave The,,Alexandra Residential Club,Forth Avenue,,Harlow,Essex                         ,England                       ,CM20 1DN,Wider Public Sector,Private Sector Enabler,False
+10001810,Tabbs Project,,Essex County Council,Ely House,Ely Way,Basildon ,Essex                         ,England                       ,SS14 2BQ,Wider Public Sector,Private Sector Enabler,False
+10001801,St Marys Prittlewell,,Church of England School,Boston Avenue,,Southend on Sea,Essex                         ,England                       ,SS2 6JH,Wider Public Sector,Private Sector Enabler,False
+10001799,St John the Evangelist Seven Kings,,190 Meads Lane,,,Ilford,Essex                         ,England                       ,IG3 8NY,Wider Public Sector,Private Sector Enabler,False
+10001798,St John the Baptist Church,,The Rectory,Church Lane,,Loughton,Essex                         ,England                       ,IG10 1PD,Wider Public Sector,Private Sector Enabler,False
+10001792,Southend High School for Girls,,Southchurch Boulevard,,,Southend,Essex                         ,England                       ,SS2 4UZ,Wider Public Sector,Private Sector Enabler,False
+10001791,Southend Community Care Services Trust,,Community House,Union Lane,,Rochford,Essex                         ,England                       ,SS4 1RB,Wider Public Sector,Private Sector Enabler,False
+10001790,South Essex Partnership University NHS Foundation Trust,,Thurrock Hospital Thameside House Long Lane Grays,Essex,Essex,Essex,Essex,England,RM16 2PX,Wider Public Sector,Mental Health Trust,False
+10001786,Shared Healthcare Services,,2nd Floor Crown House,151 High Road,,Loughton,,Scotland                      ,G10 4LF,Wider Public Sector,Private Sector Enabler,False
+10001784,School Catering,,Clockhouse Lane,,,Barking,Essex                         ,England                       ,IG11 7UU,Wider Public Sector,Private Sector Enabler,False
+10001781,Royal Ordnance Site Unit,,Unit G 411,Beechfield Walk Sewardstone Road,,Waltham Abbey,Essex                         ,England                       ,EN9 1AT,Wider Public Sector,Private Sector Enabler,False
+10001780,Royal Gloucestershire Berkshire and Wiltshire Regiment,,Meeanee Barracks,,,Colchester,Essex                         ,England                       ,CO2 7TA,Wider Public Sector,Private Sector Enabler,False
+10001777,Riverside Ice and Leisure,,Victoria Road,,,Southminster,Essex                         ,England                       ,CM,Wider Public Sector,Private Sector Enabler,False
+10001774,Redbridge Night Shelter,,16 York Road,,,Ilford,Essex                         ,England                       ,IG1 3AD,Wider Public Sector,Private Sector Enabler,False
+10001770,Raydens Dental Surgery,,Upminster Road South,,,Rainham,Essex                         ,England                       ,RM13 9AB,Wider Public Sector,Private Sector Enabler,False
+10001765,QM Department,,MCTC,Berechurch Hall Road,,Colchester,Essex                         ,England                       ,CO9 9NN,Wider Public Sector,Private Sector Enabler,False
+10001753,Othona Community Centre,,Othona Community Centre,East End Road,Bradwell On Sea,Southminster,Essex                         ,England                       ,CM0 7PN,Wider Public Sector,Private Sector Enabler,False
+10001749,Ogilby Housing Association Ltd,,Estate Office,Greenways Court,Butts Green Road,Hornchurch,Essex                         ,England                       ,RM11 2JL,Wider Public Sector,Housing Associations,False
+10001748,NPS Essex,,63 Moulsham Street,,,Chelmsford,Essex                         ,England                       ,CM2 0JA,Wider Public Sector,Private Sector Enabler,False
+10001747,North Essex Partnership University NHS Foundation Trust.,,Stapleford House Stapleford Close,Chelmsford,Essex,Chelmsford,Essex,England,CM2 0QX,Wider Public Sector,Mental Health Trust,False
+10001737,MQES Carver Barracks,,Wimbish,,,Saffron Walden,Essex                         ,England                       ,CB10 2YA,Central Government,,False
+10001734,MOD Dcta S and Td,,Flagstaff Rd,,,Colchester,Essex                         ,England                       ,CO2 75S,Central Government,,False
+10001733,MOD Colchester Garrison Entrance C,,"Victoria House,Off Ypres Road",,,Colchester,Essex                         ,England                       ,CO2 7NL,Central Government,,False
+10001709,Kenfield Chapel,,16 Atherton Road,Clayhall,,Ilford,Essex                         ,England                       ,IG5 0PB,Wider Public Sector,Private Sector Enabler,False
+10001704,Homesdale (Woodford Bh) Ltd,,C/O 105 Glengall Road,,,Woodford Green,Essex                         ,England                       ,IG8 0DP,Wider Public Sector,Private Sector Enabler,False
+10001694,Havering Womens Aid,,42-44 Brentwood Road,,,Romford,Essex                         ,England                       ,RM1 2EX,Wider Public Sector,Private Sector Enabler,False
+10001690,Havering Catering Services,,Room 101 Rainham Road Public Works Dept ,Upper Rainham Road,,Hornchurch,Essex                         ,England                       ,RH12 4ET,Wider Public Sector,Private Sector Enabler,False
+10001685,Harlow Hospital Radio,,C/o Princess Alexandra Hospital,Hamstel Road,,Harlow,Essex                         ,England                       ,CM20 1QX,Wider Public Sector,Private Sector Enabler,False
+10001680,Guru Nanak Satsang Sabha Gurudwara(Karms,,400 High Road,,,Ilford,Essex                         ,England                       ,IG1 1TW,Wider Public Sector,Private Sector Enabler,False
+10001677,Grays Baptist Tabernacle,,70 Hathaway Road,,,Grays,Essex                         ,England                       ,RM17 5LA,Wider Public Sector,Private Sector Enabler,False
+10001669,Forest Healthcare Suppliers Team,,"2nd Floor Crown House,",151 High Road,,Loughton,Essex                         ,England                       ,IG10 4LF,Wider Public Sector,Private Sector Enabler,False
+10001668,Forest Healthcare Property Services,,1st Floor Crown House Claybury G.3.,151 High Road,,Loughton,Essex                         ,England                       ,IG10 4LF,Wider Public Sector,Private Sector Enabler,False
+10001667,Foley House Trust,,Foley House,115 High Garrett,,Braintree,Essex                         ,England                       ,CM7 5MU,Wider Public Sector,Private Sector Enabler,False
+10001666,Felstead School ,,Bursars Office,Felsted,,Dunmow,Essex                         ,England                       ,CM6 3JG,Wider Public Sector,Private Sector Enabler,False
+10001660,Essex Training and Enterprise Council,,Hedgerows Business Pk,Colchester Road,,Chelmsford,Essex                         ,England                       ,CM2 5PB,Wider Public Sector,Private Sector Enabler,False
+10001659,Essex Trading Standards,,Beehive Lane,,,Chelmsford,Essex                         ,England                       ,CM2 9SY,Wider Public Sector,Private Sector Enabler,False
+10001648,Elmstead Parish Church,,The Vicarage Church Road,Elmstead,,Colchester,Essex                         ,England                       ,CO7 8DD,Wider Public Sector,Private Sector Enabler,False
+10001645,Edas Wickford Centre,,Alderney Gdns,,,Wickford,Essex                         ,England                       ,SS11 7JZ,Wider Public Sector,Private Sector Enabler,False
+10001640,Distribution Outlet,,St Barbara's Road,,,Colchester,Essex                         ,England                       ,CO2 7UQ,Wider Public Sector,Private Sector Enabler,False
+10001639,Disablement Association of Barking and Dagenham,,Pembroke Gardens,,,Dagenham,Essex                         ,England                       ,RM10 7YP,Wider Public Sector,Private Sector Enabler,False
+10001635,DCTA,,Flagstaff Road,Flagstaff Road,,Colchester,Essex                         ,England                       ,CO2 7SS,Wider Public Sector,Private Sector Enabler,False
+10001634,Countryside Properties Plc,,The Drive,Great Warley,,Brentwood,Essex                         ,England                       ,CM13 3AT,Wider Public Sector,Private Sector Enabler,False
+10001628,Colchester Institute,,Sheepen Road,,,Colchester,Essex                         ,England                       ,CO3 3LL,Wider Public Sector,Private Sector Enabler,False
+10001624,Chelmsford Vehicle Testing Station,,Widford Industrial Estate,,,Chelmsford,Essex                         ,England                       ,CM1 3AE,Wider Public Sector,Private Sector Enabler,False
+10001623,Chelmsford Diocesan Board Of Education,,Diocesan Office,Guy Harlings,,Chelmsford,Essex                         ,England                       ,CM1 1AT,Wider Public Sector,Private Sector Enabler,False
+10001615,Care UK plc,,Connaught House,850 The Crescent,Colchester Business Park,Colchester,Essex                         ,England                       ,CO4 9QB,Wider Public Sector,Private Sector Enabler,False
+10001614,Calderwood Housing Association Ltd,,Estate Office,Greenways Court,Butts Green Road,Hornchurch,Essex                         ,England                       ,RM11 2JL,Wider Public Sector,Housing Associations,False
+10001611,Brentwood Training Services,,Essex Way,,,Brentwood,Essex                         ,England                       ,CM13 3AX,Wider Public Sector,Private Sector Enabler,False
+10001609,Brentwood Ht Ltd,,3/5 Ongar Road,,,Brentwood,Essex                         ,England                       ,CM15 9AU,Wider Public Sector,Private Sector Enabler,False
+10001585,Barking Havering and Brentwood Community Health Care NHS Trust,,Goodmayes Hospital,Barley Lane,,Goodmayes,Essex                         ,England                       ,IG3 8XB,Wider Public Sector,GP Practice,False
+10001570,Accommodation Svcs Unit 4 Division,,79-90 Cotton-Wood Close,,,Colchester,Essex                         ,England                       ,CO2 9PZ,Wider Public Sector,Private Sector Enabler,False
+10001566,19 Airmobile Field Ambulance,,Goojerat Barracks,,,Colchester,Essex                         ,England                       ,CO2 7NR,Central Government,,False
+10001565,RHQ The Parachute Regiment,,Flagstaff House,4 Napier Road,,Colchester,Essex                         ,England                       ,CO2 7SW,Wider Public Sector,Private Sector Enabler,False
+10001561,Essex Training Ltd,,6 Suffolk Drive,Dukes Park Industrial Estate,,Chelmsford,Essex                         ,England                       ,CM2 6UN,Wider Public Sector,Private Sector Enabler,False
+10001554,Loughton Methodist Church,,260 High Road,,,Loughton,Essex                         ,England                       ,IG10 1RB,Wider Public Sector,Private Sector Enabler,False
+10001549,Ysgol Gynradd Drefach,,Heol Blaenhirwaun,Drefach,,Llanelli,Dyfed                         ,Wales                         ,SA14 7AN,Wider Public Sector,Education,False
+10001547,Welsh Water,,Barley Mow,,,Lampeter,Dyfed                         ,Wales                         ,SA48 7DA,Wider Public Sector,Private Sector Enabler,False
+10001545,University of Wales Aberystwyth,,Aberystwyth Art Centre,Estates Division,60 Park Place,Aberystwyth,Dyfed                         ,Wales                         ,SY23 3DE,Wider Public Sector,Education,False
+10001542,Royal Maritime Auxiliary Service,,HQ Fort Road,,,Pembroke Dock,Dyfed                         ,Wales                         ,SA72 6TB,Wider Public Sector,Private Sector Enabler,False
+10001533,Centre For Advances Welsh and Celtic Studies,,The National Library of Wales,,,Aberystwyth,Dyfed                         ,Wales                         ,SY23 3HH,Wider Public Sector,Private Sector Enabler,False
+10001531,Bromyrddinha,,89 Lammas Street,,,Carmarthen,Dyfed                         ,Wales                         ,SA31 3AP,Wider Public Sector,Private Sector Enabler,False
+10001530,Boda Cyf,,Limegrove House,Limegrove Avenue,,Carmarthen,Dyfed                         ,Wales                         ,SA31 1SW,Wider Public Sector,Private Sector Enabler,False
+10001521,Easington and Seaham Education Action Zone,,Shotton Hall Conference,Old Shotton,,Peterlee,County Durham                 ,England                       ,SR8 2PH,Wider Public Sector,Charity,False
+10001519,Wear Valley District Council,,1 The Royal Corner,Market Place,Market Place,Crook,County Durham                 ,England                       ,DL15 9UA,Wider Public Sector,District Council,False
+10001512,Teesdale District Council,,Council Offices,Teesdale House Galgate,,Barnard Castle,County Durham                 ,England                       ,DL12 8EL,Wider Public Sector,District Council,False
+10001510,Sedgefield Borough Council,,Council Offices,,,Spennymoor,County Durham                 ,England                       ,DL16 6JQ,Wider Public Sector,District Council,False
+10001505,Peterlee Education Action Zone,,Shotton Hall Conference Centre,Old Shotton,,Peterlee,County Durham                 ,England                       ,SR8 2PH,Wider Public Sector,Private Sector Enabler,False
+10001503,North Durham Healthcare NHS Trust,,Dryburn Hospital,North Road,North Road,Durham,County Durham                 ,England                       ,DH1 5TW,Wider Public Sector,Acute Trust,False
+10001482,Durham City Council,,4 Saddler Street,Hawthorn Terrace,Gilesgate,Durham,County Durham                 ,England                       ,DH1 3NZ,Wider Public Sector,,False
+10001480,District of Easington,,Council Offices,Seaside Lane,Easington,PETERLEE,County Durham                 ,England                       ,SR8 3TN,Wider Public Sector,,False
+10001479,Derwentside District Council,,Civic Centre,Medomsley Road,,Consett,County Durham                 ,England                       ,DH8 5JA,Wider Public Sector,District Council,False
+10001460,Durham,,Unit 1,Dragonville Industrial Est,,Gilesgate,County Durham                 ,England                       ,DH1 2YN,Wider Public Sector,Private Sector Enabler,False
+10001458,Caledonian Award The,,East Dunbartonshire Council,Bearsden Public Hall,69 Drymen Road,Bearsden,Dunbartonshire                ,Scotland                      ,G61 3QT,Wider Public Sector,Private Sector Enabler,False
+10001456,LLTIC,,The Old Station,Balloch Road,,Alexandria,Dunbartonshire                ,Scotland                      ,G83 8SS,Wider Public Sector,Private Sector Enabler,False
+10001454,Health Physics Afloat,,HM Naval Base,Faslane,,Clyde,Dunbartonshire                ,Scotland                      ,G84 8HL,Wider Public Sector,Private Sector Enabler,False
+10001453,Garelochhead Training Camp,,81,Garelochhead,,Helensburgh,Dunbartonshire                ,Scotland                      ,G84 0EH,Wider Public Sector,Private Sector Enabler,False
+10001446,Rathgael and Whiteabbey Schools Management Board,,169 Rathgael Road,,,Bangor,County Down                   ,Northern Ireland              ,BT19 1AT,Wider Public Sector,Private Sector Enabler,False
+10001440,Inter Trade Ireland,,The Old Gasworks Business Park,The Old Gasworks Business Park,Kilmorey Street,Newry,County Down                   ,Northern Ireland              ,BT34 2DE,Wider Public Sector,Private Sector Enabler,False
+10001439,East Down Institute Of Further and Higher,,Donard Street,,,Newcastle,County Down                   ,Northern Ireland              ,BT74 6AE,Wider Public Sector,Private Sector Enabler,False
+10001438,Down Lisburn Trust Supplies Dept,,Ardglass Rd,Ardglass Rd,,Downpatrick,County Down                   ,Northern Ireland              ,BT36 6RA,Wider Public Sector,Private Sector Enabler,False
+10001437,Down District Council,,24 Strangford Road,Downpatrick,County Down,Downpatrick,County Down,Northern Ireland,BT30 6SR,Wider Public Sector,Local Government,False
+10001433,Construction Service,,717 Upper Newtownards Road,Rosepark Workshop,,Belfast,County Down                   ,Northern Ireland              ,BT23 4BB,Wider Public Sector,Private Sector Enabler,False
+10001408,Samaritans of Bournemouth The,,4 District,1 Durrant Road,,Bournemouth,Dorset                        ,England                       ,BH2 6LE,Wider Public Sector,Private Sector Enabler,False
+10001407,Othona Community The,,Coast Road,Burton Bradstock,,Bridport,Dorset                        ,England                       ,DT6 4RN,Wider Public Sector,Private Sector Enabler,False
+10001406,New Forest Pony Breeding and Cattle Society The,,The Corner House,Ringwood Road,Branscore,Christchurch,Dorset                        ,England                       ,BH23 8AA,Wider Public Sector,Private Sector Enabler,False
+10001405,Borough Of Poole The,,"Property Services Corporate procurement,",Jade Manok Court,West Quay Road,Poole,Dorset                        ,England                       ,BH15 1JG,Wider Public Sector,Private Sector Enabler,False
+10001403,AIDIS Trust The,,1 Albany Park,Cabot Lane,,Poole,Dorset                        ,England                       ,BH17 7BX,Wider Public Sector,Private Sector Enabler,False
+10001396,Sherborne School For Girls,,Bradford Road,,,Sherborne,Dorset                        ,England                       ,DT9 3QN,Wider Public Sector,Private Sector Enabler,False
+10001391,Royal School Of Signals,,Blandford Camp,Blandford Forum,,Blandford,Dorset                        ,England                       ,DT11 8RP,Wider Public Sector,Private Sector Enabler,False
+10001389,Royal Marines,,Local Purchase Office,Hamworthy,,Poole,Dorset                        ,England                       ,BH15 4NQ,Central Government,Private Sector Enabler,False
+10001388,Royal Manor Health Care,,Park Estate Road,Easton,,Portland,Dorset                        ,England                       ,DT5 2BJ,Wider Public Sector,Private Sector Enabler,False
+10001376,Osteoporosis Prevention,,11 Shelley Road,,,Bournemouth,Dorset                        ,England                       ,BH1 4SQ,Wider Public Sector,Private Sector Enabler,False
+10001370,McCarthy Foundation,,59 Commercial Road,Parlestone,,Poole,Dorset                        ,England                       ,BH14 0JB,Wider Public Sector,Private Sector Enabler,False
+10001366,LSU STBSS,,Ellis Road,Bovington Camp,,Wareham,Dorset                        ,England                       ,BH20 3LT,Central Government,,False
+10001365,London Borough Council,,3rd Floor,Roddis House,4-12 Old Christchurch Road,Bournemouth,Dorset                        ,England                       ,BH1 1LG,Wider Public Sector,District Council,False
+10001360,Howe AH,,The Canford Heath Group Practice,9 Mitchell Road,,Poole,Dorset                        ,England                       ,BH17 8UE,Wider Public Sector,Private Sector Enabler,False
+10001359,Holton Lee,,Holton Lee East Holton,Holton Heath,,Poole,Dorset                        ,England                       ,BH16 6JN,Wider Public Sector,Private Sector Enabler,False
+10001350,Haden Facilities Management Ltd,,Park Rd,,,Poole,Dorset                        ,England                       ,BH15 2RP,Wider Public Sector,Private Sector Enabler,False
+10001348,Gatehouse Medical Centre,,Castle Road,,,Portland,Dorset                        ,England                       ,DT5 1AU,Wider Public Sector,Private Sector Enabler,False
+10001347,English Courtyard Association,,15 Moor Road,,,Broadstone,Dorset                        ,England                       ,BH18 8AZ,Wider Public Sector,Private Sector Enabler,False
+10001344,East Boro Ht,,The Office,"Bartley Court,71 East Borough",,Wimborne,Dorset                        ,England                       ,BH21 1PD,Wider Public Sector,Private Sector Enabler,False
+10001343,Dorset Residential Homes,,22 Cornwall Road,,,Dorchester,Dorset                        ,England                       ,DT1 1UR,Wider Public Sector,Private Sector Enabler,False
+10001340,Dorset HealthCare University Foundation Trust,,11 Shelley Road,Boscombe,,Bournemouth,Dorset                        ,England                       ,BH1 4JQ,Wider Public Sector,Mental Health Trust,False
+10001332,Defence Petroleum Centre,,West Moors,,,Wimborne,Dorset                        ,England                       ,BH21 6QS,Central Government,,False
+10001329,Concord House Association Ltd,,2 Montague Road,Boscombe,,Bournemouth,Dorset                        ,England                       ,BH5 2EP,Wider Public Sector,Private Sector Enabler,False
+10001326,Christchurch Community Leisure Association,,The Dorset Cricket Centre,Hurn,,Christchurch,Dorset                        ,England                       ,BH23 6DY,Wider Public Sector,Private Sector Enabler,False
+10001324,Business Link Dorset Ltd,,Stinsford Road,,,Poole,Dorset                        ,England                       ,BH17 0BL,Wider Public Sector,Private Sector Enabler,False
+10001295,Fortune Centre of Riding Therapy The,,Avon Tyrrell,Bransgore,,Christchurch,Dorset                        ,England                       ,BH23 8EE,Wider Public Sector,Private Sector Enabler,False
+10001292,Knowledge Environment Branch Directorate of Command and Battlespace Management Army,,Faraday Building,Blandford Camp,,Blandford Forum,Dorset                        ,England                       ,DT11 8RE,Central Government,Army,False
+10001291,Wyke Regis Training Area,,Camp Road,,,Weymouth,Dorset                        ,England                       ,DT4 9HH,Wider Public Sector,Private Sector Enabler,False
+10001289,Hook Court Education Trust,,"Hook Court ,Hook",,,Near Beaminster,Dorset                        ,England                       ,DT8 3NX,Wider Public Sector,Private Sector Enabler,False
+10001288,Christian Outreach Centre,,The White House,330 New Road,,Ferndown,Dorset                        ,England                       ,BH22 8ET,Wider Public Sector,Private Sector Enabler,False
+10001267,Unit RNR HMS Vivid HQ,,Maillard House,Mount Wise,,Plymouth,Devon                         ,England                       ,PL1 4JH,Wider Public Sector,Private Sector Enabler,False
+10001266,Unicorn Consultancy,,RMB Stonehouse,Durnford Street,,Plymouth,Devon                         ,England                       ,PL1 3QS,Wider Public Sector,Private Sector Enabler,False
+10001263,Trevi House Limited,,6 Endsleigh Gardens,,,Plymouth,Devon                         ,England                       ,PL4 6DR,Wider Public Sector,Private Sector Enabler,False
+10001259,Torbay Local Education Authority,,Old Way,Torquay Road,,Paignton,Devon                         ,England                       ,TQ3 2TE,Wider Public Sector,Private Sector Enabler,False
+10001257,Torbay Churches Homeless Trust,,The Factory Row Centre,12A Factory Row,Castle Circus,Torquay,Devon                         ,England                       ,TQ2 5QQ,Wider Public Sector,Private Sector Enabler,False
+10001254,Royal Citadel The,,Property Management ,,,Plymouth,Devon                         ,England                       ,PL1 2PD,Wider Public Sector,Private Sector Enabler,False
+10001253,Nutritional Cancer Therapy Trust The,,Sloley Barton,Shirwell,,Barnstaple,Devon                         ,England                       ,EX31 4LF,Wider Public Sector,Private Sector Enabler,False
+10001241,St Luke's Hospice,,Stamford Road,Plymstock,,Plymouth,Devon                         ,England                       ,PL9 9XA,Wider Public Sector,Private Sector Enabler,False
+10001240,St Loyes Foundation,,Fairfield House,Topsham Road,,Exeter,Devon                         ,England                       ,EX2 6EP,Wider Public Sector,Private Sector Enabler,False
+10001239,St George's House,,Christian Outdoor Centre,Georgeham,,Braunton,Devon                         ,England                       ,EX33 1JN,Wider Public Sector,Private Sector Enabler,False
+10001230,South Devon Womens Aid,,Po Box 82,,,Torquay,Devon                         ,England                       ,TQ1 4QX,Wider Public Sector,Private Sector Enabler,False
+10001226,Ship Hostel,,George Place,Stonehouse,,Plymouth,Devon                         ,England                       ,PL1 3NZ,Wider Public Sector,Private Sector Enabler,False
+10001220,Rok Property Solutions Plc,,Rok Centre,Guardian Road,Exeter Business Park,Exeter,Devon                         ,England                       ,EX1 3PD,Wider Public Sector,Private Sector Enabler,False
+10001218,Redcliffe House (Exeter) Ltd,,43 Denmark Road,,,Exeter,Devon                         ,England                       ,EX1 1SH,Wider Public Sector,Private Sector Enabler,False
+10001215,Porkka (Uk) Ltd,,Western Offices,17 Grosvenor Close,,Torquay,Devon                         ,England                       ,TQ2 7LB,Wider Public Sector,Private Sector Enabler,False
+10001211,Plymouth Legal Practice,,St Andrews Court,St Andrew Street,,Plymouth,Devon                         ,England                       ,PL1 2AH,Wider Public Sector,Private Sector Enabler,False
+10001209,Plymouth Healthcare Education Ltd,,15 Portland Villas,,,Plymouth,Devon                         ,England                       ,PL4 8AA,Wider Public Sector,Private Sector Enabler,False
+10001208,Plymouth Education Action Zone,,c/o Weston Mill Community Primary School,Ferndale Road,Camels Head,Plymouth,Devon                         ,England                       ,PL2 2EL,Wider Public Sector,Private Sector Enabler,False
+10001207,Plymouth County Court,,Plymouth Combined Court Centre,The Law Courts,Armada Way,Plymouth,Devon                         ,England                       ,PL1 2ER,Central Government,Private Sector Enabler,False
+10001197,North Devon College,,Old Sticklepath Hill,Sticklepath,,Barnstaple,Devon                         ,England                       ,EX31 2BQ,Wider Public Sector,Colleges of Further Education,False
+10001192,MOD Dhe,,1st Floor Mallard House Mount Wise,Devonport,,Plymouth,Devon                         ,England                       ,PL1 4JH,Central Government,,False
+10001189,Maritime Headquarters Plymouth,,Richmond Walk,Devonport,,Plymouth,Devon                         ,England                       ,PL1 4JH,Wider Public Sector,Private Sector Enabler,False
+10001188,Marine Salvage Unit,,"Building S161,HM Naval Base",Devonport,,Plymouth,Devon                         ,England                       ,PL1 4SL,Wider Public Sector,Private Sector Enabler,False
+10001182,Keychange,,All Saints Rd,,,Sidmouth,Devon                         ,England                       ,EX10 8EX,Wider Public Sector,Private Sector Enabler,False
+10001179,IEFM,,The University College Of St,"Mark & St John,Derriford Road",,Plymouth,Devon                         ,England                       ,PL,Wider Public Sector,Private Sector Enabler,False
+10001172,HMNB,,Building N215,Devonport,,Plymouth,Devon                         ,England                       ,PL2 2BG,Wider Public Sector,Private Sector Enabler,False
+10001166,Flagship Trading Ltd,,Britannia Royal Navy College,College Way,,Dartmouth,Devon                         ,England                       ,TQ6 OHJ,Wider Public Sector,Private Sector Enabler,False
+10001165,Field Studies Council,,Slapton Ley Field Centre,Slapton,,Kingsbridge,Devon                         ,England                       ,TQ7 2QP,Wider Public Sector,Private Sector Enabler,False
+10001155,East Devon College,,Bolham Road,,,Tiverton,Devon                         ,England                       ,EX16 6SH,Wider Public Sector,Colleges of Further Education,False
+10001151,Devon Fire and Rescue Service,,Clyst St Mary,Clyst St George,,Exeter,Devon                         ,England                       ,EX3 0NW,Wider Public Sector,Fire and Rescue Services,False
+10001147,Devon and Cornwall Trg Areas HQ,,Mod Mount Wise,Devonport,,Plymouth,Devon                         ,England                       ,PL1 4JH,Wider Public Sector,Private Sector Enabler,False
+10001146,Devon and Cornwall Development Int,,2 Derriford Park,,,Plymouth,Devon                         ,England                       ,PL6 5QZ,Wider Public Sector,Private Sector Enabler,False
+10001131,Channel Housing Association Ltd,,Hatfield House,Hatfield Road,,Torquay,Devon                         ,England                       ,TQ1 3HF,Wider Public Sector,Housing Associations,False
+10001129,Bso Royal Marines,,Stonehouse,,,Plymouth,Devon                         ,England                       ,PL1 3QS,Wider Public Sector,Private Sector Enabler,False
+10001119,Atkinson Secure Unit,,Atkinson Close,Beacon Lane,,Exeter,Devon                         ,England                       ,EX4 8NA,Wider Public Sector,Private Sector Enabler,False
+10001117,ASA 76 and ASA 80,,"Mqes Rlc,9 Alice Templar Close",Dryden Road,,Exeter,Devon                         ,England                       ,EX2 6AE,Wider Public Sector,Private Sector Enabler,False
+10001112,Torbay LEA,,Old Way,Torquay Road,,Dartington,Devon                         ,England                       ,TQ3 2TE,Wider Public Sector,Private Sector Enabler,False
+10001105,Dewsbury College,,Halifax Road,,,Dewsbury,West Yorkshire                ,England                       ,WF13 2AS,Wider Public Sector,Colleges of Further Education,False
+10001097,Youth Hostel Association (England and Wales),,Trevelyan House,Dimple Road,,Matlock,Derbyshire                    ,England                       ,DE4 3YH,Wider Public Sector,Private Sector Enabler,False
+10001090,Sunrise National Data Base Royal Mail,,1st Floor A Block Rowland Hill House,Bythorpe Road,,Chesterfield,Derbyshire                    ,England                       ,S49 1HQ,Wider Public Sector,Private Sector Enabler,False
+10001088,Strada Associates,,118 Green Lane,,,Derby,Derbyshire                    ,England                       ,DE1 1RY,Wider Public Sector,Private Sector Enabler,False
+10001079,South Derbyshire Chamber of Commerce,,Innovation House,Riverside Park,Raynesway,Derby,Derbyshire                    ,England                       ,DE21 7BF,Wider Public Sector,Other,False
+10001077,Residential Services,,Birchcroft,38A Main Street,,Repton,Derbyshire                    ,England                       ,DE65 6EZ,Wider Public Sector,Private Sector Enabler,False
+10001067,North Derbyshire Womens Aid,,PO Box 55,West Street,,Chesterfield,Derbyshire                    ,England                       ,S40 1XF,Wider Public Sector,Private Sector Enabler,False
+10001064,North Derbyshire Chamber of Commerce,,Commerce Centre,,,Chesterfield,Derbyshire                    ,England                       ,S41 1NA,Wider Public Sector,Private Sector Enabler,False
+10001051,High Peak and Dales P.C.T,,Walton Hospital,Whitecotes Lane,,Chesterfield,Derbyshire                    ,England                       ,S40 3HW,Wider Public Sector,Private Sector Enabler,False
+10001049,Glossop Womens Aid,,Main Office,,,Glossop,Derbyshire                    ,England                       ,SK13 8AE,Wider Public Sector,Private Sector Enabler,False
+10001032,Derby Diocesan Board Of Education,,Derby Church House,Full Steet,,Derby,Derbyshire                    ,England                       ,DE1 3DR,Wider Public Sector,Private Sector Enabler,False
+10001026,Community Healthcare Services (North Der,,Trust HQ Walton Hospital,Whitecotes Lane,,Chesterfield,Derbyshire                    ,England                       ,S40 3HN,Wider Public Sector,Private Sector Enabler,False
+10001023,Chesterfield/North Derbyshire Royal Hosp,,Top Road,Calow,,Chesterfield,Derbyshire                    ,England                       ,S44 5BL,Wider Public Sector,Private Sector Enabler,False
+10001018,Broomfield College,,Morley,,,Derby,Derbyshire                    ,England                       ,DE7 6DN,Wider Public Sector,Colleges other,False
+10001017,Bradbury Community House,,Market Street,,,Glossop,Derbyshire                    ,England                       ,SK13 8AR,Wider Public Sector,Private Sector Enabler,False
+10001015,Bonsall Adventure Camp,,Uppertown Lane,Bonsall,,Matlock,Derbyshire                    ,England                       ,DE4 2AW,Wider Public Sector,Private Sector Enabler,False
+10001000,High Vis Cleaning,,6 Sunnybank,,,Rawsley,Derbyshire                    ,England                       ,DE4 2DX,Wider Public Sector,Private Sector Enabler,False
+10000998,Sun Centre and Pavilion Theatre,,Promenade,,,Rhyl,Denbighshire                  ,Wales                         ,LL18 3AQ,Wider Public Sector,Private Sector Enabler,False
+10000994,Logan Botanic Gardens,,Main Office,,,Stranraer,Dumfries & Galloway           ,Scotland                      ,DG9 9ND,Wider Public Sector,Private Sector Enabler,False
+10000966,Newton Rigg College,,Newton Rigg,,,Penrith,Cumbria                       ,England                       ,CA11 0AH,Wider Public Sector,Colleges other,False
+10000965,Neighbourhood Revitalisation,,2 Gladstone Street,,,Workington,Cumbria                       ,England                       ,CA14 2YE,Wider Public Sector,Private Sector Enabler,False
+10000963,MODBad Longtown,,Main Office,,, ,,England                       ,OO,Wider Public Sector,Private Sector Enabler,False
+10000962,MOD WSM,,Warcop,,,Appleby-In-Westmorla,Cumbria                       ,England                       ,CA16 6PA,Central Government,,False
+10000952,Institute Of Terrestrial Ecology,,Windermere Rd,,,Grange-Over-Sands,Cumbria                       ,England                       ,LA11 6JU,Wider Public Sector,Private Sector Enabler,False
+10000950,Howgill Family Centre,,14/15 Howgill Street,,,Whitehaven,Cumbria                       ,England                       ,CA28 7HL,Wider Public Sector,Private Sector Enabler,False
+10000948,Ghyll Head Outdoor Education Centre,,Ghyll Head,,,Windermere,Cumbria                       ,England                       ,LA23 3LN,Wider Public Sector,Private Sector Enabler,False
+10000941,DTS,,B.A.D. Longtown,,,Carlisle,Cumbria                       ,England                       ,CA6 5LX,Wider Public Sector,Private Sector Enabler,False
+10000940,DTEO - COMAX,,Eskmeals,,,Millom,Cumbria                       ,England                       ,LA19 5YR,Wider Public Sector,Private Sector Enabler,False
+10000938,Derwentwater Youth Hostel,,Barrow House,Borrowdale,,Keswick,Cumbria                       ,England                       ,CA12 5UR,Wider Public Sector,Private Sector Enabler,False
+10000929,Cumbria Institute of the Arts,,Brampton Road,,,Carlisle,Cumbria                       ,England                       ,CA3 9AY,Wider Public Sector,,False
+10000926,Connected Cumbria,,Town Hall,,,Maryport,Cumbria                       ,England                       ,CA13 6BH,Wider Public Sector,Private Sector Enabler,False
+10000917,Brampton Public Utility Society Ltd,,Old Brewery,,,Brampton,Cumbria                       ,England                       ,CA8 1TR,Wider Public Sector,Private Sector Enabler,False
+10000902,British Cattle Movement Service,,Curwen Road,,,Workington,Cumbria                       ,England                       ,CA14 2DD,Central Government,NDPB,False
+10000898,Cornwall Rural Housing Association,,2 Pike Street,Liskeard,Cornwall,Liskeard,Cornwall,England,PL14 3JE,Wider Public Sector,Housing Associations,False
+10000891,Truro College,,College Road,,,Truro,Cornwall                      ,England                       ,TR1 3XX,Wider Public Sector,Colleges of Further Education,False
+10000890,Smile Centre The,,39 Church Street,,,Liskeard,Cornwall                      ,England                       ,PL14 3AQ,Wider Public Sector,Private Sector Enabler,False
+10000888,St Petroc's Society Ltd,,1st Floor,1-2 Victoria Square,,Truro,Cornwall                      ,England                       ,TR1 2RS,Wider Public Sector,Private Sector Enabler,False
+10000878,Restormel Borough Council,,Restormel Borough Offices,39 Penwinnick Road,,St. Austell,Cornwall                      ,England                       ,PL25 5DR,Wider Public Sector,District Council,False
+10000875,Penwith District Council,,Council Offices,St Clare,,Penzance,Cornwall                      ,England                       ,TR18 3QW,Wider Public Sector,District Council,False
+10000874,Penwith College,,St Clare Street,,,Penzance,Cornwall                      ,England                       ,TR18 2SA,Wider Public Sector,Colleges of Further Education,False
+10000870,North Cornwall District Council,,Higher Trenant Road,,,Wadebridge,Cornwall                      ,England                       ,PL27 6TW,Wider Public Sector,District Council,False
+10000865,Kerrier District Council,,Council Offices,Dolcoath Avenue,,Cambourne,Cornwall                      ,England                       ,TR14 8SX,Wider Public Sector,District Council,False
+10000861,Fred Lovering Housing Association Ltd,,Caprera,61 Truro Road,,St Austell,Cornwall                      ,England                       ,PL25 5JG,Wider Public Sector,Housing Associations,False
+10000858,ENC RAF,,Main Office,,,St Mawgan,Cornwall                      ,England                       ,TR8 4JX,Central Government,RAF,False
+10000857,Dragon Leisure Centre,,Lostwithiel Road,,,Bodmin,Cornwall                      ,England                       ,PL31 1DE,Wider Public Sector,Private Sector Enabler,False
+10000854,Culdrose Project Sponsors (CUPS) Dept,,RNAS Culdrose,,,Helston,Cornwall                      ,England                       ,TR12 7RH,Wider Public Sector,Private Sector Enabler,False
+10000847,Cornwall and Isles of Scilly H/A,,District Headquarters,John Keay House,Tregonissey Road,St Austell,Cornwall                      ,England                       ,PL25 4NQ,Wider Public Sector,Private Sector Enabler,False
+10000845,Compass CS,,Windshire House,Cooksland Road,,Bodmin,Cornwall                      ,England                       ,PL32 9RH,Wider Public Sector,Private Sector Enabler,False
+10000844,Carrick District Council,,Carrick House,Pyder Street,,Truro,Cornwall                      ,England                       ,TR1 1EB,Wider Public Sector,District Council,False
+10000841,Caradon District Council,,Luxstowe House,,,Liskeard,Cornwall                      ,England                       ,PL14 3DZ,Wider Public Sector,District Council,False
+10000833,Kerrier Homes Trust,,Ferris House  Dolcoath Avenue,,,Cambourne,Cornwall                      ,England                       ,TR14 8SX,Wider Public Sector,Private Sector Enabler,False
+10000832,Fairfield Country Rest Home,,Launcells,,,Near Bude,Cornwall                      ,England                       ,EX23 9NH,Wider Public Sector,Private Sector Enabler,False
+10000831,Coverac Youth Hostel,,Parc Behan School Hill,,,Helston,Cornwall                      ,England                       ,TR12 6SA,Wider Public Sector,Private Sector Enabler,False
+10000830,Ysgol Llangwm,,Llangum,,,Corwen,Conway                        ,Wales                         ,LL21 0RA,Wider Public Sector,Education,False
+10000829,Ysgol Iau Hen Golwyn,,Church Walks,,,Old Colwyn,Conway                        ,Wales                         ,LL29 9RU,Wider Public Sector,Education,False
+10000828,Ysgol Bro Gwydir,,Heol Watling,,,Llanrwst,Conway                        ,Wales                         ,LL26 0EY,Wider Public Sector,Education,False
+10000822,Ysgol Bryn Elian,,Windsor Drive,,,Colwyn Bay,Clwyd                         ,Wales                         ,LL29 8HU,Wider Public Sector,Private Sector Enabler,False
+10000821,Wrexham Local Health Board,,Wrexham Technology Park,,,Wrexham,Clwyd                         ,Wales                         ,LL13 7YP,Wider Public Sector,Health,False
+10000819,Wrexham Training,,Llysfasi College,Selin Puleston Ruabon Road,,Wrexham,Clwyd                         ,Wales                         ,LL13 7RF,Wider Public Sector,Private Sector Enabler,False
+10000818,North East Wales NHS Trust,,Maelor General Hospital ,Croesnewydd Road,,Wrexham,Clwyd                         ,Wales                         ,LL13 7TD,Wider Public Sector,Health,False
+10000816,Territorial Auxiliary and Volunteer Reserve Associations Wales,,Earl Road,,,Mold,,England                       ,CH7 1AD,Wider Public Sector,Private Sector Enabler,False
+10000765,OLDHAM J,,Priorslegh Medical Centre,Civic Centre Park Lane,,Poynton,Cheshire                      ,England                       ,SK12 1GP,Wider Public Sector,Private Sector Enabler,False
+10000744,Urenco (Capemhurst) Ltd,,Capenhurst,,,Chester,Cheshire                      ,England                       ,CH1 6ER,Wider Public Sector,Private Sector Enabler,False
+10000738,Tarporley Community High School,,Eaton Road,,,Tarporley,Cheshire                      ,England                       ,CW6 0BL,Wider Public Sector,Private Sector Enabler,False
+10000737,SureStock Ltd,,Kendrick Wing,Lovely Lane,,Warrington,Cheshire                      ,England                       ,WA5 1QG,Wider Public Sector,Private Sector Enabler,False
+10000734,Stockport Direct Services,,2nd Floor Enterprise House Oakhurst Dri,Cheadle Heath,,Stockport,Cheshire                      ,England                       ,SK3 0XS,Wider Public Sector,Private Sector Enabler,False
+10000732,Stagecoach Sevices Limited,,Daw Bank,,,Stockport,Cheshire                      ,England                       ,SK3 0DU,Wider Public Sector,Transport,False
+10000722,SAFE,,Header House HPTO,PO Box 10 RAF Burtonwood,,Warrington,Cheshire                      ,England                       ,WA5 3AL,Wider Public Sector,Private Sector Enabler,False
+10000721,Royal School For The Deaf,,160-166 Stanley Road,Cheadle Hulme,,Cheadle Hulme,Cheshire                      ,England                       ,SK8 6RQ,Wider Public Sector,Private Sector Enabler,False
+10000720,ROMEC,,1st Floor Applicon House,Unit 6,Gotts Road,Stockport,Cheshire                      ,England                       ,SK1 1AB,Wider Public Sector,Private Sector Enabler,False
+10000717,Rent Officer Service,,20 Dallam Lane,,,Warrington,Cheshire                      ,England                       ,WA2 7NG,Wider Public Sector,Private Sector Enabler,False
+10000716,Reflec plc,,Road One,Winsford Industrial Estate,,Winsford,Cheshire                      ,England                       ,CW7 3QQ,Wider Public Sector,Private Sector Enabler,False
+10000713,Poynton Parish Church,,St George with St Martin,The Vicarage,,Poynton,Cheshire                      ,England                       ,SK12 1AF,Wider Public Sector,Private Sector Enabler,False
+10000701,MOD DE SSG,,"Unit 12 Taurus Park,",Europa Boulevard,Westbrook,Warrington,Cheshire                      ,England                       ,WA5 7ZT,Central Government,,False
+10000695,Macclesfield Borough Council,,Central Services Station,Town Hall,,Macclesfield,Cheshire                      ,England                       ,SK10 1DX,Wider Public Sector,District Council,False
+10000676,Helsby Methodist Church,,The Manse,Coppins Close Helsby,,Frodsham,Cheshire                      ,England                       ,WA6 9QL,Wider Public Sector,Private Sector Enabler,False
+10000670,Griffin Lodge,,4&5 Griffin Lane,Heald Green,,Cheadle,Cheshire                      ,England                       ,SK8 3PZ,Wider Public Sector,Private Sector Enabler,False
+10000666,GIB Uk Ltd,,Clemence House,Cheadle Hulme,,Cheadle,Cheshire                      ,England                       ,SK8 5AT,Wider Public Sector,Private Sector Enabler,False
+10000664,Facilities Management Services,,Cherry Tree Hospital,Cherry Tree La,,Stockport,Cheshire                      ,England                       ,SK2 7PZ,Wider Public Sector,Private Sector Enabler,False
+10000659,Drs Rowland Taylor and Gleek,,Park Rd,,,Tarporley,Cheshire                      ,England                       ,CW6 0BE,Wider Public Sector,Private Sector Enabler,False
+10000657,Direct Communications Ltd,,Unit 36 Westminster Ind Park,,,Ellesmere Port,Cheshire                      ,England                       ,CH65 3DU,Wider Public Sector,Private Sector Enabler,False
+10000654,David Lewis Centre,,Mill Lane,Warford,,Alderley Edge,Cheshire                      ,England                       ,SK9 7UD,Wider Public Sector,Private Sector Enabler,False
+10000651,Crewe and Nantwich Borough Council,,Municipal Buildings,Earle Street,,Crewe,Cheshire                      ,England                       ,CW2 7QX,Wider Public Sector,District Council,False
+10000650,Cpro Cheadle Cpro Cheadle Hulme,,Po Box 42,,,Stockport,Cheshire                      ,England                       ,SK1 1ED,Wider Public Sector,Private Sector Enabler,False
+10000648,Congleton Borough Council,,Municipal Offices,Market Square,,Congleton,Cheshire                      ,England                       ,CW12 1EX,Wider Public Sector,District Council,False
+10000647,Community Integrated Care Ltd,,2 Old Market Court,Miners Way,,Widnes,Cheshire                      ,England                       ,WA8 7RD,Wider Public Sector,Private Sector Enabler,False
+10000646,CLS Care Services,,Market St,Market Street,,Nantwich,Cheshire                      ,England                       ,CW5 5DQ,Wider Public Sector,Private Sector Enabler,False
+10000641,Chester City Council,,The Forum,,,Chester,Cheshire                      ,England                       ,CH1 2HS,Wider Public Sector,District Council,False
+10000638,Cheshire Nursing Home Services,,94 Long Lane,,,Middlewich,Cheshire                      ,England                       ,CW10 0EN,Wider Public Sector,Private Sector Enabler,False
+10000634,Cheshire and Warrington Information Consortium,,Fire Service Headquarters,Saddler Road,,Winsford,Cheshire                      ,England                       ,CW7 2FG,Wider Public Sector,Private Sector Enabler,False
+10000627,Together Trust The,,Schools Hill,Cheadle,Cheshire,Cheadle,Cheshire,England,SK8 1JE,Wider Public Sector,Charity,False
+10000626,Bowlacre Home,,Stockport Road,,,Stockport,Cheshire                      ,England                       ,SK14 5EZ,Wider Public Sector,Private Sector Enabler,False
+10000616,Access Data Direct,,Suite 11 Baxall Business Centre,Adswood Road,,Stockport,Cheshire                      ,England                       ,SK3 8LF,Wider Public Sector,,False
+10000615,Ysgol Gymunedol Cribyn,,Cribyn Community School,Cribyn,Llanbedr Pont Steffan,Lampeter,Ceredigion                    ,Wales                         ,SA48 7NG,Wider Public Sector,Education,False
+10000612,IGER Aberystwyth Research Centre,,"Plas Gogerddan,",Aberystwyth,,Aberystwyth,Ceredigion                    ,Wales                         ,SY23 3EB,Wider Public Sector,Private Sector Enabler,False
+10000611,Coleg Ceredigion,,Llanbadam Campus,,,Aberystwyth,Ceredigion                    ,Wales                         ,SY23 3BP,Wider Public Sector,Private Sector Enabler,False
+10000609,Ysgol Gymunedol Cae'r Felin,,School Office,,,Pencader,Carmarthenshire               ,Wales                         ,SA39 9AA,Wider Public Sector,Education,False
+10000608,World Horizon Ltd,,North Dock,,,Llanelli,Carmarthenshire               ,Wales                         ,SA15 2LF,Wider Public Sector,Private Sector Enabler,False
+10000607,National Botanic Garden of Wales The,,Middleton Hall,,,Wanarthne,Carmarthenshire               ,Wales                         ,SA32 8HG,Wider Public Sector,Private Sector Enabler,False
+10000606,Community of Many Names of God The,,Skandavale,,,Llanpumsaint,Carmarthenshire               ,Wales                         ,SA33 6JT,Wider Public Sector,Private Sector Enabler,False
+10000587,Papworth Trust The,,Bernard Sunley Centre,Papworth Everard,,Cambridge,Cambridgeshire                ,England                       ,CB3 8RG,Wider Public Sector,Private Sector Enabler,False
+10000580,St Ivo Recreation Centre,,Westwood Road,St. Ives,,Huntingdon,Cambridgeshire                ,England                       ,PE27 6WU,Wider Public Sector,Private Sector Enabler,False
+10000577,Sawtry Sports Centre,,Fen Lane,Sawtry,,Huntingdon,Cambridgeshire                ,England                       ,PE17 5TH,Wider Public Sector,Private Sector Enabler,False
+10000563,Over Community Association,,24 Giffords Way,,,Over,Cambridgeshire                ,England                       ,CB4 5UB,Wider Public Sector,Private Sector Enabler,False
+10000550,JNCC,,Monkstone House,City Road,,Peterborough,Cambridgeshire                ,England                       ,PE1 1JY,Wider Public Sector,Private Sector Enabler,False
+10000534,Hercules IPT,,ES (Air) DLO MOD,Palmer Pavilion,RAF Wyton,Huntingdon ,Cambridgeshire                ,England                       ,PE28 2EA,Wider Public Sector,Private Sector Enabler,False
+10000533,Hamer Supply Sqn,,RAF Wittering,,,Peterborough,Cambridgeshire                ,England                       ,PE8 6HB,Wider Public Sector,Private Sector Enabler,False
+10000531,Government Office for the East of England,,49-53 Goldington Road,Heron House,Milton Road,Bedford,Cambridgeshire                ,England                       ,CB4 1YG,Central Government,NDPB,False
+10000526,Eurest,,Raf Brampton,,,Huntingdon,Cambridgeshire                ,England                       ,PE18 5QT,Wider Public Sector,Private Sector Enabler,False
+10000525,Emmaus UK,,48 Kingston Street,,,Cambridge,Cambridgeshire                ,England                       ,CB1 2NK,Wider Public Sector,Private Sector Enabler,False
+10000522,East Cambridgeshire Care and Repair,,11b Churchgate Street,Sohom,,Ely,Cambridgeshire                ,England                       ,CB7 5DS,Wider Public Sector,Private Sector Enabler,False
+10000518,Det Comd (N),,1 Abbey Court,Waterbeach,,Waterbeach,Cambridgeshire                ,England                       ,CB5 9PT,Wider Public Sector,Private Sector Enabler,False
+10000514,Cognitive Research Trust,,2 Charles Drive,Hartford,,Huntingdon,Cambridgeshire                ,England                       ,PE29 1SJ,Wider Public Sector,Private Sector Enabler,False
+10000512,Chilterns Thames and Eastern R A P,,Great Eastern House,Tenison Rd,,Cambridge,Cambridgeshire                ,England                       ,CB1 2TR,Wider Public Sector,Private Sector Enabler,False
+10000511,Cathedral Cafe,,Peterborough Cathedral,24 Minster Crescent,,Peterborough,Cambridgeshire                ,England                       ,PE1 1XZ,Wider Public Sector,Private Sector Enabler,False
+10000493,Buckinghamshire Locality Network Ltd,,8A Temple Square,,,Aylesbury,,England                       ,HP20 2QH,Wider Public Sector,Private Sector Enabler,False
+10000492,HM Government Communication Centre,,19 Hanslope Park Hanslope,Milton Keynes,Buckinghamshire,Milton Keynes,Buckinghamshire,England,MK19 7BH,Central Government,Executive Agency,False
+10000489,Youth Information Service,,Saxon Court,502 Avebury Boulevard,,Milton Keynes,Buckinghamshire               ,England                       ,MK9 3HS,Wider Public Sector,Private Sector Enabler,False
+10000488,Wycombe Leisure Ltd,,Pound Lane,,,Marlow,Buckinghamshire               ,England                       ,SL7 2AE,Wider Public Sector,Private Sector Enabler,False
+10000485,Wycliffe Centre,,Horsleys Green,,,High Wycombe,Buckinghamshire               ,England                       ,HP14 3XL,Wider Public Sector,Private Sector Enabler,False
+10000477,Freemantal Trust The,,Ringwood House,Walton Street,,Aylesbury,Buckinghamshire               ,England                       ,HP21 7QP,Wider Public Sector,Private Sector Enabler,False
+10000470,St Tiggy Winkle,,Aston Road,Haddenham,,Aylesbury,Buckinghamshire               ,England                       ,HP17 8AF,Wider Public Sector,Private Sector Enabler,False
+10000468,SITA,,The Pickeridge,Stoke Common Road,,Fulmer,Buckinghamshire               ,England                       ,SL3 6HA,Wider Public Sector,Private Sector Enabler,False
+10000467,SIGN THE NATIONAL SOCIETY FOR MENTAL HEALTH AND DEAFNESS,,5 BARING ROAD,,,Beaconsfield,Buckinghamshire               ,England                       ,HP9 2NB,Wider Public Sector,Private Sector Enabler,False
+10000465,Shanks Group Plc,,Astor House,Station Road,,Bourne End,Buckinghamshire               ,England                       ,SL8 5YP,Wider Public Sector,Private Sector Enabler,False
+10000464,Service Sound and Vision Corporation,SSVC,Chalfont Grove   Narcot Lane,Chalfont St Peter,,Gerrards Cross,Buckinghamshire               ,England                       ,SL9 8TW,Wider Public Sector,Private Sector Enabler,False
+10000463,Schorne Nursery,,c/o Wingate,30A Winslow Road,,Granborough,Buckinghamshire               ,England                       ,MK18 3NJ,Wider Public Sector,Private Sector Enabler,False
+10000458,RAF Daws Hill,,1400 Daws Hill Lane,Daws Hill Lane,,High Wycombe,Buckinghamshire               ,England                       ,HP11 1PZ,Central Government,RAF,False
+10000454,National Society For Epilepsy,,Chalfont Centre,Chalfont St. Peter,,Gerrards Cross,Buckinghamshire               ,England                       ,SL9 0RJ,Wider Public Sector,Private Sector Enabler,False
+10000453,National Society Epilepsy Supported Housing,,Sarcus Dean,Rickmansworth Lane,Chalfont St Peter,Gerrards Cross,Buckinghamshire               ,England                       ,SL9 OLX,Wider Public Sector,Private Sector Enabler,False
+10000451,Milton Keynes Primary Care Trust,,The Hospital Campus,Standing Way,Eaglestone,Milton Keynes,Buckinghamshire               ,England                       ,MK6 5NG,Wider Public Sector,PCT - Commissioning,False
+10000446,Meat and Livestock Commission,,Winterhill House,Winterhill,Snowdon Drive,Milton Keynes,Buckinghamshire               ,England                       ,MK6 5LD,Central Government,NDPB,False
+10000428,CSL Group Ltd,,Ashton House,Silbury Boulevard,,Milton Keynes,Buckinghamshire               ,England                       ,MK9 2HG,Wider Public Sector,Private Sector Enabler,False
+10000427,Cookham Day Centre (Charity),,"Elizabeth House,",Station hill,,Cookham,Buckinghamshire               ,England                       ,SL6 9BS,Wider Public Sector,Private Sector Enabler,False
+10000426,Church of Immaculate Heart of Mary,,23 High Street,,,Great Missenden,Buckinghamshire               ,England                       ,HP16 9AA,Wider Public Sector,Private Sector Enabler,False
+10000425,Chiltern Leisure Trust,,Herald House,150 Station Road,,Amersham,Buckinghamshire               ,England                       ,HP6 5DW,Wider Public Sector,Private Sector Enabler,False
+10000419,Buckinghamshire Shared Services,,3rd Floor,Verney House,Gatehouse Road,Aylesbury,Buckinghamshire               ,England                       ,HP19 8ET,Wider Public Sector,Private Sector Enabler,False
+10000410,BARTLETT DR,,Cobbs Garden Surgery,West street,,Olney,Buckinghamshire               ,England                       ,MK46 5QG,Wider Public Sector,Private Sector Enabler,False
+10000395,Slough Community Centre,,Montem Leisure Centre,Montem Lane,,Slough,Berkshire                     ,England                       ,SL1 2QS,Wider Public Sector,Private Sector Enabler,False
+10000389,CMPS,,The Govts Centre for Management  Policy Studies,Sunningdale Park,,Ascot,Berkshire                     ,England                       ,SL5 0QE,Wider Public Sector,Private Sector Enabler,False
+10000379,Woosehill Surgery,,Emmview Close,Woosehill,,Wokingham,Berkshire                     ,England                       ,RG41 3DA,Wider Public Sector,Private Sector Enabler,False
+10000376,Windsor Leisure Centre,,Clewer Mead,Stovell Road,,Windsor,Berkshire                     ,England                       ,LS4 5JB,Wider Public Sector,Private Sector Enabler,False
+10000375,Windsor Lawn Tennis Club,,20 Glams Road,,,Windsor,Berkshire                     ,England                       ,SL4 5AS,Wider Public Sector,Private Sector Enabler,False
+10000356,Thames Valley Chamber Training,,The Training Centre,467 Malton Avenue,,Slough,Berkshire                     ,England                       ,SL1 4QU,Wider Public Sector,Private Sector Enabler,False
+10000354,Symons Medical Centre,,25 All Saints Avenue,,,Maidenhead,Berkshire                     ,England                       ,SL6 6EL,Wider Public Sector,Private Sector Enabler,False
+10000339,Renewable Power Association,,Room 400 Kings House,Kings Road,,Reading,Berkshire                     ,England                       ,RG31 4ES,Wider Public Sector,Private Sector Enabler,False
+10000338,Redwood House Surgery,,Cannon Lane,,,Maidenhead,Berkshire                     ,England                       ,SL6 3PH,Wider Public Sector,Private Sector Enabler,False
+10000336,Reading Library,,Abbey Square,,,Reading,Berkshire                     ,England                       ,RG1 3BQ,Wider Public Sector,Private Sector Enabler,False
+10000330,Ravenswood Settlement,,Ravenswood Av,Nine Mile Ride,,Crowthorne,Berkshire                     ,England                       ,RG45 6BQ,Wider Public Sector,Private Sector Enabler,False
+10000329,RAF Alconbury,,Main Office,,,Reading,Berkshire                     ,England                       ,RG12 3DD,Central Government,RAF,False
+10000328,R&M Construction Services,,77 South Street,,,Reading,Berkshire                     ,England                       ,RG1 4RA,Wider Public Sector,Private Sector Enabler,False
+10000326,Prospects,,10 Eaton Place,,,Reading,Berkshire                     ,England                       ,RG1 7LP,Wider Public Sector,Private Sector Enabler,False
+10000316,National Foundation for Educational Research,,The Mere,Upton Park,,Slough,Berkshire                     ,England                       ,SL1 2DQ,Wider Public Sector,Private Sector Enabler,False
+10000315,Montem Cafe,,Montem Sports Centre,Montem Lane,,Slough,Berkshire                     ,England                       ,SL1 3UQ,Wider Public Sector,Private Sector Enabler,False
+10000307,JSCSC Bracknell,,Broad Lane,,,Bracknell,Berkshire                     ,England                       ,RG12 9TU,Central Government,,False
+10000305,Intervention Board,,40 Caversham Road,PO Box 69,,Reading,Berkshire                     ,England                       ,RG1 3YD,Wider Public Sector,Private Sector Enabler,False
+10000304,Interserve Plc,,Interserve House,Ruscombe Park,Twyford,Reading,Berkshire                     ,England                       ,RG10 9JU,Wider Public Sector,Private Sector Enabler,False
+10000294,Furnival H Co-Op Ltd,,141 Furnival Avenue,,,Slough,Berkshire                     ,England                       ,SL2 1DF,Wider Public Sector,Private Sector Enabler,False
+10000292,FEBEG,,Charters Road,,,Ascot,Berkshire                     ,England                       ,SL5 9QD,Wider Public Sector,Private Sector Enabler,False
+10000291,European Centre for Medium Range Weather Forecasting,,Shinfield Park,Shinfield Road,,Reading,Berkshire                     ,England                       ,RG2 9AX,Wider Public Sector,Private Sector Enabler,False
+10000289,Englefield Res Homes Assn Ltd,,Estate Office,"Englefield Road,Theale",,Reading,Berkshire                     ,England                       ,RG7 5DZ,Wider Public Sector,Private Sector Enabler,False
+10000287,Elizabeth Fry Hostel,,6 Coley Avenue,,,Reading,Berkshire                     ,England                       ,RG1 6LQ,Wider Public Sector,Private Sector Enabler,False
+10000286,Edward Jenner Institute for Vaccine Research,,Compton,,,Near Newbury,Berkshire                     ,England                       ,RG20 7NN,Wider Public Sector,Private Sector Enabler,False
+10000285,Econopower Consulting Eng,,Wexham Road,Wexham,,Slough,Berkshire                     ,England                       ,SL,Wider Public Sector,Private Sector Enabler,False
+10000281,East Berks Care and Housing,,57 Grenfell Road,,,Maidenhead,Berkshire                     ,England                       ,SL6 1ES,Wider Public Sector,Private Sector Enabler,False
+10000280,Durable Berkeley Co Ltd,,10-13 Marsach Street,,,Reading,Berkshire                     ,England                       ,RG4 5A4,Wider Public Sector,Private Sector Enabler,False
+10000278,Downe House,,Cold Ash,Thatcham,,Thatcham,Berkshire                     ,England                       ,RG18 9JJ,Wider Public Sector,Private Sector Enabler,False
+10000277,DCSA UKNDA - ELDAC,,Despatch Section,Station Road,,Thatcham,Berkshire                     ,England                       ,RG19 4RA,Wider Public Sector,Private Sector Enabler,False
+10000273,Commonwealth Wargrave Commission,,2 Marlowe Road,,,Maidenhead,Berkshire                     ,England                       ,SL6 7DX,Wider Public Sector,Private Sector Enabler,False
+10000269,National School of Government,,Sunningdale Park,Larch Avenue,,Ascot,Berkshire                     ,England                       ,SL5 0QB,Central Government,,False
+10000268,Centre For British Teachers,,1 The Chambers,East St,,Reading,Berkshire                     ,England                       ,RG1 4JD,Wider Public Sector,Private Sector Enabler,False
+10000260,Bethnay Care Trust,,Boyne Court,Boyndon Road,,Maidenhead,Berkshire                     ,England                       ,SL6 4EU,Wider Public Sector,Private Sector Enabler,False
+10000258,Berkshire Shared Services Organisations,,Wokingham Hospital,41 Barkham Road,,Wokingham,Berkshire                     ,England                       ,RG41 2RE,Wider Public Sector,Support,False
+10000257,Berkshire Shared Services,,Upton Hospital,Albert Street,,Slough,Berkshire                     ,England                       ,SL1 2BJ,Wider Public Sector,Private Sector Enabler,False
+10000253,Berkshire  Shared Service Organisation,,Kings Point,120 Kings Road,,Reading,Berkshire                     ,England                       ,RG1 3DA,Wider Public Sector,Private Sector Enabler,False
+10000243,Wigmore Church and Community Centre,,Crawley Green Road,,,Luton,Bedfordshire                  ,England                       ,LU2 9AG,Wider Public Sector,Private Sector Enabler,False
+10000235,St Mary the Virgin,,The Vicarage,Church Road,Harlington,Dunstable,Bedfordshire                  ,England                       ,LU5 6LE,Wider Public Sector,Private Sector Enabler,False
+10000233,South Bedfordshire District Council,,District Offices,High Street North,,Dunstable,Bedfordshire                  ,England                       ,LU6 1LF,Wider Public Sector,District Council,False
+10000228,Royal Air Force Stanbridge,,Main Office,,, ,,England                       ,OO,Wider Public Sector,Private Sector Enabler,False
+10000226,RAF,,85,Raf Henlow,,Henlow,Bedfordshire                  ,England                       ,SS16 6GN,Wider Public Sector,Private Sector Enabler,False
+10000223,MOD Procurement Executive and R&D,,Clapham Tunnel Site,,,Bedford,Bedfordshire                  ,England                       ,MK,Central Government,,False
+10000222,Mid Bedfordshire District Council,,12 Dunstable Street,Ampthill,Ampthilll,Bedford,Bedfordshire                  ,England                       ,MK45 2JU,Wider Public Sector,District Council,False
+10000218,Luton Day Centre For Homeless,,141 Park Street,,,Luton,Bedfordshire                  ,England                       ,LU1 3HG,Wider Public Sector,Private Sector Enabler,False
+10000215,London Luton Airport,,Percival House,Percival Way,,Luton,Bedfordshire                  ,England                       ,LU2 9LY,Wider Public Sector,Private Sector Enabler,False
+10000202,Flintwick Baptist Church,,13 Kings Road,,,Flitwick,Bedfordshire                  ,England                       ,MK45 1EJ,Wider Public Sector,Private Sector Enabler,False
+10000201,First Place Housing,,4a Tavistock Place,Tavistock Street,,Dunstable,Bedfordshire                  ,England                       ,LU6 1NG,Wider Public Sector,Private Sector Enabler,False
+10000199,Emmaus Carlton,,Pine Trees,School Lane,,Carlton,Bedfordshire                  ,England                       ,MK43 7GL,Wider Public Sector,Private Sector Enabler,False
+10000189,Challney High School for Boys,,Stoneygate Road,,,Luton,Bedfordshire                  ,England                       ,LU4 9TS,Wider Public Sector,Private Sector Enabler,False
+10000168,WTI Training Group,,Mc Gowan House,Nobel Business Park,Ardeer,Stevenson,Ayrshire                      ,Scotland                      ,KA20 3LT,Wider Public Sector,Private Sector Enabler,False
+10000165,St Andrews Academy,,Jacks Road,,,Saltcoats,Ayrshire                      ,Scotland                      ,KA21 5NT,Wider Public Sector,Private Sector Enabler,False
+10000161,HMS Gannet,,Monkton,,,Prestwick,Ayrshire                      ,Scotland                      ,KA9 2RZ,Central Government,Navy,False
+10000158,Garnock Academy,,School Road,,,Kilbirnie,Ayrshire                      ,Scotland                      ,KA25 7AX,Wider Public Sector,Private Sector Enabler,False
+10000155,Doctor Fegan and Partners,,The Surgery,107B Main Street,,West Kilbride,Ayrshire                      ,Scotland                      ,KA73 9AR,Wider Public Sector,Private Sector Enabler,False
+10000153,Cunninghame District Council,,Cunninghame House,,,Irvine,Ayrshire                      ,Scotland                      ,KA12 8EE,Wider Public Sector,Local Government,False
+10000146,Worthingtons of Thorbury,,14 High Street,,,Bristol,,England                       ,BS35 2AQ,Wider Public Sector,Private Sector Enabler,False
+10000139,Torpy and Partners Ltd,,Merchants House,26-28 Regent Street,Clifton,Bristol,,England                       ,BS8 4HG,Wider Public Sector,Private Sector Enabler,False
+10000137,Royal Marines Reserve (Bristol),,Dorset House Litfield Place,Clifton,,Bristol,,England                       ,BS8 3NA,Wider Public Sector,Private Sector Enabler,False
+10000136,Royal Fleet Auxiliary,,Room 506 Carpenter House,Broadquay,,Bath,,England                       ,BA1 5AB,Wider Public Sector,Private Sector Enabler,False
+10000128,National Blood Authority,NHSBT,1st Floor 2440 The Quadrant,Aztec West,Almondsbury,Bristol,,England                       ,BS32 4AQ,Wider Public Sector,Support,False
+10000127,Nailsea Health Centre Chambers,,Somerset Square,Nailsea,,Bristol,,England                       ,BS48 1RQ,Wider Public Sector,Private Sector Enabler,False
+10000124,Ministry Of Defence Foxhill,,Site Management 2 Central Store   C/O Block C,Bath,Somerset,Bath,Somerset,England,BA1 5AB,Central Government,TBA,False
+10000120,Greenhill House Cheshire Home,,South Road,Timsbury,,Bath,,England                       ,BA3 1ES,Wider Public Sector,Private Sector Enabler,False
+10000119,Government Office for the South West,,1st Floor,2 Rivergate,Temple Quay,Bristol,,England                       ,BS1 6ED,Central Government,NDPB,False
+10000116,Cs(Fm)s MOD,,Spur 1 Block c,Old Ensleigh,,Bath,,England                       ,BA1 5AB,Wider Public Sector,Private Sector Enabler,False
+10000115,County of Avon Social Services Dept,,Lewis House,Manvers Street,,Bath,,England                       ,BA1 1JG,Wider Public Sector,Private Sector Enabler,False
+10000112,Capitec,,Newbridge Hill,5th Floor Marble Arch Tower,55 Bryanston Street,Bath,,England                       ,BA1 3DA,Wider Public Sector,Private Sector Enabler,False
+10000110,Brunelcare,,3 Redcliff Parade West,,,Bristol,,England                       ,BS1 6SL,Wider Public Sector,Private Sector Enabler,False
+10000108,Vehicle and Operator Services Agency (VOSA),,Ashton Vale Road Ashton Gate,Bristol,Gloucestershire,Bristol,Gloucestershire,England,BS3 2JE,Central Government,NDPB,False
+10000098,Craigavon Area Hospital Group Trust,,Craigavon Area Hospital,68 Lurgan Road,,Portadown,County Armagh                 ,Northern Ireland              ,BT63 5QQ,Wider Public Sector,Health,False
+10000096,Armagh and Dungannon Health,,Gosford Place,The Mall,,Armagh,County Armagh                 ,Northern Ireland              ,BT61 9AR,Wider Public Sector,Health,False
+10000093,Glencoe Mountain Rescue Team,,South Cuil,Duror,,Appin,Argyll & Bute                 ,Scotland                      ,PA38 4DA,Wider Public Sector,Private Sector Enabler,False
+10000086,Air Publications Eng Supply Wing,,RAF Aldergrove,,,Crumlin,,Northern Ireland              ,BFPO 808,Central Government,RAF,False
+10000076,South and East Belfast Health and Social Services,,Trust Headquarters,Knockbracken Healthcare Park,Saintfield Road,Belfast,Antrim                        ,Northern Ireland              ,BT8 8BH,Wider Public Sector,Private Sector Enabler,False
+10000057,Larne Borough Council,,Smiley Buildings Victoria Road,Larne,Antrim,Larne,Antrim,Northern Ireland,BT40 1RU,Wider Public Sector,Local Government,False
+10000056,John Graham (Dromore) Ltd,,Lagan Mills,,,Dromore,Antrim                        ,Northern Ireland              ,BT25 1AS,Wider Public Sector,Private Sector Enabler,False
+10000055,Homefirst Community Trust HQ,,The Cottage,5 Greenmount Avenue,,Ballymena,Antrim                        ,Northern Ireland              ,BT43 6DA,Wider Public Sector,Private Sector Enabler,False
+10000054,Homefirst Community Trust,,60 Steeple Road,,,Antrim,Antrim                        ,Northern Ireland              ,BT41 2RJ,Wider Public Sector,Private Sector Enabler,False
+10000049,East Antrim Institute of Further and Higher Education,,400 Shore Road,,,Newtonabbey,Antrim                        ,Northern Ireland              ,BT37 9RS,Wider Public Sector,Education,False
+10000047,DRD Water Service N Ireland,,Room 108C,34 College Street,,Belfast,Antrim                        ,Northern Ireland              ,BT1 6DR,Wider Public Sector,Private Sector Enabler,False
+10000046,DRD Water Service,,Northland House,3 Frederick Street,,Belfast,Antrim                        ,Northern Ireland              ,BT1 2NS,Wider Public Sector,Private Sector Enabler,False
+10000044,DOE NI,,1st Floor,Calvert House,23 Castle Place,Belfast,Antrim                        ,Northern Ireland              ,BT1 1FY,Wider Public Sector,Private Sector Enabler,False
+10000026,Sheriff Court,,Church Street,,,Dumbarton,Angus                         ,Scotland                      ,G82 1QR,Wider Public Sector,Private Sector Enabler,False
+10000025,Royal  Marines Condor,,Royal Marine Condor,Arbroath,,Angus,,Scotland                      ,DD11 2BT,Wider Public Sector,Private Sector Enabler,False
+10000019,Dundee & Angus College,,Keptie Road,Arbroath,Angus,Arbroath,Angus,Scotland,DD11 3EA,Wider Public Sector,Education,False
+10000017,Ellon Academy,,School Hill Road,,,Ellon,Aberdeenshire                 ,Scotland                      ,AB41 9JS,Wider Public Sector,Private Sector Enabler,False
+10000013,Inverurie West Parish Church,,West Manse,Westfield Road,,Inverurie,Aberdeenshire                 ,Scotland                      ,AB51 3YS,Wider Public Sector,Private Sector Enabler,False
+10000012,Dalkia Utilities Services plc,,Unit 5,Brandony Place,Port Lethan,Aberdeen,Aberdeenshire                 ,Scotland                      ,AB12 4YF,Wider Public Sector,Private Sector Enabler,False
+10000011,Central Buchan Practice,,School Street,,,New Pitsligo,Aberdeenshire                 ,Scotland                      ,AB4 4ND,Wider Public Sector,Private Sector Enabler,False

--- a/db/data_migrate/20181015134534_import_missing_customers.rb
+++ b/db/data_migrate/20181015134534_import_missing_customers.rb
@@ -1,0 +1,26 @@
+# The CSV file was generated with the help of db/data_migrate/filter_customers.rb
+#
+# Execute with:
+#
+#   rails runner db/data_migrate/20181015134534_import_missing_customers.rb
+#
+require 'csv'
+require 'progress_bar'
+
+puts 'Reading CSV file...'
+customers_csv_path = Rails.root.join('db', 'data_migrate', '20181015134534_import_missing_customers.csv')
+csv = CSV.read(customers_csv_path, headers: true, header_converters: :symbol)
+
+puts 'Importing customers...'
+bar = ProgressBar.new(csv.count)
+csv.each do |customer_row|
+  postcode = customer_row[:postcode] == 'XXXX' ? nil : customer_row[:postcode].strip
+
+  customer = Customer.find_or_initialize_by(urn: customer_row[:urn])
+  customer.postcode = postcode
+  customer.sector = customer_row[:sector].strip.parameterize.underscore
+  customer.name = customer_row[:customername].strip
+  customer.save!
+
+  bar.increment!
+end


### PR DESCRIPTION
It looks like https://github.com/dxw/DataSubmissionServiceAPI/pull/80 missed the mark slightly, as a bunch of inactive customers were not included in the data migration.

This was noticed because the coda finance report was reporting numbers that were slightly at odds to the managment charge totals for the entire submission. The report relies on the SubmissionEntry#central_government and SubmissionEntry#wider_public_sector scopes to grab entries for each sector. The problem is, if the entry has a customer URN that isn't in the database it won't appear under either scope, resulting in it not appearing in either calculation, thus the under reporting.

We need to make sure that the ingest/validation process is tightened up such that this isn't possible in the future.