### PR TITLE
(583) Include minus sign '-' in the whitelist

### DIFF
--- a/app/models/ingest_post_processor.rb
+++ b/app/models/ingest_post_processor.rb
@@ -19,7 +19,7 @@ class IngestPostProcessor
 
   def total_value
     value = params.dig(:data, framework_definition.total_value_field)
-    value = value.gsub(/([^0-9.]+)/, '').to_f if value.is_a?(String)
+    value = value.gsub(/([^0-9.\-]+)/, '').to_f if value.is_a?(String)
     value
   end
 

--- a/spec/models/ingest_post_processor_spec.rb
+++ b/spec/models/ingest_post_processor_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe IngestPostProcessor do
     end
 
     context 'given parameters with invalid characters' do
-      let(:params) { { entry_type: 'invoice', data: { 'Total Cost (ex VAT)' => ' £ 12,345.67 xxx ' } } }
+      let(:params) { { entry_type: 'invoice', data: { 'Total Cost (ex VAT)' => ' -£ 12,345.67 xxx ' } } }
 
       it 'removes those values when extracting the total value from the data field' do
-        expect(total_value).to eql(12345.67)
+        expect(total_value).to eql(-12345.67)
       end
     end
   end


### PR DESCRIPTION
When I switched from blacklisting invalid characters to a whitelist of
numeric-like values, I forgot to include the minus sign '-'.

This fix ensures that negative values stay negative!