### PR TITLE
Update bulk user import process

### DIFF
--- a/app/models/auth0_authenticated_user.rb
+++ b/app/models/auth0_authenticated_user.rb
@@ -1,0 +1,41 @@
+# Used to create a new User record, setting up the required authorisation in
+# Auth0, the current authentication service.
+#
+# See docs/onboarding-suppliers.md for example usage
+class Auth0AuthenticatedUser
+  AUTH0_DATABASE_BASED_CONNECTION_NAME = 'Username-Password-Authentication'.freeze
+
+  attr_reader :auth0_client, :full_name, :email, :supplier_name, :supplier_id
+
+  def initialize(auth0_client, full_name, email, supplier_name, supplier_id)
+    @auth0_client = auth0_client
+    @full_name = full_name
+    @email = email
+    @supplier_name = supplier_name
+    @supplier_id = supplier_id
+  end
+
+  def create!
+    auth0_response = auth0_client.create_user(full_name, auth0_create_options)
+    User.create!(email: email, auth_id: auth0_response.fetch('user_id'))
+  end
+
+  private
+
+  def auth0_create_options
+    {
+      email: email,
+      email_verified: true,
+      password: random_password,
+      connection: AUTH0_DATABASE_BASED_CONNECTION_NAME,
+      app_metadata: {
+        supplier: supplier_name,
+        supplier_id: supplier_id
+      }
+    }
+  end
+
+  def random_password
+    SecureRandom.urlsafe_base64
+  end
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,4 +1,5 @@
 class Membership < ApplicationRecord
   belongs_to :supplier
   belongs_to :user
+  validates :user_id, uniqueness: { scope: :supplier_id }
 end

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -4,6 +4,7 @@ class Supplier < ApplicationRecord
   has_many :submissions, dependent: :nullify
   has_many :tasks, inverse_of: :supplier, dependent: :destroy
   has_many :memberships, dependent: :destroy
+  has_many :users, through: :memberships
 
   validates :name, presence: true
   validates :coda_reference, allow_nil: true, format: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :memberships, dependent: :destroy
+  has_many :suppliers, through: :memberships
   validates :email, presence: true, uniqueness: true
   validates :auth_id, presence: true, uniqueness: true
 end

--- a/docs/onboarding-suppliers.md
+++ b/docs/onboarding-suppliers.md
@@ -4,9 +4,8 @@ Because of the dependency on Auth0 for authentication and the way the
 architecture and data model is currently split, onboarding suppliers and their
 users is a three-step process:
 
-  1. Add suppliers to the API application using a data migration
-  2. Add users to the supplier-facing application and Auth0
-  3. Link the users to their suppliers in the API application
+  1. Add suppliers
+  2. Add users to Auth0 and local database, and create memberships
 
 ## 1. Add suppliers to the API application
 
@@ -15,14 +14,44 @@ for an example of a data migration that will add a list of new suppliers to
 the application. Note that it also outputs a data-structure that will be used
 in the next step.
 
-## 2. Add users to the supplier-facing application and Auth0
+## 2. Add users to Auth0 and local database, and create memberships
 
-The next step is documented in the DataSubmissionService repo in
-docs/setting-up-new-users.md. Essentially some utility code can be used to
-1) add the users to Auth0; 2) Add user records to the application database; 3)
-output the code that will complete the next step.
+This can be performed using the `Auth0AuthenticatedUser` utility class.
 
-## 3. Link the users to their suppliers in the API application
+Below is an example Ruby script demonstrating its use. It assumes the following:
+- There is a CSV file containing the user details with headers: Supplier Name,
+  User Name, Email
+- All suppliers have already been created in step 1
+- AUTH0 environment variables are set, including one called `AUTH0_API_TOKEN`
+  that contains a valid API token. One can be acquired from "API Explorer" tab
+  in the API section of Auth0.
 
-The output from the previous step will need to be run on the API application
-so that the newly added users are associated with their suppliers.
+```ruby
+require 'auth0'
+require 'csv'
+ # set this based on the output from the supplier data migration that is run on the API
+ auth0_client = Auth0Client.new(
+  client_id: ENV['AUTH0_CLIENT_ID'],
+  domain: ENV['AUTH0_DOMAIN'],
+  token: ENV['AUTH0_API_TOKEN'], # This needs to be generated/acquired from Auth0
+  api_version: 2
+)
+ # copy the csv to the docker container using docker cp. Make sure to cleanup after!
+CSV.read('./tmp/users.csv', headers: true, header_converters: :symbol).each do |row|
+  user_name = row.fetch(:user_name)
+  email = row.fetch(:email)
+  supplier_name = row.fetch(:supplier_name)
+  supplier = Supplier.find_by!(name: supplier_name)
+  user = if User.exists?(email: email)
+    p "found #{email}"
+    User.find_by(email: email)
+  else
+    sleep(0.5)
+    p "created #{email}"
+    auth0_authenticated_user = Auth0AuthenticatedUser.new(auth0_client, user_name, email, supplier_name, supplier.id)
+    auth0_authenticated_user.create!
+  end
+  supplier.users << user unless supplier.users.include?(user)
+  p "added #{email} to #{supplier_name}"
+end
+```

--- a/spec/models/auth0_authenticated_user_spec.rb
+++ b/spec/models/auth0_authenticated_user_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Auth0AuthenticatedUser do
+  let(:auth0_client) { instance_double('Auth0 client') }
+  let(:auth0_create_user_response) do
+    {
+      'email' => email,
+      'email_verified' => true,
+      'name' => user_name,
+      'updated_at' => '2018-09-25T12:19:46.006Z',
+      'picture' => 'https://s.gravatar.com/avatar/1234.png',
+      'user_id' => 'auth0|12345',
+      'nickname' => user_name,
+      'identities' => [
+        {
+          'connection' => 'Username-Password-Authentication',
+          'user_id' => '12345',
+          'provider' => 'auth0',
+          'isSocial' => false
+        }
+      ],
+      'created_at' => '2018-09-25T12:19:46.006Z',
+      'app_metadata' => { 'supplier' => supplier_name, 'supplier_id' => supplier_id }
+    }
+  end
+  let(:user_name) { 'Test User' }
+  let(:email) { 'test@user.com' }
+  let(:supplier_name) { 'DXW' }
+  let(:supplier_id) { '123456' }
+  let(:auth0_authenticated_user) do
+    Auth0AuthenticatedUser.new(auth0_client, user_name, email, supplier_name, supplier_id)
+  end
+
+  describe '#create' do
+    it 'creates the user on Auth0 and creates a corresponding database record matching the auth0 user id' do
+      expect(auth0_client).to receive(:create_user).with(
+        user_name,
+        a_hash_including(
+          email: email,
+          email_verified: true,
+          password: kind_of(String),
+          connection: Auth0AuthenticatedUser::AUTH0_DATABASE_BASED_CONNECTION_NAME,
+          app_metadata: {
+            supplier: supplier_name,
+            supplier_id: supplier_id
+          }
+        )
+      ).and_return(auth0_create_user_response)
+
+      user = auth0_authenticated_user.create!
+
+      expect(user).to be_persisted
+      expect(user.email).to eq 'test@user.com'
+      expect(user.auth_id).to eq 'auth0|12345'
+    end
+  end
+end


### PR DESCRIPTION
Now that we have migrated the user model to this application, we can simplify the user import process.

In this commit, I have recreated the Auth0AuthenticatedUser helper class, and updated the documentation.

I have also created has_many through relationships between users and suppliers, and made that relationship validate that only one reltionship exists between the two.