### PR TITLE
(573) Expose report_no_business boolean in API

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -36,4 +36,8 @@ class Submission < ApplicationRecord
   def sheet_names
     entries.distinct.pluck(Arel.sql("source->>'sheet'"))
   end
+
+  def report_no_business?
+    files.count.zero?
+  end
 end

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -26,6 +26,8 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
     Hash[submission.sheet_names.map { |sheet_name| [sheet_name, errors_for(sheet_name)] }]
   end
 
+  attribute :report_no_business?
+
   private
 
   def submission

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -33,4 +33,13 @@ RSpec.describe Submission do
       expect(submission.sheet_names).to match_array %w[Invoices Orders]
     end
   end
+
+  describe '#report_no_business?' do
+    it 'returns false if submission has files' do
+      expect(FactoryBot.create(:submission_with_validated_entries).report_no_business?).to be(false)
+    end
+    it 'returns true if submission has no files' do
+      expect(FactoryBot.create(:submission).report_no_business?).to be(true)
+    end
+  end
 end

--- a/spec/serializable/serializable_submission_spec.rb
+++ b/spec/serializable/serializable_submission_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe SerializableSubmission do
     it 'exposes a count of the number of order entries' do
       expect(serialized_submission.as_jsonapi[:attributes][:order_count]).to eq(3)
     end
+
+    it 'exposes a report_no_business? boolean' do
+      expect(serialized_submission.as_jsonapi[:attributes][:report_no_business?]).to eq(true)
+    end
   end
 
   describe '#sheet_errors' do


### PR DESCRIPTION
Based on the number of submission files for a given submission we can
tell if this is a report no business or report MI task.

We will use this in the frontend app to show the appropriate confirmation
page.

https://trello.com/c/FQtsRpgH/573-confirmation-page-iteration