### PR TITLE
(583) Fix setting of `total_value` when ingested value contains invalid characters

### DIFF
--- a/app/models/ingest_post_processor.rb
+++ b/app/models/ingest_post_processor.rb
@@ -18,7 +18,9 @@ class IngestPostProcessor
   end
 
   def total_value
-    params.dig(:data, framework_definition.total_value_field)
+    value = params.dig(:data, framework_definition.total_value_field)
+    value = value.gsub(/([^0-9.]+)/, '').to_f if value.is_a?(String)
+    value
   end
 
   private

--- a/db/data_migrate/20181109141112_fix_submission_entries_total_values.rb
+++ b/db/data_migrate/20181109141112_fix_submission_entries_total_values.rb
@@ -1,0 +1,27 @@
+require 'progress_bar'
+
+Framework.all.find_each do |framework|
+  puts framework.short_name
+
+  total_value_field = framework.definition::Invoice.total_value_field
+
+  entries = SubmissionEntry
+            .validated
+            .invoices
+            .where(
+              "submission_entries.total_value <> \
+               TRANSLATE(submission_entries.data->>'#{total_value_field}', '$£ ,', '')::decimal"
+            )
+            .joins(submission: :framework)
+            .merge(Framework.where(short_name: framework.short_name))
+
+  bar = ProgressBar.new(entries.count)
+
+  entries.find_each do |entry|
+    total_value = BigDecimal(entry.data[total_value_field].tr('$£, ', ''))
+    management_charge = framework.definition.management_charge(total_value)
+
+    entry.update!(total_value: total_value, management_charge: management_charge)
+    bar.increment!
+  end
+end

--- a/spec/models/ingest_post_processor_spec.rb
+++ b/spec/models/ingest_post_processor_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe IngestPostProcessor do
         expect(total_value).to eql(66)
       end
     end
+
+    context 'given parameters with invalid characters' do
+      let(:params) { { entry_type: 'invoice', data: { 'Total Cost (ex VAT)' => ' £ 12,345.67 xxx ' } } }
+
+      it 'removes those values when extracting the total value from the data field' do
+        expect(total_value).to eql(12345.67)
+      end
+    end
   end
 
   describe '#customer_urn' do


### PR DESCRIPTION
Several submission entries contain commas and other invalid characters in their total column within their `data` blob. When this was copied to the `total_value` field, it was truncated, which threw off the numbers we were reporting. 

This fix ensures that these characters are stripped when the `total_value` is set on an entry. A data migration backfills the totals that were previously affected.