### PR TITLE
(541) Rename "Publisher's Name" to "Publisher Name" in RM3797

### DIFF
--- a/app/models/framework/definition/RM3797.rb
+++ b/app/models/framework/definition/RM3797.rb
@@ -15,7 +15,7 @@ class Framework
         field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
         field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber'
         field 'Product Group', :string, exports_to: 'ProductGroup'
-        field "Publisher's Name", :string, exports_to: 'ProductClass'
+        field 'Publisher Name', :string, exports_to: 'ProductClass'
         field 'Product Description', :string, exports_to: 'ProductDescription'
         field 'Crown Commercial Service Unique Product Codes', :string, exports_to: 'ProductCode'
         field 'UNSPSC', :integer, exports_to: 'UNSPSC'

--- a/data/framework_miso_fields.csv
+++ b/data/framework_miso_fields.csv
@@ -304,7 +304,7 @@ ColumnId,TemplateId,FrameworkId,Name,SheetName,DestinationTable,FieldGroup,Short
 20995,933,684,Journal Subscriptions,InvoicesRaised,Invoices,Default,CustInvoiceDate,CustInvoiceDate,Customer Invoice Date,InvoiceDate,varchar,,System.Date,True,,Document Management & Logistics,RM3797
 20996,933,684,Journal Subscriptions,InvoicesRaised,Invoices,Default,CustInvoiceNum,CustInvoiceNum,Customer Invoice Number,InvoiceNumber,varchar,50,System.String,True,,Document Management & Logistics,RM3797
 20997,933,684,Journal Subscriptions,InvoicesRaised,Invoices,Default,ProductGroup,ProductGroup,Product Group,ProductGroup,varchar,255,System.String,True,,Document Management & Logistics,RM3797
-20998,933,684,Journal Subscriptions,InvoicesRaised,Invoices,Default,ProductClass,ProductClass,Publisher's Name,ProductClass,varchar,255,System.String,True,,Document Management & Logistics,RM3797
+20998,933,684,Journal Subscriptions,InvoicesRaised,Invoices,Default,ProductClass,ProductClass,Publisher Name,ProductClass,varchar,255,System.String,True,,Document Management & Logistics,RM3797
 20999,933,684,Journal Subscriptions,InvoicesRaised,Invoices,Default,ProductDescription,ProductDescription,Product Description,ProductDescription,varchar,255,System.String,True,,Document Management & Logistics,RM3797
 21000,933,684,Journal Subscriptions,InvoicesRaised,Invoices,Default,ProductCode,ProductCode,Crown Commercial Service Unique Product Codes,ProductCode,varchar,255,System.String,True,,Document Management & Logistics,RM3797
 21001,933,684,Journal Subscriptions,InvoicesRaised,Invoices,Default,UNSPSC,UNSPSC,UNSPSC,UNSPSC,varchar,,System.Int32,True,,Document Management & Logistics,RM3797

--- a/db/data_migrate/20181025104334_fix_rm3797_data_after_template_adjustment.rb
+++ b/db/data_migrate/20181025104334_fix_rm3797_data_after_template_adjustment.rb
@@ -1,0 +1,17 @@
+# Updates the ingested data for RM3797 to reflect the adjustment we've made to
+# the template (removed a single-quote-as-apostrophe)
+#
+# Execute with:
+#
+#   rails runner db/data_migrate/20181025104334_fix_rm3797_data_after_template_adjustment.rb
+#
+rm3797 = Framework.where(short_name: 'RM3797')
+submissions = Submission.where(framework: rm3797)
+
+submissions.each do |submission|
+  submission.entries.each do |entry|
+    entry.data['Publisher Name'] = entry.data["Publisher's Name"]
+    entry.data.delete("Publisher's Name")
+    entry.save!
+  end
+end

--- a/spec/lib/generators/framework/definition_generator_spec.rb
+++ b/spec/lib/generators/framework/definition_generator_spec.rb
@@ -72,13 +72,4 @@ RSpec.describe Framework::DefinitionGenerator, type: :generator do
       expect(definition).to match "field 'Cost Centre', :string"
     end
   end
-
-  context 'Single quotes in fields – RM3797' do
-    let(:generator_arguments)      { %w[RM3797] }
-    let(:expected_definition_file) { 'RM3797.rb' }
-
-    it %(escapes the "Publisher's Name" field) do
-      expect(definition).to include(%(field "Publisher's Name"))
-    end
-  end
 end


### PR DESCRIPTION
The original value's apostrophe was causing problems with our new implementation of framework validation. 

As this character only appears in a single field in one framework, we're changing the template to
remove this issue.