### PR TITLE
(553) User AuthID and local users table to find tasks

### DIFF
--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -15,7 +15,7 @@ class V1::TasksController < ApplicationController
     tasks = Task.where(nil)
     tasks = tasks.where(status: params.dig(:filter, :status)) if params.dig(:filter, :status)
     tasks = tasks.where(supplier_id: params.dig(:filter, :supplier_id)) if params.dig(:filter, :supplier_id)
-    tasks = tasks.for_user_id(params.dig(:filter, :user_id)) if params.dig(:filter, :user_id)
+    tasks = tasks.for_auth_id(params.dig(:filter, :auth_id)) if params.dig(:filter, :auth_id)
 
     render jsonapi: tasks, include: params.dig(:include)
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -19,10 +19,9 @@ class Task < ApplicationRecord
   has_many :submissions, dependent: :nullify
   has_one :latest_submission, -> { order(created_at: :desc) }, inverse_of: :task, class_name: 'Submission'
 
-  def self.for_user_id(user_id)
-    supplier_ids = Membership
-                   .where(user_id: user_id)
-                   .pluck(:supplier_id)
+  def self.for_auth_id(user_auth_id)
+    user = User.find_by!(auth_id: user_auth_id)
+    supplier_ids = user.memberships.pluck(:supplier_id)
 
     where(supplier_id: supplier_ids)
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Task do
     expect(Task.new.status).to eq 'unstarted'
   end
 
-  describe '.for_user_id' do
+  describe '.for_auth_id' do
     it 'returns tasks for all suppliers that the current user is a member of' do
       user = FactoryBot.create(:user)
 
@@ -27,7 +27,7 @@ RSpec.describe Task do
       task2 = FactoryBot.create(:task, supplier: users_supplier2)
       task3 = FactoryBot.create(:task, supplier: other_supplier)
 
-      tasks = Task.for_user_id(user.id)
+      tasks = Task.for_auth_id(user.auth_id)
 
       expect(tasks).to include(task1)
       expect(tasks).to include(task2)

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe '/v1' do
     end
   end
 
-  describe 'GET /tasks?filter[user_id]=' do
+  describe 'GET /tasks?filter[auth_id]=' do
     it 'returns a filtered list of tasks for a user\'s suppliers' do
       user = FactoryBot.create(:user)
 
@@ -128,7 +128,7 @@ RSpec.describe '/v1' do
       FactoryBot.create(:task, supplier: current_supplier, description: 'hello')
       FactoryBot.create(:task, supplier: another_supplier)
 
-      get "/v1/tasks?filter[user_id]=#{user.id}"
+      get "/v1/tasks?filter[auth_id]=#{CGI.escape(user.auth_id)}"
 
       expect(response).to be_successful
 


### PR DESCRIPTION
Now that we have app sending us auth0 IDs, we can use those and our local user db to locate tasks.
This will remove our need to have app storing user data.