### PR TITLE
(512) Generate validation rules from MISO export

### DIFF
--- a/app/models/framework/miso_field_validations.rb
+++ b/app/models/framework/miso_field_validations.rb
@@ -78,7 +78,7 @@ class Framework
       urn_field = fields.find { |f| f['ExportsTo'] == 'CustomerURN' }
       return if urn_field.nil?
 
-      validations[urn_field['DisplayName']] << 'urn: true'
+      validations[urn_field['DisplayName']] = 'urn: true'
     end
   end
 end

--- a/app/models/framework/miso_field_validations.rb
+++ b/app/models/framework/miso_field_validations.rb
@@ -24,6 +24,8 @@ class Framework
 
     def generate_mandatory_field_rules
       fields
+        .reject { |field| field['ExportsTo'] == 'CustomerURN' }
+        .reject { |field| %w[System.Decimal System.Int32 System.Date].include?(field['SystemDataType']) }
         .select { |field| field['Mandatory'] == 'True' }
         .each do |field|
           validations[field['DisplayName']] << 'presence: true'

--- a/app/models/framework/miso_field_validations.rb
+++ b/app/models/framework/miso_field_validations.rb
@@ -1,0 +1,72 @@
+class Framework
+  class MisoFieldValidations
+    attr_reader :fields, :validations
+
+    def initialize(fields)
+      @fields = fields
+      @validations = {}
+    end
+
+    def rules
+      fields.each { |field| validations[field['DisplayName']] = [] }
+
+      generate_mandatory_field_rules
+      generate_boolean_field_rules
+      generate_decimal_field_rules
+      generate_integer_field_rules
+      generate_date_field_rules
+      generate_urn_field_rule
+
+      validations.reject { |_k, v| v.empty? }
+    end
+
+    private
+
+    def generate_mandatory_field_rules
+      fields
+        .select { |field| field['Mandatory'] == 'True' }
+        .each do |field|
+          validations[field['DisplayName']] << 'presence: true'
+        end
+    end
+
+    def generate_boolean_field_rules
+      fields
+        .select { |field| field['SystemDataType'] == 'System.Boolean' }
+        .each do |field|
+          validations[field['DisplayName']] << 'inclusion: { in: %w[true false] }'
+        end
+    end
+
+    def generate_date_field_rules
+      fields
+        .select { |field| field['SystemDataType'] == 'System.Date' }
+        .each do |field|
+          validations[field['DisplayName']] << 'ingested_date: true'
+        end
+    end
+
+    def generate_decimal_field_rules
+      fields
+        .select { |field| field['SystemDataType'] == 'System.Decimal' }
+        .each do |field|
+          validations[field['DisplayName']] << 'numericality: true'
+        end
+    end
+
+    def generate_integer_field_rules
+      fields
+        .select { |field| field['SystemDataType'] == 'System.Int32' }
+        .each do |field|
+          validations[field['DisplayName']] << 'numericality: { only_integer: true }'
+        end
+    end
+
+    def generate_urn_field_rule
+      urn_field = fields.find { |f| f['ExportsTo'] == 'CustomerURN' }
+      return if urn_field.nil?
+
+      validations[urn_field['DisplayName']] << 'urn: true'
+    end
+  end
+end

--- a/app/models/framework/miso_field_validations.rb
+++ b/app/models/framework/miso_field_validations.rb
@@ -11,6 +11,7 @@ class Framework
       fields.each { |field| validations[field['DisplayName']] = [] }
 
       generate_mandatory_field_rules
+      generate_optional_decimal_field_rules
       generate_boolean_field_rules
       generate_decimal_field_rules
       generate_integer_field_rules
@@ -29,6 +30,15 @@ class Framework
         .select { |field| field['Mandatory'] == 'True' }
         .each do |field|
           validations[field['DisplayName']] << 'presence: true'
+        end
+    end
+
+    def generate_optional_decimal_field_rules
+      fields
+        .select { |field| %w[System.Decimal System.Int32].include?(field['SystemDataType']) }
+        .reject { |field| field['Mandatory'] == 'True' }
+        .each do |field|
+          validations[field['DisplayName']] << 'allow_nil: true'
         end
     end
 

--- a/app/models/framework/miso_fields.rb
+++ b/app/models/framework/miso_fields.rb
@@ -27,14 +27,22 @@ class Framework
       row['DisplayName']
     end
 
+    def invoice_validations
+      @invoice_validations ||= MisoFieldValidations.new(invoice_fields).rules
+    end
+
+    def order_fields
+      @order_fields ||= framework_fields.select { |row| row['DestinationTable'] == 'Orders' }
+    end
+
     def order_total_value_field
       row = order_fields.find { |f| f['ExportsTo'] == 'ContractValue' } or
         raise ArgumentError, "no ContractValue field found for framework '#{framework_short_name}'"
       row['DisplayName']
     end
 
-    def order_fields
-      @order_fields ||= framework_fields.select { |row| row['DestinationTable'] == 'Orders' }
+    def order_validations
+      @order_validations ||= MisoFieldValidations.new(order_fields).rules
     end
 
     private

--- a/lib/generators/framework/definition_generator.rb
+++ b/lib/generators/framework/definition_generator.rb
@@ -35,7 +35,7 @@ class Framework
       name
     end
 
-    delegate :framework_name, :invoice_fields, :order_fields, to: :miso_fields
+    delegate :framework_name, :invoice_fields, :invoice_validations, :order_fields, :order_validations, to: :miso_fields
 
     def miso_fields
       @miso_fields ||= Framework::MisoFields.new(framework_short_name)
@@ -48,7 +48,7 @@ class Framework
     def exports_to(field)
       value = field['ExportsTo']
       should_export = value.present? && !value&.match(/[!?]/)
-      ", exports_to: '#{value}'" if should_export
+      "exports_to: '#{value}'" if should_export
     end
 
     def invoice_total_value_field

--- a/lib/generators/framework/templates/framework_definition.rb.erb
+++ b/lib/generators/framework/templates/framework_definition.rb.erb
@@ -8,7 +8,12 @@ class Framework
         <%= invoice_total_value_field %>
 
         <%- invoice_fields.each do |field| -%>
-        field <%= quote(field['DisplayName']) %>, <%= activemodel_data_type field['SystemDataType'] %><%= exports_to(field) %>
+        <%= [
+              "field #{quote(field['DisplayName'])}",
+              activemodel_data_type(field['SystemDataType']),
+              exports_to(field),
+              invoice_validations[field['DisplayName']]
+            ].flatten.compact.join(', ') %>
         <%- end -%>
       end
       <%- if order_fields.any? -%>
@@ -17,7 +22,12 @@ class Framework
         <%= order_total_value_field %>
 
         <%- order_fields.each do |field| -%>
-        field <%= quote(field['DisplayName']) %>, <%= activemodel_data_type field['SystemDataType'] %><%= exports_to(field) %>
+        <%= [
+              "field #{quote(field['DisplayName'])}",
+              activemodel_data_type(field['SystemDataType']),
+              exports_to(field),
+              invoice_validations[field['DisplayName']]
+            ].flatten.compact.join(', ') %>
         <%- end -%>
       end
       <%- end -%>

--- a/spec/models/framework/miso_field_validations_spec.rb
+++ b/spec/models/framework/miso_field_validations_spec.rb
@@ -6,25 +6,43 @@ RSpec.describe Framework::MisoFieldValidations do
   let(:validation) { Framework::MisoFieldValidations.new(invoice_fields) }
 
   describe '#rules' do
-    it 'is included for mandatory fields' do
-      expect(validation.rules['Lot Number']).to include('presence: true')
-    end
+    describe 'presence validation' do
+      it 'is included for mandatory fields' do
+        expect(validation.rules['Lot Number']).to include('presence: true')
+      end
 
-    it 'returns numericality validations for decimal and integer fields' do
-      expect(validation.rules['Invoice Price Per Vehicle']).to include('numericality: true')
-      expect(validation.rules['UNSPSC']).to include('numericality: { only_integer: true }')
-    end
+      it 'is not included for mandatory decimal fields' do
+        expect(validation.rules['Invoice Price Per Vehicle']).not_to include('presence: true')
+      end
 
-    it 'returns date validations for date fields' do
-      expect(validation.rules['Customer Invoice Date']).to include('ingested_date: true')
-    end
+      it 'is not included for mandatory integer fields' do
+        expect(validation.rules['UNSPSC']).not_to include('presence: true')
+      end
 
-    it 'returns inclusion validations for boolean fields' do
-      expect(validation.rules['VAT Applicable?']).to include('inclusion: { in: %w[true false] }')
-    end
+      it 'is not included for mandatory date fields' do
+        expect(validation.rules['Customer Invoice Date']).not_to include('presence: true')
+      end
 
-    it 'returns URN validations' do
-      expect(validation.rules['Customer URN']).to include('urn: true')
+      it 'is not included on mandatory URN validations' do
+        expect(validation.rules['Customer URN']).not_to include('presence: true')
+      end
     end
+  end
+
+  it 'returns numericality validations for decimal and integer fields' do
+    expect(validation.rules['Invoice Price Per Vehicle']).to include('numericality: true')
+    expect(validation.rules['UNSPSC']).to include('numericality: { only_integer: true }')
+  end
+
+  it 'returns date validations for date fields' do
+    expect(validation.rules['Customer Invoice Date']).to include('ingested_date: true')
+  end
+
+  it 'returns inclusion validations for boolean fields' do
+    expect(validation.rules['VAT Applicable?']).to include('inclusion: { in: %w[true false] }')
+  end
+
+  it 'returns URN validations' do
+    expect(validation.rules['Customer URN']).to include('urn: true')
   end
 end

--- a/spec/models/framework/miso_field_validations_spec.rb
+++ b/spec/models/framework/miso_field_validations_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe Framework::MisoFieldValidations do
 
       it 'returns URN validations' do
         expect(validation.rules['Customer URN']).to include('urn: true')
+        expect(validation.rules['Customer URN']).not_to include('presence: true')
+        expect(validation.rules['Customer URN']).not_to include('numericality: { only_integer: true }')
       end
     end
   end

--- a/spec/models/framework/miso_field_validations_spec.rb
+++ b/spec/models/framework/miso_field_validations_spec.rb
@@ -48,4 +48,13 @@ RSpec.describe Framework::MisoFieldValidations do
       end
     end
   end
+
+  context 'RM807' do
+    let(:framework_short_name) { 'RM807' }
+
+    it 'includes allow_nil rule for optional decimal and integer fields' do
+      expect(validation.rules['UNSPSC']).to include('allow_nil: true')
+      expect(validation.rules['On line booking discount']).to include('allow_nil: true')
+    end
+  end
 end

--- a/spec/models/framework/miso_field_validations_spec.rb
+++ b/spec/models/framework/miso_field_validations_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Framework::MisoFieldValidations do
+  let(:framework_short_name) { 'RM1070' }
+  let(:invoice_fields) { Framework::MisoFields.new(framework_short_name).invoice_fields }
+  let(:validation) { Framework::MisoFieldValidations.new(invoice_fields) }
+
+  describe '#rules' do
+    it 'is included for mandatory fields' do
+      expect(validation.rules['Lot Number']).to include('presence: true')
+    end
+
+    it 'returns numericality validations for decimal and integer fields' do
+      expect(validation.rules['Invoice Price Per Vehicle']).to include('numericality: true')
+      expect(validation.rules['UNSPSC']).to include('numericality: { only_integer: true }')
+    end
+
+    it 'returns date validations for date fields' do
+      expect(validation.rules['Customer Invoice Date']).to include('ingested_date: true')
+    end
+
+    it 'returns inclusion validations for boolean fields' do
+      expect(validation.rules['VAT Applicable?']).to include('inclusion: { in: %w[true false] }')
+    end
+
+    it 'returns URN validations' do
+      expect(validation.rules['Customer URN']).to include('urn: true')
+    end
+  end
+end

--- a/spec/models/framework/miso_field_validations_spec.rb
+++ b/spec/models/framework/miso_field_validations_spec.rb
@@ -1,48 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe Framework::MisoFieldValidations do
-  let(:framework_short_name) { 'RM1070' }
   let(:invoice_fields) { Framework::MisoFields.new(framework_short_name).invoice_fields }
   let(:validation) { Framework::MisoFieldValidations.new(invoice_fields) }
 
-  describe '#rules' do
-    describe 'presence validation' do
-      it 'is included for mandatory fields' do
-        expect(validation.rules['Lot Number']).to include('presence: true')
+  context 'RM1070' do
+    let(:framework_short_name) { 'RM1070' }
+
+    describe '#rules' do
+      describe 'presence validation' do
+        it 'is included for mandatory fields' do
+          expect(validation.rules['Lot Number']).to include('presence: true')
+        end
+
+        it 'is not included for mandatory decimal fields' do
+          expect(validation.rules['Invoice Price Per Vehicle']).not_to include('presence: true')
+        end
+
+        it 'is not included for mandatory integer fields' do
+          expect(validation.rules['UNSPSC']).not_to include('presence: true')
+        end
+
+        it 'is not included for mandatory date fields' do
+          expect(validation.rules['Customer Invoice Date']).not_to include('presence: true')
+        end
+
+        it 'is not included on mandatory URN validations' do
+          expect(validation.rules['Customer URN']).not_to include('presence: true')
+        end
       end
 
-      it 'is not included for mandatory decimal fields' do
-        expect(validation.rules['Invoice Price Per Vehicle']).not_to include('presence: true')
+      it 'is included for decimal and integer fields' do
+        expect(validation.rules['Invoice Price Per Vehicle']).to include('numericality: true')
+        expect(validation.rules['UNSPSC']).to include('numericality: { only_integer: true }')
       end
 
-      it 'is not included for mandatory integer fields' do
-        expect(validation.rules['UNSPSC']).not_to include('presence: true')
+      it 'returns date validations for date fields' do
+        expect(validation.rules['Customer Invoice Date']).to include('ingested_date: true')
       end
 
-      it 'is not included for mandatory date fields' do
-        expect(validation.rules['Customer Invoice Date']).not_to include('presence: true')
+      it 'returns inclusion validations for boolean fields' do
+        expect(validation.rules['VAT Applicable?']).to include('inclusion: { in: %w[true false] }')
       end
 
-      it 'is not included on mandatory URN validations' do
-        expect(validation.rules['Customer URN']).not_to include('presence: true')
+      it 'returns URN validations' do
+        expect(validation.rules['Customer URN']).to include('urn: true')
       end
     end
-  end
-
-  it 'returns numericality validations for decimal and integer fields' do
-    expect(validation.rules['Invoice Price Per Vehicle']).to include('numericality: true')
-    expect(validation.rules['UNSPSC']).to include('numericality: { only_integer: true }')
-  end
-
-  it 'returns date validations for date fields' do
-    expect(validation.rules['Customer Invoice Date']).to include('ingested_date: true')
-  end
-
-  it 'returns inclusion validations for boolean fields' do
-    expect(validation.rules['VAT Applicable?']).to include('inclusion: { in: %w[true false] }')
-  end
-
-  it 'returns URN validations' do
-    expect(validation.rules['Customer URN']).to include('urn: true')
   end
 end


### PR DESCRIPTION
Amends the framework definition generator to append validation rules based on the fields exported from MISO.