### PR TITLE
(340) Perform validation for one framework 

### DIFF
--- a/app/jobs/submission_validation_job.rb
+++ b/app/jobs/submission_validation_job.rb
@@ -1,5 +1,5 @@
 class SubmissionValidationJob < ApplicationJob
-  def perform(submission, calculation_job = SubmissionManagementChargeCalculationJob)
+  def perform(submission)
     framework_definition = submission.framework.definition
 
     submission.entries.pending.find_each do |entry|
@@ -16,6 +16,10 @@ class SubmissionValidationJob < ApplicationJob
       entry.save!
     end
 
-    calculation_job.perform_later(submission)
+    if submission.entries.errored.any?
+      submission.ready_for_review!
+    else
+      SubmissionManagementChargeCalculationJob.perform_later(submission)
+    end
   end
 end

--- a/app/jobs/submission_validation_job.rb
+++ b/app/jobs/submission_validation_job.rb
@@ -2,7 +2,7 @@ class SubmissionValidationJob < ApplicationJob
   def perform(submission, calculation_job = SubmissionManagementChargeCalculationJob)
     framework_definition = submission.framework.definition
 
-    submission.entries.pending.each do |entry|
+    submission.entries.pending.find_each do |entry|
       sheet_definition = framework_definition.for_entry_type(entry.entry_type)
       entry_data = sheet_definition.new_from_params(entry.data)
 

--- a/app/jobs/submission_validation_job.rb
+++ b/app/jobs/submission_validation_job.rb
@@ -1,0 +1,21 @@
+class SubmissionValidationJob < ApplicationJob
+  def perform(submission, calculation_job = SubmissionManagementChargeCalculationJob)
+    framework_definition = submission.framework.definition
+
+    submission.entries.pending.each do |entry|
+      sheet_definition = framework_definition.for_entry_type(entry.entry_type)
+      entry_data = sheet_definition.new_from_params(entry.data)
+
+      if entry_data.valid?
+        entry.aasm_state = :validated
+      else
+        entry.aasm_state = :errored
+        entry.validation_errors = entry_data.errors.details
+      end
+
+      entry.save!
+    end
+
+    calculation_job.perform_later(submission)
+  end
+end

--- a/app/models/export/submission_entry_row.rb
+++ b/app/models/export/submission_entry_row.rb
@@ -1,3 +1,5 @@
+require './lib/string_utils'
+
 module Export
   ##
   # Used for SubmissionEntries with entry_types of
@@ -6,8 +8,7 @@ module Export
   #
   # These rows also define 8 additional ++AdditionalN++ fields.
   class SubmissionEntryRow < CsvRow
-    US_DATE_FORMAT = %r(^(\d{1,2})\/(\d{1,2})\/(\d{2})$)
-    UK_DATE_FORMAT = %r(^(\d{1,2})\/(\d{1,2})\/(\d{4})$)
+    include StringUtils
 
     def value_for(destination_field, default: NOT_IN_DATA)
       source_field = source_field_for(destination_field)
@@ -21,15 +22,7 @@ module Export
     end
 
     def formatted_date(date_string)
-      if date_string&.match UK_DATE_FORMAT
-        Date.strptime(date_string, '%d/%m/%Y').iso8601
-      elsif date_string&.match US_DATE_FORMAT
-        Date.strptime(date_string, '%m/%d/%y').iso8601
-      else
-        date_string
-      end
-    rescue ArgumentError
-      date_string
+      parse_date_string(date_string)&.iso8601 || date_string
     end
 
     private

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -41,6 +41,23 @@ class Framework
         field 'Invoice Price Excluding Options', :decimal, exports_to: 'Additional8'
         field 'List Price Excluding Options', :decimal
         field 'eAuction Contract No', :string
+
+        validates 'Lot Number', 'Customer Organisation', 'Customer URN', 'Customer Invoice Date', 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', presence: true
+
+        validates 'Lot Number', inclusion: { in: %w[1 2 3 4 5 6 7 8 9] }
+        validates 'VAT Applicable?', inclusion: { in: [true, false] }
+        validates 'Customer URN', urn: true
+
+        validates 'Invoice Price Per Vehicle', numericality: true, allow_nil: true
+        validates 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', numericality: true
+        validates 'Additional Expenditure to provide goods', numericality: true, allow_nil: true
+        validates 'VAT amount charged', numericality: true, allow_nil: true
+        validates 'All Conversion and third party conversion costs excluding factory fit options', numericality: true, allow_nil: true
+        validates 'CO2 Emissions', numericality: true, allow_nil: true
+        validates 'Customer Support Terms', numericality: true, allow_nil: true
+        validates 'Additional support terms given to Lease companies', numericality: true, allow_nil: true
+        validates 'Invoice Price Excluding Options', numericality: true, allow_nil: true
+        validates 'List Price Excluding Options', numericality: true, allow_nil: true
       end
     end
   end

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -12,7 +12,7 @@ class Framework
         field 'Lot Number', :string, exports_to: 'LotNumber', presence: true, inclusion: { in: %w[1 2 3 4 5 6 7 8 9] }
         field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
         field 'Customer Organisation', :string, exports_to: 'CustomerName', presence: true
-        field 'Customer URN', :integer, exports_to: 'CustomerURN', presence: true, urn: true
+        field 'Customer URN', :string, exports_to: 'CustomerURN', presence: true, urn: true
         field 'Customer Invoice Date', :string, exports_to: 'InvoiceDate', presence: true, ingested_date: true
         field 'Invoice Number', :string, exports_to: 'InvoiceNumber'
         field 'Invoice Line Number', :string

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -9,11 +9,11 @@ class Framework
       class Invoice < Sheet
         total_value_field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT'
 
-        field 'Lot Number', :string, exports_to: 'LotNumber'
+        field 'Lot Number', :string, exports_to: 'LotNumber', presence: true, inclusion: { in: %w[1 2 3 4 5 6 7 8 9] }
         field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
-        field 'Customer Organisation', :string, exports_to: 'CustomerName'
-        field 'Customer URN', :integer, exports_to: 'CustomerURN'
-        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate'
+        field 'Customer Organisation', :string, exports_to: 'CustomerName', presence: true
+        field 'Customer URN', :integer, exports_to: 'CustomerURN', presence: true, urn: true
+        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate', presence: true
         field 'Invoice Number', :string, exports_to: 'InvoiceNumber'
         field 'Invoice Line Number', :string
         field 'Vehicle Model', :string, exports_to: 'ProductSubClass'
@@ -21,43 +21,26 @@ class Framework
         field 'Vehicle Segment', :string, exports_to: 'ProductGroup'
         field 'UNSPSC', :integer, exports_to: 'UNSPSC'
         field 'Unit of Purchase', :string, exports_to: 'UnitType'
-        field 'Invoice Price Per Vehicle', :decimal, exports_to: 'UnitPrice'
+        field 'Invoice Price Per Vehicle', :decimal, exports_to: 'UnitPrice', numericality: true, allow_nil: true
         field 'Quantity', :integer, exports_to: 'UnitQuantity'
-        field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', :decimal, exports_to: 'InvoiceValue'
-        field 'Additional Expenditure to provide goods', :decimal, exports_to: 'Expenses'
-        field 'VAT Applicable?', :boolean, exports_to: 'VATIncluded'
-        field 'VAT amount charged', :decimal, exports_to: 'VATCharged'
+        field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', :decimal, exports_to: 'InvoiceValue', presence: true, numericality: true
+        field 'Additional Expenditure to provide goods', :decimal, exports_to: 'Expenses', numericality: true, allow_nil: true
+        field 'VAT Applicable?', :boolean, exports_to: 'VATIncluded', inclusion: { in: [true, false] }
+        field 'VAT amount charged', :decimal, exports_to: 'VATCharged', numericality: true, allow_nil: true
         field 'Vehicle CAP Code', :string, exports_to: 'ProductCode'
         field 'Vehicle Trim/Derivative', :string, exports_to: 'ProductDescription'
         field 'Cost Centre', :string
         field 'Contract Number', :string
         field 'Vehicle Registration Number', :string, exports_to: 'Additional1'
-        field 'All Conversion and third party conversion costs excluding factory fit options', :decimal, exports_to: 'Additional2'
-        field 'CO2 Emissions', :decimal, exports_to: 'Additional3'
+        field 'All Conversion and third party conversion costs excluding factory fit options', :decimal, exports_to: 'Additional2', numericality: true, allow_nil: true
+        field 'CO2 Emissions', :decimal, exports_to: 'Additional3', numericality: true, allow_nil: true
         field 'Fuel Type', :string, exports_to: 'Additional4'
-        field 'Customer Support Terms', :decimal, exports_to: 'Additional5'
+        field 'Customer Support Terms', :decimal, exports_to: 'Additional5', numericality: true, allow_nil: true
         field 'Leasing Company', :string, exports_to: 'Additional6'
-        field 'Additional support terms given to Lease companies', :decimal, exports_to: 'Additional7'
-        field 'Invoice Price Excluding Options', :decimal, exports_to: 'Additional8'
-        field 'List Price Excluding Options', :decimal
+        field 'Additional support terms given to Lease companies', :decimal, exports_to: 'Additional7', numericality: true, allow_nil: true
+        field 'Invoice Price Excluding Options', :decimal, exports_to: 'Additional8', numericality: true, allow_nil: true
+        field 'List Price Excluding Options', :decimal, numericality: true, allow_nil: true
         field 'eAuction Contract No', :string
-
-        validates 'Lot Number', 'Customer Organisation', 'Customer URN', 'Customer Invoice Date', 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', presence: true
-
-        validates 'Lot Number', inclusion: { in: %w[1 2 3 4 5 6 7 8 9] }
-        validates 'VAT Applicable?', inclusion: { in: [true, false] }
-        validates 'Customer URN', urn: true
-
-        validates 'Invoice Price Per Vehicle', numericality: true, allow_nil: true
-        validates 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', numericality: true
-        validates 'Additional Expenditure to provide goods', numericality: true, allow_nil: true
-        validates 'VAT amount charged', numericality: true, allow_nil: true
-        validates 'All Conversion and third party conversion costs excluding factory fit options', numericality: true, allow_nil: true
-        validates 'CO2 Emissions', numericality: true, allow_nil: true
-        validates 'Customer Support Terms', numericality: true, allow_nil: true
-        validates 'Additional support terms given to Lease companies', numericality: true, allow_nil: true
-        validates 'Invoice Price Excluding Options', numericality: true, allow_nil: true
-        validates 'List Price Excluding Options', numericality: true, allow_nil: true
       end
     end
   end

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -21,25 +21,25 @@ class Framework
         field 'Vehicle Segment', :string, exports_to: 'ProductGroup'
         field 'UNSPSC', :string, exports_to: 'UNSPSC'
         field 'Unit of Purchase', :string, exports_to: 'UnitType'
-        field 'Invoice Price Per Vehicle', :decimal, exports_to: 'UnitPrice', numericality: true, allow_nil: true
+        field 'Invoice Price Per Vehicle', :string, exports_to: 'UnitPrice', numericality: true, allow_nil: true
         field 'Quantity', :string, exports_to: 'UnitQuantity'
-        field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', :decimal, exports_to: 'InvoiceValue', presence: true, numericality: true
-        field 'Additional Expenditure to provide goods', :decimal, exports_to: 'Expenses', numericality: true, allow_nil: true
+        field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', :string, exports_to: 'InvoiceValue', presence: true, numericality: true
+        field 'Additional Expenditure to provide goods', :string, exports_to: 'Expenses', numericality: true, allow_nil: true
         field 'VAT Applicable?', :string, exports_to: 'VATIncluded', inclusion: { in: ['Y', 'N'], message: "Is VAT applicable on this product or service? Enter 'Y' or 'N'" }
-        field 'VAT amount charged', :decimal, exports_to: 'VATCharged', numericality: true, allow_nil: true
+        field 'VAT amount charged', :string, exports_to: 'VATCharged', numericality: true, allow_nil: true
         field 'Vehicle CAP Code', :string, exports_to: 'ProductCode'
         field 'Vehicle Trim/Derivative', :string, exports_to: 'ProductDescription'
         field 'Cost Centre', :string
         field 'Contract Number', :string
         field 'Vehicle Registration Number', :string, exports_to: 'Additional1'
-        field 'All Conversion and third party conversion costs excluding factory fit options', :decimal, exports_to: 'Additional2', numericality: true, allow_nil: true
-        field 'CO2 Emissions', :decimal, exports_to: 'Additional3', numericality: true, allow_nil: true
+        field 'All Conversion and third party conversion costs excluding factory fit options', :string, exports_to: 'Additional2'
+        field 'CO2 Emissions', :string, exports_to: 'Additional3'
         field 'Fuel Type', :string, exports_to: 'Additional4'
-        field 'Customer Support Terms', :decimal, exports_to: 'Additional5', numericality: true, allow_nil: true
+        field 'Customer Support Terms', :string, exports_to: 'Additional5'
         field 'Leasing Company', :string, exports_to: 'Additional6'
-        field 'Additional support terms given to Lease companies', :decimal, exports_to: 'Additional7', numericality: true, allow_nil: true
-        field 'Invoice Price Excluding Options', :decimal, exports_to: 'Additional8', numericality: true, allow_nil: true
-        field 'List Price Excluding Options', :decimal, numericality: true, allow_nil: true
+        field 'Additional support terms given to Lease companies', :string, exports_to: 'Additional7'
+        field 'Invoice Price Excluding Options', :string, exports_to: 'Additional8', numericality: true, allow_nil: true
+        field 'List Price Excluding Options', :string, numericality: true, allow_nil: true
         field 'eAuction Contract No', :string
       end
     end

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -13,7 +13,7 @@ class Framework
         field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
         field 'Customer Organisation', :string, exports_to: 'CustomerName', presence: true
         field 'Customer URN', :integer, exports_to: 'CustomerURN', presence: true, urn: true
-        field 'Customer Invoice Date', :date, exports_to: 'InvoiceDate', presence: true
+        field 'Customer Invoice Date', :string, exports_to: 'InvoiceDate', presence: true, ingested_date: true
         field 'Invoice Number', :string, exports_to: 'InvoiceNumber'
         field 'Invoice Line Number', :string
         field 'Vehicle Model', :string, exports_to: 'ProductSubClass'

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -25,7 +25,7 @@ class Framework
         field 'Quantity', :integer, exports_to: 'UnitQuantity'
         field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', :decimal, exports_to: 'InvoiceValue', presence: true, numericality: true
         field 'Additional Expenditure to provide goods', :decimal, exports_to: 'Expenses', numericality: true, allow_nil: true
-        field 'VAT Applicable?', :boolean, exports_to: 'VATIncluded', inclusion: { in: [true, false] }
+        field 'VAT Applicable?', :string, exports_to: 'VATIncluded', inclusion: { in: ['Y', 'N'], message: "Is VAT applicable on this product or service? Enter 'Y' or 'N'" }
         field 'VAT amount charged', :decimal, exports_to: 'VATCharged', numericality: true, allow_nil: true
         field 'Vehicle CAP Code', :string, exports_to: 'ProductCode'
         field 'Vehicle Trim/Derivative', :string, exports_to: 'ProductDescription'

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -19,10 +19,10 @@ class Framework
         field 'Vehicle Model', :string, exports_to: 'ProductSubClass'
         field 'Vehicle Make', :string, exports_to: 'ProductClass'
         field 'Vehicle Segment', :string, exports_to: 'ProductGroup'
-        field 'UNSPSC', :integer, exports_to: 'UNSPSC'
+        field 'UNSPSC', :string, exports_to: 'UNSPSC'
         field 'Unit of Purchase', :string, exports_to: 'UnitType'
         field 'Invoice Price Per Vehicle', :decimal, exports_to: 'UnitPrice', numericality: true, allow_nil: true
-        field 'Quantity', :integer, exports_to: 'UnitQuantity'
+        field 'Quantity', :string, exports_to: 'UnitQuantity'
         field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', :decimal, exports_to: 'InvoiceValue', presence: true, numericality: true
         field 'Additional Expenditure to provide goods', :decimal, exports_to: 'Expenses', numericality: true, allow_nil: true
         field 'VAT Applicable?', :string, exports_to: 'VATIncluded', inclusion: { in: ['Y', 'N'], message: "Is VAT applicable on this product or service? Enter 'Y' or 'N'" }

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -9,11 +9,11 @@ class Framework
       class Invoice < Sheet
         total_value_field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT'
 
-        field 'Lot Number', :string, exports_to: 'LotNumber', presence: true, inclusion: { in: %w[1 2 3 4 5 6 7 8 9] }
+        field 'Lot Number', :string, exports_to: 'LotNumber', inclusion: { in: %w[1 2 3 4 5 6 7 8 9] }
         field 'Customer PostCode', :string, exports_to: 'CustomerPostCode'
         field 'Customer Organisation', :string, exports_to: 'CustomerName', presence: true
-        field 'Customer URN', :string, exports_to: 'CustomerURN', presence: true, urn: true
-        field 'Customer Invoice Date', :string, exports_to: 'InvoiceDate', presence: true, ingested_date: true
+        field 'Customer URN', :string, exports_to: 'CustomerURN', urn: true
+        field 'Customer Invoice Date', :string, exports_to: 'InvoiceDate', ingested_date: true
         field 'Invoice Number', :string, exports_to: 'InvoiceNumber'
         field 'Invoice Line Number', :string
         field 'Vehicle Model', :string, exports_to: 'ProductSubClass'
@@ -23,7 +23,7 @@ class Framework
         field 'Unit of Purchase', :string, exports_to: 'UnitType'
         field 'Invoice Price Per Vehicle', :string, exports_to: 'UnitPrice', numericality: true, allow_nil: true
         field 'Quantity', :string, exports_to: 'UnitQuantity'
-        field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', :string, exports_to: 'InvoiceValue', presence: true, numericality: true
+        field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT', :string, exports_to: 'InvoiceValue', numericality: true
         field 'Additional Expenditure to provide goods', :string, exports_to: 'Expenses', numericality: true, allow_nil: true
         field 'VAT Applicable?', :string, exports_to: 'VATIncluded', inclusion: { in: ['Y', 'N'], message: "Is VAT applicable on this product or service? Enter 'Y' or 'N'" }
         field 'VAT amount charged', :string, exports_to: 'VATCharged', numericality: true, allow_nil: true

--- a/app/models/framework/sheet.rb
+++ b/app/models/framework/sheet.rb
@@ -34,14 +34,13 @@ class Framework
       # but adds options that we need. Right now that's exports_to.
       def field(*args)
         options = args.extract_options!
+        field_name = args.first
         exports_to = options.delete(:exports_to)
 
-        if exports_to
-          field_name = args.first
-          export_mappings[exports_to] = field_name
-        end
+        export_mappings[exports_to] = field_name if exports_to
 
-        attribute(*args, options)
+        attribute(*args)
+        validates(field_name, options) if options.present?
       end
     end
   end

--- a/app/models/framework/sheet.rb
+++ b/app/models/framework/sheet.rb
@@ -2,7 +2,22 @@ class Framework
   ##
   # Define a Sheet for Orders/Invoices on a field-by-field basis
   class Sheet
+    include ActiveModel::Attributes
+    include ActiveModel::Validations
+
     class << self
+      def new_from_params(params)
+        instance = new
+
+        params.each_pair do |param, value|
+          next unless instance.attributes.key?(param)
+
+          instance.send("#{param}=", value)
+        end
+
+        instance
+      end
+
       def export_mappings
         @export_mappings ||= {}
       end
@@ -20,13 +35,13 @@ class Framework
       def field(*args)
         options = args.extract_options!
         exports_to = options.delete(:exports_to)
+
         if exports_to
           field_name = args.first
           export_mappings[exports_to] = field_name
         end
 
-        true # avoid Rubocop guard clause before we can start calling ActiveModel
-        # attribute(*args, options) # call ActiveModel for validations
+        attribute(*args, options)
       end
     end
   end

--- a/app/validators/ingested_date_validator.rb
+++ b/app/validators/ingested_date_validator.rb
@@ -1,0 +1,20 @@
+class IngestedDateValidator < ActiveModel::EachValidator
+  US_DATE_FORMAT = %r(^(\d{1,2})\/(\d{1,2})\/(\d{2})$)
+  UK_DATE_FORMAT = %r(^(\d{1,2})\/(\d{1,2})\/(\d{4})$)
+
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, :invalid_ingested_date) unless valid_date_string?(value)
+  end
+
+  private
+
+  def valid_date_string?(value)
+    case value
+    when UK_DATE_FORMAT then Date.strptime(value, '%d/%m/%Y')
+    when US_DATE_FORMAT then Date.strptime(value, '%m/%d/%y')
+    else false
+    end
+  rescue ArgumentError
+    false
+  end
+end

--- a/app/validators/ingested_date_validator.rb
+++ b/app/validators/ingested_date_validator.rb
@@ -1,20 +1,9 @@
+require './lib/string_utils'
+
 class IngestedDateValidator < ActiveModel::EachValidator
-  US_DATE_FORMAT = %r(^(\d{1,2})\/(\d{1,2})\/(\d{2})$)
-  UK_DATE_FORMAT = %r(^(\d{1,2})\/(\d{1,2})\/(\d{4})$)
+  include StringUtils
 
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, :invalid_ingested_date) unless valid_date_string?(value)
-  end
-
-  private
-
-  def valid_date_string?(value)
-    case value
-    when UK_DATE_FORMAT then Date.strptime(value, '%d/%m/%Y')
-    when US_DATE_FORMAT then Date.strptime(value, '%m/%d/%y')
-    else false
-    end
-  rescue ArgumentError
-    false
+    record.errors.add(attribute, :invalid_ingested_date) unless parse_date_string(value)
   end
 end

--- a/app/validators/urn_validator.rb
+++ b/app/validators/urn_validator.rb
@@ -1,0 +1,7 @@
+class UrnValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if Customer.exists?(urn: value)
+
+    record.errors.add(attribute, :invalid_urn)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,5 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
+---
 en:
-  hello: "Hello world"
+  errors:
+    messages:
+      invalid_urn: 'is not a recognised URN'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,4 @@ en:
   errors:
     messages:
       invalid_urn: 'is not a recognised URN'
+      invalid_ingested_date: 'must be in the format dd/mm/yyyy'

--- a/lib/string_utils.rb
+++ b/lib/string_utils.rb
@@ -1,0 +1,17 @@
+module StringUtils
+  US_DATE_FORMAT = %r(^(\d{1,2})\/(\d{1,2})\/(\d{2})$)
+  UK_DATE_FORMAT = %r(^(\d{1,2})\/(\d{1,2})\/(\d{4})$)
+
+  # Parses the two formats of dates that we currently see returned by the ingest
+  # process: 'DD/MM/YYYY' and 'MM/DD/YY'
+  #
+  # Returns a Date if the string is a valid date, nil if it is not.
+  def parse_date_string(value)
+    case value
+    when UK_DATE_FORMAT then Date.strptime(value, '%d/%m/%Y')
+    when US_DATE_FORMAT then Date.strptime(value, '%m/%d/%y')
+    end
+  rescue ArgumentError
+    nil
+  end
+end

--- a/spec/jobs/submission_validation_job_spec.rb
+++ b/spec/jobs/submission_validation_job_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionValidationJob do
+  describe '#perform' do
+    it 'validates each entry and then triggers the management charge calculation' do
+      framework = FactoryBot.create(:framework, short_name: 'RM1070')
+      submission = FactoryBot.create(:submission, framework: framework)
+      FactoryBot.create(:customer, urn: 12345678)
+
+      calculation_job = double('SubmissionManagementChargeCalculationJob', perform_later: true)
+
+      # rubocop:disable Metrics/LineLength
+      good_data = {
+        'Lot Number' => '1',
+        'Customer Organisation' => 'Example Ltd',
+        'Customer URN' => '12345678',
+        'Customer Invoice Date' => '01/01/2018',
+        'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT' => 12.34,
+        'VAT Applicable?' => 'n'
+      }
+      # rubocop:enable Metrics/LineLength
+
+      bad_data = {
+        'Lot Number' => '1',
+        'Customer Organisation' => 'Example Ltd',
+        'Customer URN' => '00000000',
+        'Customer Invoice Date' => '01/01/2018',
+        'VAT Applicable?' => 'n'
+      }
+
+      FactoryBot.create(:invoice_entry, submission: submission, data: good_data)
+      FactoryBot.create(:invoice_entry, submission: submission, data: bad_data)
+
+      SubmissionValidationJob.new.perform(submission, calculation_job)
+
+      expect(submission.entries.validated.count).to eql 1
+      expect(submission.entries.errored.count).to eql 1
+      expect(calculation_job).to have_received(:perform_later).with(submission)
+    end
+  end
+end

--- a/spec/jobs/submission_validation_job_spec.rb
+++ b/spec/jobs/submission_validation_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SubmissionValidationJob do
         'Customer URN' => '12345678',
         'Customer Invoice Date' => '01/01/2018',
         'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT' => 12.34,
-        'VAT Applicable?' => 'n'
+        'VAT Applicable?' => 'N'
       }
       # rubocop:enable Metrics/LineLength
 
@@ -25,7 +25,7 @@ RSpec.describe SubmissionValidationJob do
         'Customer Organisation' => 'Example Ltd',
         'Customer URN' => '00000000',
         'Customer Invoice Date' => '01/01/2018',
-        'VAT Applicable?' => 'n'
+        'VAT Applicable?' => 'N'
       }
 
       FactoryBot.create(:invoice_entry, submission: submission, data: good_data)

--- a/spec/jobs/submission_validation_job_spec.rb
+++ b/spec/jobs/submission_validation_job_spec.rb
@@ -2,26 +2,27 @@ require 'rails_helper'
 
 RSpec.describe SubmissionValidationJob do
   describe '#perform' do
+    # rubocop:disable Metrics/LineLength
+    let(:total_value_field) { 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT' }
+    # rubocop:enable Metrics/LineLength
     let(:framework) { FactoryBot.create(:framework, short_name: 'RM1070') }
     let(:submission) { FactoryBot.create(:submission, framework: framework) }
     let!(:customer) { FactoryBot.create(:customer, urn: 12345678) }
     let(:good_data) do
-      # rubocop:disable Metrics/LineLength
       {
         'Lot Number' => '1',
         'Customer Organisation' => 'Example Ltd',
         'Customer URN' => '12345678',
         'Customer Invoice Date' => '01/01/2018',
-        'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT' => 12.34,
+        total_value_field => 12.34,
         'VAT Applicable?' => 'N'
       }
-      # rubocop:enable Metrics/LineLength
     end
     let(:bad_data) do
       {
         'Lot Number' => '1',
         'Customer Organisation' => 'Example Ltd',
-        'Customer URN' => '00000000',
+        'Customer URN' => '12345678',
         'Customer Invoice Date' => '01/01/2018',
         'VAT Applicable?' => 'N'
       }
@@ -30,25 +31,38 @@ RSpec.describe SubmissionValidationJob do
     context 'with all valid rows' do
       it 'updates validation status of each entry and triggers the management charge calculation' do
         FactoryBot.create(:invoice_entry, submission: submission, data: good_data)
-        FactoryBot.create(:invoice_entry, submission: submission, data: good_data)
+        good_row = FactoryBot.create(:invoice_entry, submission: submission, data: good_data)
 
         expect { SubmissionValidationJob.new.perform(submission) }.not_to change { submission.aasm_state }
 
         expect(submission.entries.validated.count).to eql 2
         expect(submission.entries.errored.count).to eql 0
         expect(SubmissionManagementChargeCalculationJob).to have_been_enqueued
+        expect(good_row.validation_errors).to eq(nil)
       end
     end
     context 'with an invalid row' do
       it 'updates validation status of each entry and marks the submission as failed' do
         FactoryBot.create(:invoice_entry, submission: submission, data: good_data)
-        FactoryBot.create(:invoice_entry, submission: submission, data: bad_data)
+        bad_row = FactoryBot.create(:invoice_entry, submission: submission, data: bad_data)
 
         SubmissionValidationJob.new.perform(submission)
 
         expect(submission.entries.validated.count).to eql 1
         expect(submission.entries.errored.count).to eql 1
         expect(submission).to be_validation_failed
+        bad_row.reload
+        expect(bad_row.validation_errors).to eq(
+          [
+            {
+              'message' => 'is not a number',
+              'location' => {
+                'row' => bad_row.source['row'],
+                'column' => total_value_field,
+              },
+            }
+          ]
+        )
         expect(SubmissionManagementChargeCalculationJob).not_to have_been_enqueued
       end
     end

--- a/spec/jobs/submission_validation_job_spec.rb
+++ b/spec/jobs/submission_validation_job_spec.rb
@@ -2,15 +2,12 @@ require 'rails_helper'
 
 RSpec.describe SubmissionValidationJob do
   describe '#perform' do
-    it 'validates each entry and then triggers the management charge calculation' do
-      framework = FactoryBot.create(:framework, short_name: 'RM1070')
-      submission = FactoryBot.create(:submission, framework: framework)
-      FactoryBot.create(:customer, urn: 12345678)
-
-      calculation_job = double('SubmissionManagementChargeCalculationJob', perform_later: true)
-
+    let(:framework) { FactoryBot.create(:framework, short_name: 'RM1070') }
+    let(:submission) { FactoryBot.create(:submission, framework: framework) }
+    let!(:customer) { FactoryBot.create(:customer, urn: 12345678) }
+    let(:good_data) do
       # rubocop:disable Metrics/LineLength
-      good_data = {
+      {
         'Lot Number' => '1',
         'Customer Organisation' => 'Example Ltd',
         'Customer URN' => '12345678',
@@ -19,23 +16,41 @@ RSpec.describe SubmissionValidationJob do
         'VAT Applicable?' => 'N'
       }
       # rubocop:enable Metrics/LineLength
-
-      bad_data = {
+    end
+    let(:bad_data) do
+      {
         'Lot Number' => '1',
         'Customer Organisation' => 'Example Ltd',
         'Customer URN' => '00000000',
         'Customer Invoice Date' => '01/01/2018',
         'VAT Applicable?' => 'N'
       }
+    end
 
-      FactoryBot.create(:invoice_entry, submission: submission, data: good_data)
-      FactoryBot.create(:invoice_entry, submission: submission, data: bad_data)
+    context 'with all valid rows' do
+      it 'updates validation status of each entry and triggers the management charge calculation' do
+        FactoryBot.create(:invoice_entry, submission: submission, data: good_data)
+        FactoryBot.create(:invoice_entry, submission: submission, data: good_data)
 
-      SubmissionValidationJob.new.perform(submission, calculation_job)
+        expect { SubmissionValidationJob.new.perform(submission) }.not_to change { submission.aasm_state }
 
-      expect(submission.entries.validated.count).to eql 1
-      expect(submission.entries.errored.count).to eql 1
-      expect(calculation_job).to have_received(:perform_later).with(submission)
+        expect(submission.entries.validated.count).to eql 2
+        expect(submission.entries.errored.count).to eql 0
+        expect(SubmissionManagementChargeCalculationJob).to have_been_enqueued
+      end
+    end
+    context 'with an invalid row' do
+      it 'updates validation status of each entry and marks the submission as failed' do
+        FactoryBot.create(:invoice_entry, submission: submission, data: good_data)
+        FactoryBot.create(:invoice_entry, submission: submission, data: bad_data)
+
+        SubmissionValidationJob.new.perform(submission)
+
+        expect(submission.entries.validated.count).to eql 1
+        expect(submission.entries.errored.count).to eql 1
+        expect(submission).to be_validation_failed
+        expect(SubmissionManagementChargeCalculationJob).not_to have_been_enqueued
+      end
     end
   end
 end

--- a/spec/models/framework/definition/RM1070_spec.rb
+++ b/spec/models/framework/definition/RM1070_spec.rb
@@ -84,6 +84,45 @@ RSpec.describe Framework::Definition::RM1070 do
       end
     end
 
+    describe '"Total Supplier price including standard factory fit options..." field' do
+      let(:field_name) do
+        'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT'
+      end
+
+      it 'validates as a numeric amount' do
+        expect(invoice_from_params(field_name => 12.12)).to be_valid
+        expect(invoice_from_params(field_name => -1234)).to be_valid
+        expect(invoice_from_params(field_name => '12.12')).to be_valid
+        expect(invoice_from_params(field_name => '-124.12')).to be_valid
+
+        expect(invoice_from_params(field_name => nil)).not_to be_valid
+        expect(invoice_from_params(field_name => '£123')).not_to be_valid
+        expect(invoice_from_params(field_name => 'Bob')).not_to be_valid
+      end
+    end
+
+    [
+      'Invoice Price Per Vehicle',
+      'Additional Expenditure to provide goods',
+      'VAT amount charged',
+      'Invoice Price Excluding Options',
+      'List Price Excluding Options'
+    ].each do |field_name|
+      describe "'#{field_name} field" do
+        it 'validates as a numeric amount or as nil' do
+          expect(invoice_from_params(field_name => nil)).to be_valid
+          expect(invoice_from_params(field_name => 0)).to be_valid
+          expect(invoice_from_params(field_name => 12.12)).to be_valid
+          expect(invoice_from_params(field_name => -1234)).to be_valid
+          expect(invoice_from_params(field_name => '12.12')).to be_valid
+          expect(invoice_from_params(field_name => '-124.12')).to be_valid
+
+          expect(invoice_from_params(field_name => '£123')).not_to be_valid
+          expect(invoice_from_params(field_name => 'Bob')).not_to be_valid
+        end
+      end
+    end
+
     def invoice_from_params(overrides)
       Framework::Definition::RM1070::Invoice.new_from_params valid_params.merge(overrides)
     end

--- a/spec/models/framework/definition/RM1070_spec.rb
+++ b/spec/models/framework/definition/RM1070_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe Framework::Definition::RM1070 do
       end
     end
 
+    describe '"Customer Invoice Date" field' do
+      it 'validates as an ingested date field' do
+        ['9/14/18', '9/10/17', '12/10/2018', '30/10/2019'].each do |valid_date_string|
+          expect(invoice_from_params('Customer Invoice Date' => valid_date_string)).to be_valid
+        end
+
+        ['13/10/18', '12/20/2018', 'Bob'].each do |bad_date_string|
+          invoice = invoice_from_params('Customer Invoice Date' => bad_date_string)
+          expect(invoice).not_to be_valid
+          expect(invoice.errors['Customer Invoice Date'].first)
+            .to eq('must be in the format dd/mm/yyyy')
+        end
+      end
+    end
+
     def invoice_from_params(overrides)
       Framework::Definition::RM1070::Invoice.new_from_params valid_params.merge(overrides)
     end

--- a/spec/models/framework/definition/RM1070_spec.rb
+++ b/spec/models/framework/definition/RM1070_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe Framework::Definition::RM1070 do
+  let(:customer) { FactoryBot.create(:customer) }
+
+  describe Framework::Definition::RM1070::Invoice do
+    # rubocop:disable Metrics/LineLength
+    let(:valid_params) do
+      {
+        'UNSPSC' => 25101503,
+        'Quantity' => 1,
+        'Fuel Type' => 'DIESEL',
+        'Lot Number' => 7,
+        'Cost Centre' => 'N/A',
+        'Customer URN' => customer.urn,
+        'Vehicle Make' => 'Vauxhall',
+        'CO2 Emissions' => 101,
+        'Vehicle Model' => 'Astra 16',
+        'Invoice Number' => 787908,
+        'Contract Number' => 'RM1070',
+        'Leasing Company' => 'N/A',
+        'VAT Applicable?' => 'Y',
+        'Vehicle Segment' => 'Lower Medium',
+        'Unit of Purchase' => 'Each',
+        'Vehicle CAP Code' => 'VAAS16DFS5HDTM 7',
+        'Customer PostCode' => 'BS11 0YH',
+        'VAT amount charged' => 0.2,
+        'Invoice Line Number' => 1,
+        'eAuction Contract No' => 'N/A',
+        'Customer Invoice Date' => '9/11/18',
+        'Customer Organisation' => 'Avon & Somerset [Police]',
+        'Customer Support Terms' => 40,
+        'Vehicle Trim/Derivative' => 'Astra 5 Dr Sports Tourer Police 1.6Cdti (136Ps) S/S 6 Speed',
+        'Invoice Price Per Vehicle' => 10530.23,
+        'Vehicle Registration Number' => 'WX18BCU',
+        'List Price Excluding Options' => 16495.83,
+        'Invoice Price Excluding Options' => 9897.5,
+        'Additional Expenditure to provide goods' => 0,
+        'Additional support terms given to Lease companies' => 'N/A',
+        'All Conversion and third party conversion costs excluding factory fit options' => 1012.71,
+        'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT' => 10530.23
+      }
+    end
+    # rubocop:enable Metrics/LineLength
+
+    it 'validates valid invoice entry data' do
+      invoice = Framework::Definition::RM1070::Invoice.new_from_params(valid_params)
+
+      expect(invoice).to be_valid
+    end
+
+    describe '"VAT Applicable?" field' do
+      it 'only validates "Y" or "N"' do
+        invoice = invoice_from_params('VAT Applicable?' => 'Y')
+        expect(invoice).to be_valid
+        expect(invoice.attributes['VAT Applicable?']).to eq 'Y'
+
+        invoice = invoice_from_params('VAT Applicable?' => 'N')
+        expect(invoice).to be_valid
+        expect(invoice.attributes['VAT Applicable?']).to eq 'N'
+
+        invoice = invoice_from_params('VAT Applicable?' => 'Yes')
+        expect(invoice).not_to be_valid
+        expect(invoice.errors['VAT Applicable?'].first).to match("Enter 'Y' or 'N'")
+
+        invoice = invoice_from_params('VAT Applicable?' => true)
+        expect(invoice).not_to be_valid
+        expect(invoice.errors['VAT Applicable?'].first).to match("Enter 'Y' or 'N'")
+      end
+    end
+
+    def invoice_from_params(overrides)
+      Framework::Definition::RM1070::Invoice.new_from_params valid_params.merge(overrides)
+    end
+  end
+end

--- a/spec/models/framework/sheet_spec.rb
+++ b/spec/models/framework/sheet_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Framework::Sheet do
+  let(:sheet_class) do
+    Class.new(Framework::Sheet) do
+      field 'Test Field', :string
+    end
+  end
+
+  describe '.new_from_params' do
+    it 'takes parameters and loads them into a new instance' do
+      sheet = sheet_class.new_from_params(
+        'Test Field' => 'test'
+      )
+
+      expect(sheet.attributes).to include('Test Field' => 'test')
+    end
+
+    it 'ignores parameters that do not exist in the sheet definition' do
+      sheet = sheet_class.new_from_params(
+        'Test Field' => 'test',
+        'Missing from Sheet' => true
+      )
+
+      expect(sheet.attributes).not_to include('Missing from Sheet')
+    end
+  end
+end

--- a/spec/validators/ingested_date_validator_spec.rb
+++ b/spec/validators/ingested_date_validator_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe IngestedDateValidator do
+  let(:sheet_class) do
+    Class.new(Framework::Sheet) do
+      extend ActiveModel::Naming
+
+      def self.name
+        'Validator'
+      end
+
+      field 'An Ingested Date', :string, ingested_date: true
+    end
+  end
+
+  it 'validates DD/MM/YYYY date strings' do
+    ['12/10/2018', '1/1/2018', '21/9/2017'].each do |valid_date_string|
+      instance = sheet_class.new_from_params('An Ingested Date' => valid_date_string)
+      expect(instance).to be_valid
+    end
+  end
+
+  it 'validates MM/DD/YY date strings' do
+    ['9/10/18', '8/1/18', '2/28/17', '3/28/19'].each do |valid_date_string|
+      instance = sheet_class.new_from_params('An Ingested Date' => valid_date_string)
+      expect(instance).to be_valid
+    end
+  end
+
+  it 'does not validate correctly formatted but invalid dates' do
+    ['28/9/17', '9/21/2017'].each do |invalid_date_string|
+      instance = sheet_class.new_from_params('An Ingested Date' => invalid_date_string)
+      expect(instance).not_to be_valid
+      expect(instance.errors['An Ingested Date'].first).to eq 'must be in the format dd/mm/yyyy'
+    end
+  end
+
+  it 'does not validate values not formatted as a date' do
+    instance = sheet_class.new_from_params('An Ingested Date' => 'Bob')
+    expect(instance).not_to be_valid
+    expect(instance.errors['An Ingested Date'].first).to eq 'must be in the format dd/mm/yyyy'
+  end
+end

--- a/spec/validators/urn_validator_spec.rb
+++ b/spec/validators/urn_validator_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe UrnValidator do
+  let(:sheet_class) do
+    Class.new(Framework::Sheet) do
+      extend ActiveModel::Naming
+
+      def self.name
+        'Validator'
+      end
+
+      field 'Customer URN', :string, urn: true
+    end
+  end
+
+  it 'is valid for URNs that exist' do
+    FactoryBot.create(:customer, urn: 12345678)
+
+    sheet = sheet_class.new_from_params(
+      'Customer URN' => 12345678
+    )
+
+    expect(sheet).to be_valid
+  end
+
+  it 'is invalid for a missing URN' do
+    sheet = sheet_class.new_from_params(
+      'Customer URN' => 88888888
+    )
+
+    expect(sheet).not_to be_valid
+  end
+end

--- a/spec/validators/urn_validator_spec.rb
+++ b/spec/validators/urn_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe UrnValidator do
     FactoryBot.create(:customer, urn: 12345678)
 
     sheet = sheet_class.new_from_params(
-      'Customer URN' => 12345678
+      'Customer URN' => '12345678'
     )
 
     expect(sheet).to be_valid
@@ -25,7 +25,7 @@ RSpec.describe UrnValidator do
 
   it 'is invalid for a missing URN' do
     sheet = sheet_class.new_from_params(
-      'Customer URN' => 88888888
+      'Customer URN' => '88888888'
     )
 
     expect(sheet).not_to be_valid


### PR DESCRIPTION
Using an ActiveJob background task, we validates all of the entries associated with the given submission.

The `field` DSL method has been enhanced to both create ActiveModel attributes and validations.