### PR TITLE
Ensure all memberships have a valid user

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,6 +1,4 @@
 class Membership < ApplicationRecord
   belongs_to :supplier
-  belongs_to :user, optional: true
-
-  validates :user_id, presence: true
+  belongs_to :user
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -3,5 +3,4 @@ require 'rails_helper'
 RSpec.describe Membership do
   it { is_expected.to belong_to(:supplier) }
   it { is_expected.to belong_to(:user) }
-  it { is_expected.to validate_presence_of(:user_id) }
 end


### PR DESCRIPTION
While we were in the process of migrating users across to API, we couldn't enforce that a Membership's user existed, as it might not have yet.

Now that we have finished this migration, I've gone and cleaned up the production data, and we're ready to enforce this.