### PR TITLE
(560) admin user can delete a supplier user

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,6 +76,7 @@ Metrics/BlockLength:
     Max: 40
     Exclude:
         - 'spec/**/*'
+        - 'config/routes.rb'
 
 Naming/ClassAndModuleCamelCase:
     Exclude:
@@ -84,4 +85,3 @@ Naming/ClassAndModuleCamelCase:
 Lint/AmbiguousBlockAssociation:
     Exclude:
         - 'spec/**/*'
-

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -21,6 +21,18 @@ class Admin::UsersController < AdminController
     end
   end
 
+  def confirm_delete
+    @user = User.find(params[:id])
+  end
+
+  def destroy
+    @user = User.find(params[:id])
+    @user.delete_on_auth0
+    @user.destroy
+    flash[:alert] = 'User has been deleted'
+    redirect_to admin_users_path
+  end
+
   private
 
   def user_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,4 +33,10 @@ class User < ApplicationRecord
     )
     update auth_id: auth0_response.fetch('user_id')
   end
+
+  def delete_on_auth0
+    auth0_client = Auth0Api.new.client
+    auth0_client.delete_user(auth_id)
+    update auth_id: nil
+  end
 end

--- a/app/views/admin/users/confirm_delete.html.haml
+++ b/app/views/admin/users/confirm_delete.html.haml
@@ -1,0 +1,25 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %fieldset.govuk-fieldset
+      %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
+        %h1.govuk-fieldset__heading
+          Delete this User?
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %p
+      This user will no longer have access to the service
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %table.govuk-table
+      %thead.govuk-table__head
+        %tr.govuk-table__row
+          %th.govuk-table__header Name
+          %th.govuk-table__header Email
+      %tbody.govuk-table__body
+        %tr.govuk-table__row
+          %td.govuk-table__cell= @user.name
+          %td.govuk-table__cell= @user.email
+    .govuk-form-group
+      = form_for [:admin, @user], method: :delete do |form|
+        = form.submit 'Delete user', class: 'govuk-button'

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -12,6 +12,8 @@
       Actions
     %p
       = link_to 'Link to a supplier', new_admin_user_membership_path(@user)
+    %p
+      = link_to 'Delete user', confirm_delete_admin_user_path(@user)
 
 .govuk-grid-row{:class => 'govuk-!-margin-top-7'}
   .govuk-grid-column-full

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,8 +37,11 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root 'users#index'
-    resources :users, only: %i[index show new create] do
+    resources :users, only: %i[index show new create destroy] do
       resources :memberships, only: %i[new create show destroy]
+      member do
+        get :confirm_delete
+      end
     end
     get '/sign_in', to: 'sessions#new', as: :sign_in
     get '/sign_out', to: 'sessions#destroy', as: :sign_out

--- a/spec/features/adding_a_user_spec.rb
+++ b/spec/features/adding_a_user_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
-RSpec.feature 'Finding a user' do
-  scenario 'successfully' do
+RSpec.feature 'Adding a user' do
+  before do
+    stub_auth0_token_request
+    stub_auth0_create_user_request
+
     sign_in_as_admin
-    stub_request(:post, 'https://testdomain/oauth/token')
-      .to_return(status: 200, body: '{"access_token":"TOKEN"}')
-    stub_request(:post, 'https://testdomain/api/v2/users')
-      .to_return(status: 200, body: '{"user_id":"auth0|TEST"}')
-    visit admin_users_path
+  end
+  scenario 'successfully' do
+    click_on 'Users'
     click_on 'Add a new user'
     fill_in 'Name', with: 'New User'
     fill_in 'Email address', with: 'new@example.com'
@@ -18,12 +19,8 @@ RSpec.feature 'Finding a user' do
 
   scenario 'with Rails validation error' do
     FactoryBot.create(:user, email: 'new@example.com')
-    sign_in_as_admin
-    stub_request(:post, 'https://testdomain/oauth/token')
-      .to_return(status: 200, body: '{"access_token":"TOKEN"}')
-    stub_request(:post, 'https://testdomain/api/v2/users')
-      .to_return(status: 200, body: '{"user_id":"auth0|TEST"}')
-    visit admin_users_path
+
+    click_on 'Users'
     click_on 'Add a new user'
     fill_in 'Name', with: 'New User'
     fill_in 'Email address', with: 'new@example.com'

--- a/spec/features/deleting_a_user_spec.rb
+++ b/spec/features/deleting_a_user_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.feature 'Delating a user' do
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    stub_auth0_token_request
+    stub_auth0_delete_user_request(user)
+  end
+
+  scenario 'successfully' do
+    sign_in_as_admin
+    click_on 'Users'
+    click_on user.name
+    click_on 'Delete user'
+    click_on 'Delete user'
+
+    expect(page).to have_content('User has been deleted')
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,17 +2,17 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it { is_expected.to have_many(:memberships) }
-  describe '#create_with_auth0' do
-    it 'submits to Auth0 and updates auth_id' do
-      stub_request(:post, 'https://testdomain/oauth/token')
-        .to_return(status: 200, body: '{"access_token":"TOKEN"}')
-      stub = stub_request(:post, 'https://testdomain/api/v2/users')
-             .to_return(status: 200, body: '{"user_id":"auth0|TEST"}')
 
-      user = FactoryBot.create(:user, name: 'Test', email: 'test@example.com')
+  describe '#create_with_auth0' do
+    let(:user) { FactoryBot.create(:user) }
+    let!(:auth0_create_call) { stub_auth0_create_user_request }
+
+    before { stub_auth0_token_request }
+
+    it 'submits to Auth0 and updates auth_id' do
       user.create_with_auth0
 
-      expect(stub).to have_been_requested
+      expect(auth0_create_call).to have_been_requested
       expect(user.auth_id).to eq('auth0|TEST')
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,4 +16,18 @@ RSpec.describe User, type: :model do
       expect(user.auth_id).to eq('auth0|TEST')
     end
   end
+
+  describe '#delete_on_auth0' do
+    let(:user) { FactoryBot.create(:user) }
+    let!(:auth0_delete_call) { stub_auth0_delete_user_request(user) }
+
+    before { stub_auth0_token_request }
+
+    it 'deletes user on Auth0 and nils auth_id' do
+      user.delete_on_auth0
+
+      expect(auth0_delete_call).to have_been_requested
+      expect(user.auth_id).to eq(nil)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,6 +28,7 @@ Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.include Auth0Helpers
   config.include SingleSignOnHelpers, type: :feature
   config.include JSONAPI::RSpec
   config.include StorageHelpers

--- a/spec/support/auth0_helpers.rb
+++ b/spec/support/auth0_helpers.rb
@@ -1,0 +1,11 @@
+module Auth0Helpers
+  def stub_auth0_token_request
+    stub_request(:post, 'https://testdomain/oauth/token')
+      .to_return(status: 200, body: '{"access_token":"TOKEN"}')
+  end
+
+  def stub_auth0_delete_user_request(user)
+    stub_request(:delete, "https://testdomain/api/v2/users/#{user.auth_id}")
+      .to_return(status: 200, body: '')
+  end
+end

--- a/spec/support/auth0_helpers.rb
+++ b/spec/support/auth0_helpers.rb
@@ -8,4 +8,9 @@ module Auth0Helpers
     stub_request(:delete, "https://testdomain/api/v2/users/#{user.auth_id}")
       .to_return(status: 200, body: '')
   end
+
+  def stub_auth0_create_user_request
+    stub_request(:post, 'https://testdomain/api/v2/users')
+      .to_return(status: 200, body: '{"user_id":"auth0|TEST"}')
+  end
 end


### PR DESCRIPTION
So that we can remove users that should no longer have access, 
admin users should be able to delete users from the system. 
For now we are happy with a hard delete because we are not yet associating users with anything other than their supplier.

Descriptive aria labels and styling and markup added
Code for deleting a user also removes them from Auth0

Resolves:
https://trello.com/c/XNaLOYPk/560-admin-user-can-delete-a-supplier-user