### PR TITLE
558 admin user can link unlink users to from suppliers

### DIFF
--- a/app/assets/stylesheets/components/button/_button.scss
+++ b/app/assets/stylesheets/components/button/_button.scss
@@ -51,6 +51,9 @@ $button-shadow-size: $govuk-border-width-form-element;
 }
 
 .govuk-button--as-link {
+  border:none;
+  padding: 0;
+  margin-bottom: 0;
   text-decoration: underline;
   color: govuk-colour("blue");
   @include govuk-font(19);
@@ -70,12 +73,8 @@ $button-shadow-size: $govuk-border-width-form-element;
     color: $govuk-link-active-colour;
   }
   &:focus {
-    color: $govuk-focus-text-colour;
+    @include govuk-focusable-fill();
   }
 }
-//input type submit, default styles override
-input[type="submit"].govuk-button--as-link {
-  border:none;
-  padding: 0;
-  margin-bottom: 0;
-}
+
+

--- a/app/assets/stylesheets/components/button/_button.scss
+++ b/app/assets/stylesheets/components/button/_button.scss
@@ -50,4 +50,32 @@ $button-shadow-size: $govuk-border-width-form-element;
   }
 }
 
+.govuk-button--as-link {
+  text-decoration: underline;
+  color: govuk-colour("blue");
+  @include govuk-font(19);
+  &:link {
+    color: $govuk-link-colour;
+  }
 
+  &:visited {
+    color: $govuk-link-visited-colour;
+  }
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+  }
+
+  &:active {
+    color: $govuk-link-active-colour;
+  }
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+}
+//input type submit, default styles override
+input[type="submit"].govuk-button--as-link {
+  border:none;
+  padding: 0;
+  margin-bottom: 0;
+}

--- a/app/controllers/admin/memberships_controller.rb
+++ b/app/controllers/admin/memberships_controller.rb
@@ -1,0 +1,31 @@
+class Admin::MembershipsController < AdminController
+  before_action :find_user
+  def new
+    @suppliers = Supplier.all - @user.suppliers
+  end
+
+  def create
+    @user.memberships.create!(membership_params)
+    redirect_to admin_user_path(@user)
+  end
+
+  def show
+    @membership = @user.memberships.find(params[:id])
+  end
+
+  def destroy
+    @membership = @user.memberships.find(params[:id])
+    @membership.destroy
+    redirect_to admin_user_path(@user)
+  end
+
+  private
+
+  def find_user
+    @user = User.find(params[:user_id])
+  end
+
+  def membership_params
+    params.require(:membership).permit(:supplier_id)
+  end
+end

--- a/app/views/admin/memberships/new.html.haml
+++ b/app/views/admin/memberships/new.html.haml
@@ -1,9 +1,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
-    %fieldset.govuk-fieldset
-      %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
-        %h1.govuk-fieldset__heading
-          Link to a supplier
+    %h1.govuk-heading-xl
+      Link to a supplier
     %table.govuk-table
       %thead.govuk-table__head
         %tr.govuk-table__row
@@ -16,4 +14,4 @@
             %td.govuk-table__cell
               = form_for [:admin, @user, Membership.new] do |form|
                 = form.hidden_field :supplier_id, value: supplier.id
-                = form.submit 'Link user', class: 'govuk-button govuk-!-margin-bottom-0'
+                = form.submit 'Link user', 'aria-label' => "Link user #{@user.name} to #{supplier.name}", class: 'govuk-button--as-link'

--- a/app/views/admin/memberships/new.html.haml
+++ b/app/views/admin/memberships/new.html.haml
@@ -1,0 +1,13 @@
+%table
+  %thead
+    %tr
+      %th Supplier
+      %th Actions
+  %tbody
+    - @suppliers.each do |supplier|
+      %tr
+        %td= supplier.name
+        %td
+          = form_for [:admin, @user, Membership.new] do |form|
+            = form.hidden_field :supplier_id, value: supplier.id
+            = form.submit 'Link user'

--- a/app/views/admin/memberships/new.html.haml
+++ b/app/views/admin/memberships/new.html.haml
@@ -1,13 +1,19 @@
-%table
-  %thead
-    %tr
-      %th Supplier
-      %th Actions
-  %tbody
-    - @suppliers.each do |supplier|
-      %tr
-        %td= supplier.name
-        %td
-          = form_for [:admin, @user, Membership.new] do |form|
-            = form.hidden_field :supplier_id, value: supplier.id
-            = form.submit 'Link user'
+.govuk-grid-row
+  .govuk-grid-column-full
+    %fieldset.govuk-fieldset
+      %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
+        %h1.govuk-fieldset__heading
+          Link to a supplier
+    %table.govuk-table
+      %thead.govuk-table__head
+        %tr.govuk-table__row
+          %th.govuk-table__header Supplier
+          %th.govuk-table__header Actions
+      %tbody.govuk-table__body
+        - @suppliers.each do |supplier|
+          %tr.govuk-table__row
+            %td.govuk-table__cell= supplier.name
+            %td.govuk-table__cell
+              = form_for [:admin, @user, Membership.new] do |form|
+                = form.hidden_field :supplier_id, value: supplier.id
+                = form.submit 'Link user', class: 'govuk-button govuk-!-margin-bottom-0'

--- a/app/views/admin/memberships/new.html.haml
+++ b/app/views/admin/memberships/new.html.haml
@@ -1,7 +1,9 @@
 .govuk-grid-row
   .govuk-grid-column-full
     %h1.govuk-heading-xl
-      Link to a supplier
+      Link
+      = @user.name
+      to a supplier
     %table.govuk-table
       %thead.govuk-table__head
         %tr.govuk-table__row

--- a/app/views/admin/memberships/show.html.haml
+++ b/app/views/admin/memberships/show.html.haml
@@ -10,5 +10,5 @@
     %h2.govuk-heading-m= @membership.supplier.name
     .govuk-form-group
       = form_for [:admin, @user, @membership], method: :delete do |form|
-        = form.submit 'Unlink user', class: 'govuk-button'
+        = form.submit 'Unlink user', 'aria-label' => "Unlink user #{@user.name} from a #{@membership.supplier.name}", class: 'govuk-button'
 

--- a/app/views/admin/memberships/show.html.haml
+++ b/app/views/admin/memberships/show.html.haml
@@ -1,7 +1,14 @@
-%h1 Unlink user from a supplier
-%h2= @user.name
-%p= @user.email
-%p This user will no longer be able to complete tasks on behalf of the following supplier:textile
-%h2= @membership.supplier.name
-= form_for [:admin, @user, @membership], method: :delete do |form|
-  = form.submit 'Unlink user'
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %fieldset.govuk-fieldset
+      %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
+        %h1.govuk-fieldset__heading
+          Unlink user from a supplier
+    %h2.govuk-heading-m= @user.name
+    %p= @user.email
+    %p This user will no longer be able to complete tasks on behalf of the following supplier
+    %h2.govuk-heading-m= @membership.supplier.name
+    .govuk-form-group
+      = form_for [:admin, @user, @membership], method: :delete do |form|
+        = form.submit 'Unlink user', class: 'govuk-button'
+

--- a/app/views/admin/memberships/show.html.haml
+++ b/app/views/admin/memberships/show.html.haml
@@ -1,0 +1,7 @@
+%h1 Unlink user from a supplier
+%h2= @user.name
+%p= @user.email
+%p This user will no longer be able to complete tasks on behalf of the following supplier:textile
+%h2= @membership.supplier.name
+= form_for [:admin, @user, @membership], method: :delete do |form|
+  = form.submit 'Unlink user'

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -6,7 +6,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %form{method: 'get'}
-      %h4.govuk-heading-s
+      %h2.govuk-heading-s
         Search
       .ccs-search-form-group
         %label.govuk-label.govuk-visually-hidden{for: 'search'} Search
@@ -14,7 +14,7 @@
         %button.govuk-button Search
 
   .govuk-grid-column-one-third
-    %h4.govuk-heading-s
+    %h2.govuk-heading-s
       Actions
     %p
       = link_to 'Add a new user', new_admin_user_path

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -19,7 +19,7 @@
     %p
       = link_to 'Add a new user', new_admin_user_path
 
-%table.govuk-table
+%table.govuk-table{:class => 'govuk-!-margin-top-7'}
   %thead.govuk-table__head
     %tr.govuk-table__row
       %th.govuk-table__header Name

--- a/app/views/admin/users/new.html.haml
+++ b/app/views/admin/users/new.html.haml
@@ -20,4 +20,4 @@
           = form.label :email, 'Email address', class: 'govuk-label'
           = form.text_field :email, class: 'govuk-input'
         .govuk-form-group
-          = form.submit 'Add new user', class: 'govuk-button'
+          = form.submit 'Add new user', 'aria-label': 'Add new user', class: 'govuk-button'

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -7,12 +7,16 @@
     %p
       Account active since:
       = @user.created_at.to_s(:short)
+  .govuk-grid-column-one-third
+    %h2.govuk-heading-s
+      Actions
+    %p
+      = link_to 'Link to a supplier', new_admin_user_membership_path(@user)
 
-= link_to 'Link to a supplier', new_admin_user_membership_path(@user)
-
-.govuk-grid-row
+.govuk-grid-row{:class => 'govuk-!-margin-top-7'}
   .govuk-grid-column-full
-    %h2.govuk-heading-m Linked Suppliers
+    %h2.govuk-heading-m
+      Linked Suppliers
 
     %table.govuk-table
       %thead.govuk-table__head
@@ -25,7 +29,8 @@
             %td.govuk-table__cell= membership.supplier.name
             %td.govuk-table__cell= link_to 'Unlink', admin_user_membership_path(@user, membership)
 
-    %h2.govuk-heading-m Frameworks
+    %h2.govuk-heading-m{:class => 'govuk-!-margin-top-7'}
+      Frameworks
 
     %table.govuk-table
       %thead.govuk-table__head
@@ -39,7 +44,8 @@
               %td.govuk-table__cell= framework.name
               %td.govuk-table__cell= supplier.name
 
-    %h2.govuk-heading-m Recent Tasks
+    %h2.govuk-heading-m{:class => 'govuk-!-margin-top-7'}
+      Recent Tasks
 
     %table.govuk-table
       %thead.govuk-table__head

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h3.govuk-heading-m= @user.name
+    %h2.govuk-heading-m= @user.name
     %p= @user.email
     %p
       Account active since:
@@ -12,7 +12,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-full
-    %h3.govuk-heading-m Linked Suppliers
+    %h2.govuk-heading-m Linked Suppliers
 
     %table.govuk-table
       %thead.govuk-table__head
@@ -25,7 +25,7 @@
             %td.govuk-table__cell= membership.supplier.name
             %td.govuk-table__cell= link_to 'Unlink', admin_user_membership_path(@user, membership)
 
-    %h3.govuk-heading-m Frameworks
+    %h2.govuk-heading-m Frameworks
 
     %table.govuk-table
       %thead.govuk-table__head
@@ -39,7 +39,7 @@
               %td.govuk-table__cell= framework.name
               %td.govuk-table__cell= supplier.name
 
-    %h3.govuk-heading-m Recent Tasks
+    %h2.govuk-heading-m Recent Tasks
 
     %table.govuk-table
       %thead.govuk-table__head

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -8,6 +8,8 @@
       Account active since:
       = @user.created_at.to_s(:short)
 
+= link_to 'Link to a supplier', new_admin_user_membership_path(@user)
+
 .govuk-grid-row
   .govuk-grid-column-full
     %h3.govuk-heading-m Linked Suppliers
@@ -16,10 +18,12 @@
       %thead.govuk-table__head
         %tr.govuk-table__row
           %th.govuk-table__header Name
+          %th.govuk-table__header Actions
       %tbody.govuk-table__body
-        - @user.suppliers.each do |supplier|
+        - @user.memberships.each do |membership|
           %tr.govuk-table__row
-            %td.govuk-table__cell= supplier.name
+            %td.govuk-table__cell= membership.supplier.name
+            %td.govuk-table__cell= link_to 'Unlink', admin_user_membership_path(@user, membership)
 
     %h3.govuk-heading-m Frameworks
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,9 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root 'users#index'
-    resources :users, only: %i[index show new create]
+    resources :users, only: %i[index show new create] do
+      resources :memberships, only: %i[new create show destroy]
+    end
     get '/sign_in', to: 'sessions#new', as: :sign_in
     get '/sign_out', to: 'sessions#destroy', as: :sign_out
   end

--- a/spec/features/managing_user_memberships_spec.rb
+++ b/spec/features/managing_user_memberships_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+RSpec.feature 'Managing user memberships' do
+  scenario 'adding a user to a supplier' do
+    sign_in_as_admin
+    user = FactoryBot.create(:user)
+    user.suppliers << FactoryBot.create(:supplier, name: 'Supplier 1')
+    FactoryBot.create(:supplier, name: 'Supplier 2')
+    visit admin_user_path(user)
+    click_on 'Link to a supplier'
+    expect(page).to_not have_content('Supplier 1')
+    expect(page).to have_content('Supplier 2')
+    click_on 'Link user'
+    expect(page).to have_content('Supplier 1')
+    expect(page).to have_content('Supplier 2')
+  end
+  scenario 'removing a user from a supplier' do
+    sign_in_as_admin
+    user = FactoryBot.create(:user)
+    user.suppliers << FactoryBot.create(:supplier, name: 'Supplier 1')
+    visit admin_user_path(user)
+    expect(page).to have_content('Supplier 1')
+    click_on 'Unlink'
+    click_on 'Unlink user'
+    expect(page).to_not have_content('Supplier 1')
+  end
+end


### PR DESCRIPTION
So that an added user can see tasks, they need to be associated with the supplier they are a member of, and unlink or link a user from supplier.
This story is to add and style the interface to manage users association with suppliers 

This resolves trello card: https://trello.com/c/aPULjt1F/558-admin-user-can-link-unlink-users-to-from-suppliers