### PR TITLE
Configure sidekiq as active_job queue adapter

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,9 @@ module DataSubmissionServiceApi
       g.orm :active_record, primary_key_type: :uuid
     end
 
+    # Use Sidekiq for background jobs
+    config.active_job.queue_adapter = :sidekiq
+
     console do
       require './lib/console_helpers'
       if defined?(Pry)


### PR DESCRIPTION
This will be used in place of the default inline process once the redis cluster is up and the worker service is enabled.

**Note this should only be merged once the infrastructure has been updated with a Redis cluster and a worker service for handling the queued jobs.**