### PR TITLE
Backfill submission entry management charge and update reports/exports

### DIFF
--- a/app/models/export/coda_finance_report/row.rb
+++ b/app/models/export/coda_finance_report/row.rb
@@ -100,7 +100,7 @@ module Export
       end
 
       def management_charge
-        (total_sales * management_charge_rate / 100)
+        submission.entries.invoices.sector(sector).sum(:management_charge)
       end
 
       def management_charge_rate

--- a/app/models/export/coda_finance_report/row.rb
+++ b/app/models/export/coda_finance_report/row.rb
@@ -96,10 +96,7 @@ module Export
       end
 
       def total_sales
-        submission.entries
-                  .invoices
-                  .sector(sector)
-                  .sum { |entry| numeric_string_to_number(entry.data['Total Cost (ex VAT)']) }
+        submission.entries.invoices.sector(sector).sum(:total_value)
       end
 
       def management_charge

--- a/app/models/export/submissions/extract.rb
+++ b/app/models/export/submissions/extract.rb
@@ -11,6 +11,7 @@ module Export
             orders.total_value                AS _total_order_value,
             COALESCE(orders.entry_count, 0)   AS _order_entry_count,
             invoices.total_value              AS _total_invoice_value,
+            invoices.total_management_charge  AS _total_management_charge_value,
             COALESCE(invoices.entry_count, 0) AS _invoice_entry_count,
             MIN(blobs.filename) :: text       AS _first_filename
           POSTGRESQL
@@ -27,6 +28,7 @@ module Export
             LEFT JOIN (SELECT
                          submission_id,
                          SUM(total_value) AS total_value,
+                         SUM(management_charge) AS total_management_charge,
                          COUNT(*)         AS entry_count
                        FROM submission_entries
                        WHERE entry_type = 'invoice'
@@ -40,7 +42,7 @@ module Export
           aasm_state: RELEVANT_STATUSES
         ).group(
           'submissions.id, frameworks.short_name, orders.total_value, invoices.total_value,'\
-          'orders.entry_count, invoices.entry_count'
+          'invoices.total_management_charge, orders.entry_count, invoices.entry_count'
         )
       end
     end

--- a/app/models/export/submissions/row.rb
+++ b/app/models/export/submissions/row.rb
@@ -41,7 +41,7 @@ module Export
       end
 
       def management_charge_value
-        format('%0.2f', submission.management_charge / 100.0) if submission.management_charge
+        format_money(submission._total_management_charge_value)
       end
 
       def management_charge_rate

--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -39,6 +39,10 @@ class Framework
         def management_charge_rate(charge_rate = nil)
           @management_charge_rate ||= charge_rate
         end
+
+        def management_charge(value)
+          (value * (management_charge_rate / 100)).truncate(4)
+        end
       end
     end
 

--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -24,14 +24,14 @@ class Framework
       class << self
         ##
         # E.g. "Rail Legal Services"
-        def framework_name(value = nil)
-          @framework_name ||= value
+        def framework_name(framework_name = nil)
+          @framework_name ||= framework_name
         end
 
         ##
         # E.g. "RM3786"
-        def framework_short_name(value = nil)
-          @framework_short_name ||= value
+        def framework_short_name(framework_short_name = nil)
+          @framework_short_name ||= framework_short_name
         end
 
         ##

--- a/app/models/submission_entry.rb
+++ b/app/models/submission_entry.rb
@@ -3,6 +3,7 @@ class SubmissionEntry < ApplicationRecord
 
   belongs_to :submission
   belongs_to :submission_file, optional: true
+  has_one :framework, through: :submission
 
   validates :data, presence: true
   validates :entry_type, inclusion: { in: %w[invoice order] }, allow_blank: true

--- a/db/data_migrate/20181015092520_backfill_submission_entries_management_charge.rb
+++ b/db/data_migrate/20181015092520_backfill_submission_entries_management_charge.rb
@@ -1,0 +1,16 @@
+# Backfill management charges for all validated invoice entries. Run with:
+#
+#   rails runner db/data_migrate/20181015092520_backfill_submission_entries_management_charge.rb
+#
+require 'progress_bar'
+
+entries_to_backfill = SubmissionEntry.invoices.validated.includes(:framework).where(management_charge: nil)
+progress_bar = ProgressBar.new(entries_to_backfill.count)
+
+entries_to_backfill.find_each do |submission_entry|
+  framework_definition = submission_entry.framework.definition
+  submission_entry.update! management_charge: framework_definition.management_charge(submission_entry.total_value)
+  progress_bar.increment!
+rescue NoMethodError
+  puts "Could not calculate charge for #{submission_entry.id}"
+end

--- a/db/migrate/20181011145547_add_management_charge_to_entries.rb
+++ b/db/migrate/20181011145547_add_management_charge_to_entries.rb
@@ -1,0 +1,5 @@
+class AddManagementChargeToEntries < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submission_entries, :management_charge, :decimal, precision: 18, scale: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_10_111040) do
+ActiveRecord::Schema.define(version: 2018_10_11_145547) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 2018_10_10_111040) do
     t.jsonb "validation_errors"
     t.string "entry_type"
     t.decimal "total_value"
+    t.decimal "management_charge", precision: 18, scale: 4
     t.index ["aasm_state"], name: "index_submission_entries_on_aasm_state"
     t.index ["entry_type"], name: "index_submission_entries_on_entry_type"
     t.index ["source"], name: "index_submission_entries_on_source", using: :gin

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -22,4 +22,11 @@ namespace :export do
   task :contracts, [:output] => [:environment] do |_task, args|
     Export::Anything.new(Export::Contracts::Extract.all_relevant, args[:output]).run
   end
+
+  desc 'Export coda finance report to CSV'
+  task coda_finance_report: :environment do
+    export_path = "/tmp/coda_finance_report_#{Time.zone.today}.csv"
+    puts "Exporting to #{export_path}"
+    Export::CodaFinanceReport.new(Submission.completed, File.open(export_path, 'w')).run
+  end
 end

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
 
     factory :submission_with_validated_entries do
       after(:create) do |submission, _evaluator|
-        create_list(:invoice_entry, 2, :valid, submission: submission, total_value: 10.00)
+        create_list(:invoice_entry, 2, :valid, submission: submission, total_value: 10.00, management_charge: 0.1)
         create_list(:order_entry, 1, :valid, submission: submission, total_value: 3.00)
         if submission.files.empty?
           create_list(:submission_file, 1, submission: submission, rows: submission.entries.count)

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     end
 
     trait :legal_framework_invoice_data do
+      total_value(-135.98)
       data do
         {
           'UNSPSC' => '80120000',
@@ -61,6 +62,7 @@ FactoryBot.define do
     end
 
     trait :legal_framework_contract_data do
+      total_value 5000
       data do
         {
           'Matter Name' => 'DWP - Claim by Mr I Dontexist',

--- a/spec/lib/tasks/export/submissions_spec.rb
+++ b/spec/lib/tasks/export/submissions_spec.rb
@@ -18,13 +18,12 @@ RSpec.describe 'rake export:submissions', type: :task do
         framework: create(:framework, short_name: 'RM3767'),
         aasm_state: 'completed',
         created_at: Time.zone.local(2018, 9, 18, 14, 20, 35),
-        management_charge: 45000,
         purchase_order_number: 'PO1234',
         files: [
           create(:submission_file, :with_attachment)
         ],
         entries: [
-          create(:invoice_entry, total_value: 179.00),
+          create(:invoice_entry, total_value: 179.12, management_charge: 1.7912),
           create(:order_entry, total_value: 804.00)
         ]
       )
@@ -53,7 +52,7 @@ RSpec.describe 'rake export:submissions', type: :task do
     it 'writes each submission to that output' do
       expect(output_lines.length).to eql(3)
       expect(output_lines.find { |line| line.match('PO1234') }).to eql(
-        "#{submission.task.id},#{submission.id},supplier_accepted,file,xls,1,804.00,1,179.00,450.00," \
+        "#{submission.task.id},#{submission.id},supplier_accepted,file,xls,1,804.00,1,179.12,1.79," \
         '0.01,2018-09-18T14:20:35Z,,,,,PO1234'
       )
     end

--- a/spec/models/export/coda_finance_report/row_spec.rb
+++ b/spec/models/export/coda_finance_report/row_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :invoice_entry,
         :valid,
         submission: submission,
+        total_value: 801.50,
         data: { 'Total Cost (ex VAT)' => '801.50', 'Customer URN' => home_office.urn }
       )
     end
@@ -79,6 +80,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :invoice_entry,
         :valid,
         submission: submission,
+        total_value: 428.95,
         data: { 'Total Cost (ex VAT)' => '428.95', 'Customer URN' => health_dept.urn }
       )
     end
@@ -87,6 +89,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :invoice_entry,
         :valid,
         submission: submission,
+        total_value: -428.95,
         data: { 'Total Cost (ex VAT)' => '-428.95', 'Customer URN' => bobs_charity.urn }
       )
     end
@@ -95,6 +98,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :order_entry,
         :valid,
         submission: submission,
+        total_value: 1000,
         data: { 'Total Cost (ex VAT)' => '1000.00', 'Customer URN' => home_office.urn }
       )
     end
@@ -103,6 +107,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :order_entry,
         :valid,
         submission: submission,
+        total_value: 1200,
         data: { 'Total Cost (ex VAT)' => '1200.00', 'Customer URN' => bobs_charity.urn }
       )
     end
@@ -115,17 +120,6 @@ RSpec.describe Export::CodaFinanceReport::Row do
     it 'reports the total management charge, scoped to the sector, as ‘Commission’' do
       expect(cg_report_row.commission).to eq '6.15'
       expect(wps_report_row.commission).to eq '-2.14'
-    end
-
-    it 'handles sales amounts written as a human-readable number' do
-      FactoryBot.create(
-        :invoice_entry,
-        :valid,
-        submission: submission,
-        data: { 'Total Cost (ex VAT)' => ' 2,428.95 ', 'Customer URN' => health_dept.urn }
-      )
-      expect(cg_report_row.inf_sales).to eq '3659.40'
-      expect(cg_report_row.commission).to eq '18.29'
     end
 
     it 'handles no business submissions, reporting them as zero sales and commission' do

--- a/spec/models/export/coda_finance_report/row_spec.rb
+++ b/spec/models/export/coda_finance_report/row_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :valid,
         submission: submission,
         total_value: 801.50,
+        management_charge: 4.00,
         data: { 'Total Cost (ex VAT)' => '801.50', 'Customer URN' => home_office.urn }
       )
     end
@@ -81,6 +82,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :valid,
         submission: submission,
         total_value: 428.95,
+        management_charge: 2.1447,
         data: { 'Total Cost (ex VAT)' => '428.95', 'Customer URN' => health_dept.urn }
       )
     end
@@ -90,6 +92,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :valid,
         submission: submission,
         total_value: -428.95,
+        management_charge: -2.1447,
         data: { 'Total Cost (ex VAT)' => '-428.95', 'Customer URN' => bobs_charity.urn }
       )
     end
@@ -99,6 +102,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :valid,
         submission: submission,
         total_value: 1000,
+        management_charge: 5,
         data: { 'Total Cost (ex VAT)' => '1000.00', 'Customer URN' => home_office.urn }
       )
     end
@@ -108,6 +112,7 @@ RSpec.describe Export::CodaFinanceReport::Row do
         :valid,
         submission: submission,
         total_value: 1200,
+        management_charge: 6,
         data: { 'Total Cost (ex VAT)' => '1200.00', 'Customer URN' => bobs_charity.urn }
       )
     end
@@ -117,8 +122,8 @@ RSpec.describe Export::CodaFinanceReport::Row do
       expect(wps_report_row.inf_sales).to eq '-428.95'
     end
 
-    it 'reports the total management charge, scoped to the sector, as ‘Commission’' do
-      expect(cg_report_row.commission).to eq '6.15'
+    it 'reports the total management charge to 2dp, scoped to the sector, as ‘Commission’' do
+      expect(cg_report_row.commission).to eq '6.14'
       expect(wps_report_row.commission).to eq '-2.14'
     end
 

--- a/spec/models/export/coda_finance_report_spec.rb
+++ b/spec/models/export/coda_finance_report_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Export::CodaFinanceReport do
       :invoice_entry,
       :valid,
       total_value: 678.55,
+      management_charge: 10.17,
       data: { 'Total Cost (ex VAT)' => '678.55', 'Customer URN' => home_office.urn }
     )
   end
@@ -38,6 +39,7 @@ RSpec.describe Export::CodaFinanceReport do
       :invoice_entry,
       :valid,
       total_value: 123.45,
+      management_charge: 1.85,
       data: { 'Total Cost (ex VAT)' => '123.45', 'Customer URN' => home_office.urn },
     )
   end
@@ -50,7 +52,7 @@ RSpec.describe Export::CodaFinanceReport do
   let(:expected_csv) do
     <<~CSV
       RunID,Nominal,Customer Code,Customer Name,Contract ID,Order Number,Lot Description,Inf Sales,Commission,Commission %,End User,Submitter,Month,M_Q
-      #{submission.id},409999,C011111,Mary,RM3787,PO-123,G CLOUD,802.00,12.03,0.015,UCGV,Mary,August 2018,M
+      #{submission.id},409999,C011111,Mary,RM3787,PO-123,G CLOUD,802.00,12.02,0.015,UCGV,Mary,August 2018,M
       #{submission.id},409999,C011111,Mary,RM3787,PO-123,G CLOUD,0.00,0.00,0.015,UWPS,Mary,August 2018,M
       #{no_business_submission.id},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,0.015,UCGV,Bob,August 2018,M
       #{no_business_submission.id},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,0.015,UWPS,Bob,August 2018,M

--- a/spec/models/export/coda_finance_report_spec.rb
+++ b/spec/models/export/coda_finance_report_spec.rb
@@ -27,12 +27,18 @@ RSpec.describe Export::CodaFinanceReport do
   end
   let(:submission_entry_1) do
     FactoryBot.build(
-      :invoice_entry, :valid, data: { 'Total Cost (ex VAT)' => '678.55', 'Customer URN' => home_office.urn }
+      :invoice_entry,
+      :valid,
+      total_value: 678.55,
+      data: { 'Total Cost (ex VAT)' => '678.55', 'Customer URN' => home_office.urn }
     )
   end
   let(:submission_entry_2) do
     FactoryBot.build(
-      :invoice_entry, :valid, data: { 'Total Cost (ex VAT)' => '123.45', 'Customer URN' => home_office.urn },
+      :invoice_entry,
+      :valid,
+      total_value: 123.45,
+      data: { 'Total Cost (ex VAT)' => '123.45', 'Customer URN' => home_office.urn },
     )
   end
 

--- a/spec/models/export/submissions/extract_spec.rb
+++ b/spec/models/export/submissions/extract_spec.rb
@@ -57,6 +57,13 @@ RSpec.describe Export::Submissions::Extract do
         end
       end
 
+      describe '#_total_management_charge_value as a projection on the Submission model' do
+        it 'is nil on the no-business and 20.0 on the file' do
+          expect(extract_no_business_submission._total_invoice_value).to be_nil
+          expect(extract_file_submission._total_management_charge_value.to_digits).to eql('0.2')
+        end
+      end
+
       describe '#_first_filename as a projection on the Submission model' do
         context 'on a file submission' do
           subject { extract_file_submission._first_filename }

--- a/spec/models/export/submissions/row_spec.rb
+++ b/spec/models/export/submissions/row_spec.rb
@@ -68,16 +68,10 @@ RSpec.describe Export::Submissions::Row do
   end
 
   describe '#management_charge_value' do
-    subject { row.management_charge_value }
+    let(:submission) { double 'Submission', _total_management_charge_value: 13.23 }
 
-    context 'Submission#management_charge is present in pence' do
-      let(:submission) { double 'Submission', management_charge: 45000 }
-      it { is_expected.to eql('450.00') }
-    end
-
-    context 'Submission#management_charge is absent' do
-      let(:submission) { double 'Submission', management_charge: nil }
-      it { is_expected.to be_nil }
+    it 'presents the charge identified by the _total_management_charge_value projected field' do
+      expect(row.management_charge_value).to eq '13.23'
     end
   end
 

--- a/spec/models/framework/definition_spec.rb
+++ b/spec/models/framework/definition_spec.rb
@@ -43,4 +43,12 @@ RSpec.describe Framework::Definition do
       expect(Framework::Definition.all).to all(satisfy { |c| c.ancestors.include?(Framework::Definition::Base) })
     end
   end
+
+  describe 'Base.management_charge' do
+    it 'returns the management charge based on the framework’s management charge rate, rounded to 4 decimal places' do
+      expect(Framework::Definition::RM3756.management_charge(BigDecimal('102123.23'))).to eq BigDecimal('1531.8484')
+      expect(Framework::Definition::RM1070.management_charge(BigDecimal('102123.23'))).to eq BigDecimal('510.6161')
+      expect(Framework::Definition::CM_OSG_05_3565.management_charge(BigDecimal('102123.23'))).to eq BigDecimal('0')
+    end
+  end
 end


### PR DESCRIPTION
This PR contains the various pieces that were needed to be able to generate a valid finance report and data warehouse export:

- adds the new submission_entries#management_charge column to store the per-row calculation
- adds a data migration to backfill the data for all validated submission entries
- updates the coda finance report to report the total spend and management charge using the newly available values
- updates the data warehouse export to report the spend and management charge using the newly available values.

Also depends on https://github.com/dxw/DataSubmissionServiceAPI/pull/111 to ensure all valid customer URNs are present in the database.

This work delivers on several stories and for the sake of ease-of-review and merging, it made sense to land them in this one PR. The stories are:

https://trello.com/c/XcMH4YfX/494-update-finance-report-to-use-new-total-value-and-per-row-management-charge
https://trello.com/c/7FXWrnkQ/507-existing-submission-invoice-entries-are-back-filled-with-their-management-charge-calculation
https://trello.com/c/Tx7NL6NS/496-the-data-warehouse-export-is-updated-to-report-submission-management-charge