### PR TITLE
(576) Fix typo in 'total_value_field' for RM3767

### DIFF
--- a/app/models/framework/definition/RM3767.rb
+++ b/app/models/framework/definition/RM3767.rb
@@ -7,7 +7,7 @@ class Framework
       management_charge_rate BigDecimal('1')
 
       class Invoice < Sheet
-        total_value_field 'Total Cost (Ex VAT)'
+        total_value_field 'Total Cost (ex VAT)'
 
         field 'Lot Number', :string, exports_to: 'LotNumber'
         field 'Customer URN', :integer, exports_to: 'CustomerURN'


### PR DESCRIPTION
This caused the IngestPostProcessor to not set the `total_value` on
submission entries, which in turn caused the management charge
calculator to fail, causing the submission to hang on the front end.