### PR TITLE
(581) Format decimal fields correctly in export

### DIFF
--- a/app/models/export/invoices/row.rb
+++ b/app/models/export/invoices/row.rb
@@ -21,11 +21,11 @@ module Export
           value_for('ProductSubClass', default: nil),
           value_for('ProductCode', default: nil),
           value_for('UnitType'),
-          value_for('UnitPrice'),
+          unit_price,
           value_for('UnitQuantity'),
-          value_for('InvoiceValue'),
+          invoice_value,
           value_for('Expenses', default: nil),
-          value_for('VATCharged'),
+          vat_charged,
           value_for('PromotionCode', default: nil),
           invoice.management_charge,
           *values_for_additional
@@ -37,6 +37,18 @@ module Export
 
       def invoice_date
         formatted_date value_for('InvoiceDate')
+      end
+
+      def unit_price
+        formatted_decimal value_for('UnitPrice')
+      end
+
+      def invoice_value
+        formatted_decimal value_for('InvoiceValue')
+      end
+
+      def vat_charged
+        formatted_decimal value_for('VATCharged')
       end
     end
   end

--- a/app/models/export/submission_entry_row.rb
+++ b/app/models/export/submission_entry_row.rb
@@ -25,6 +25,13 @@ module Export
       parse_date_string(date_string)&.iso8601 || date_string
     end
 
+    def formatted_decimal(value)
+      return '#NOTINDATA' if value == '#NOTINDATA'
+
+      value = value.gsub(/([^0-9.\-]+)/, '').to_f if value.is_a?(String)
+      value
+    end
+
     private
 
     def source_field_for(destination_field)

--- a/spec/lib/tasks/export/invoices_spec.rb
+++ b/spec/lib/tasks/export/invoices_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'rake export:invoices', type: :task do
       expect(output_lines[1]).to eql(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,2018-05-31,3307957,DEP/0008.00032,"\
         'GITIS Terms and Conditions,1,Contracts,Core,,Legal Director/Senior Solicitor,,Hourly,151.09,-0.9,-135.98,,'\
-        '-27.20,,142.99,0.00,0.00,0.00,N/A,Time and Material,,,'
+        '-27.2,,142.99,0.00,0.00,0.00,N/A,Time and Material,,,'
       )
     end
 

--- a/spec/models/export/submission_entry_row_spec.rb
+++ b/spec/models/export/submission_entry_row_spec.rb
@@ -78,4 +78,30 @@ RSpec.describe Export::SubmissionEntryRow do
       expect(row.formatted_date('13/28/19')).to eq '13/28/19'
     end
   end
+
+  describe '#format_decimal strips non-numeric characters' do
+    let(:row) { Export::SubmissionEntryRow.new(entry) }
+    let(:entry) { double 'SubmissionEntry' }
+
+    it 'handles integers' do
+      expect(row.formatted_decimal(42)).to eql 42
+      expect(row.formatted_decimal(-1234)).to eql(-1234)
+    end
+
+    it 'handles floats' do
+      expect(row.formatted_decimal(42.42)).to eql 42.42
+      expect(row.formatted_decimal(-12.34)).to eql(-12.34)
+    end
+
+    it 'handles strings containing invalid characters' do
+      expect(row.formatted_decimal('  12.34   ')).to eql 12.34
+      expect(row.formatted_decimal('€5.12')).to eql 5.12
+      expect(row.formatted_decimal('- $10.99')).to eql(-10.99)
+      expect(row.formatted_decimal(' 4,321.99 ')).to eql(4321.99)
+    end
+
+    it 'handles strings that do not contain a number' do
+      expect(row.formatted_decimal(' N/A ')).to eql 0.0
+    end
+  end
 end


### PR DESCRIPTION
Sometimes fields that we expect to contain decimals may contain other characters (such as `£`), so we need to make sure these are removed before exporting.