### PR TITLE
Allow test DB to be configured separately

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -13,7 +13,7 @@ development:
 
 test:
   <<: *default
-  url: <%= ENV['DATABASE_URL'] %>
+  url: <%= ENV['TEST_DATABASE_URL'] || ENV['DATABASE_URL'] %>
 
 staging:
   <<: *default


### PR DESCRIPTION
This makes it easier to specify separete database names for test and
development environments, which is necessary if working outside of
docker and you don't want running tests to overwrite the development
database: simply set a separate URL for the test database in a .env file
and let dotenv-rails do its thing.