### PR TITLE
Configure ActiveJob for local development using Docker

### DIFF
--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -1,4 +1,5 @@
-DATABASE_URL=DATABASE_URL=postgres://postgres@db:5432/DataSubmissionServiceApi_development?template=template0&pool=5&encoding=unicode
+DATABASE_URL=postgres://postgres@db:5432/DataSubmissionServiceApi_development?template=template0&pool=5&encoding=unicode
+REDIS_URL=redis://redis:6379/
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_S3_REGION=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,26 @@ services:
       - .:/srv/dss-api:cached
     command: bash -c "rm -f tmp/pids/server.pid && rails s"
     container_name: "data-submission-service-api_web"
-
+  worker:
+    build:
+      context: .
+      args:
+        RAILS_ENV: "development"
+    environment:
+      RAILS_ENV: "development"
+    env_file:
+      - docker-compose.env
+    depends_on:
+      - db
+      - redis
+      - web
+    tty: true
+    stdin_open: true
+    restart: on-failure
+    volumes:
+      - .:/srv/dss-api:cached
+    command: bash -c "bundle exec sidekiq"
+    container_name: "data-submission-service-api_worker"
   db:
     image: postgres
     volumes:
@@ -31,6 +50,6 @@ services:
   redis:
     image: redis
     expose:
-    - 6379
+      - 6379
 volumes:
   pg_data: {}


### PR DESCRIPTION
*NB: These changes are for the local 'development' environment only, not 'test'*

- Add REDIS_URL environment variable which points to the containerised version of Redis
- Add worker to `docker-compose.yml` so that the background jobs can get executed