### PR TITLE
Data migration for users with multiple suppliers

### DIFF
--- a/db/data_migrate/20181025125924_set_task_descriptions_for_users_with_multiple_suppliers.rb
+++ b/db/data_migrate/20181025125924_set_task_descriptions_for_users_with_multiple_suppliers.rb
@@ -1,0 +1,23 @@
+# NOTE: To be run AFTER the October tasks have been generated
+#
+# rails runner db/data_migrate/20181025125924_set_task_descriptions_for_users_with_multiple_suppliers.rb
+SUPPLIER_WITH_SHARED_USERS = [
+  'ISUZU (UK) LTD',
+  'Leasedrive Limited',
+  'Leasedrive Velo',
+  'Royal Devon and Exeter Hospital',
+  'Royal Devon & Exeter NHS Foundation Trust',
+  'SEAT UK Ltd',
+  'Skoda Auto UK',
+  'SUBARU (UK) LTD',
+  'Synergy Health Managed Services Ltd',
+  'Synergy Health PLC',
+  'Volkswagen Commercial Vehicles',
+  'Volkswagen (UK) Ltd'
+].freeze
+
+SUPPLIER_WITH_SHARED_USERS.each do |supplier_name|
+  supplier = Supplier.find_by!(name: supplier_name)
+  puts "Setting task description for #{supplier_name}'s October tasks"
+  supplier.tasks.where(period_month: 10, period_year: 2018).update(description: supplier.name)
+end


### PR DESCRIPTION
This is the data migration that we'll need to run once the November tasks have been created. They'll be created with the following rake task nearer the opening of the submission window:

```
bundle exec rake generate:tasks[10,2018]
```

After that the data migration can be run: 

```
rails runner db/data_migrate/20181025125924_set_task_descriptions_for_users_with_multiple_suppliers.rb
```