### PR TITLE
Add Sidekiq for background job processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'rubocop'
 
 gem 'progress_bar', require: false
 
+gem 'sidekiq'
+
 group :development, :test do
   gem 'brakeman', require: false
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     byebug (10.0.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.2)
     crass (1.0.4)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
@@ -164,6 +165,8 @@ GEM
       pry (>= 0.10.4)
     puma (3.11.4)
     rack (2.0.5)
+    rack-protection (2.0.4)
+      rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.2.0)
@@ -211,6 +214,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redis (4.0.2)
     request_store (1.4.1)
       rack (>= 1.4)
     rest-client (2.0.2)
@@ -254,6 +258,10 @@ GEM
       concurrent-ruby (~> 1.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
+    sidekiq (5.2.2)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -310,6 +318,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   shoulda-matchers
+  sidekiq
   spring
   spring-watcher-listen (~> 2.0.0)
 
@@ -317,4 +326,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - docker-compose.env
     depends_on:
       - db
+      - redis
     tty: true
     stdin_open: true
     restart: on-failure
@@ -27,6 +28,9 @@ services:
       - pg_data:/var/lib/postgresql/data/:cached
     restart: on-failure
     container_name: "data-submission-service-api_db"
-
+  redis:
+    image: redis
+    expose:
+    - 6379
 volumes:
   pg_data: {}


### PR DESCRIPTION
This is a dependency of the infrastructure work that will set up a service to run workers for processing background jobs.