### PR TITLE
User search tweaks

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,10 +8,8 @@ class User < ApplicationRecord
   def self.search(query)
     if query.present?
       joins(:suppliers).where(
-        'users.name ILIKE ? OR email ILIKE ? OR suppliers.name ILIKE ?',
-        "%#{query}%",
-        "%#{query}%",
-        "%#{query}%",
+        'users.name ILIKE :query OR email ILIKE :query OR suppliers.name ILIKE :query',
+        query: "%#{query}%"
       )
     else
       where(nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,10 +7,8 @@ class User < ApplicationRecord
 
   def self.search(query)
     if query.present?
-      joins(:suppliers).where(
-        'users.name ILIKE :query OR email ILIKE :query OR suppliers.name ILIKE :query',
-        query: "%#{query}%"
-      )
+      eager_load(:suppliers)
+        .where('users.name ILIKE :query OR email ILIKE :query OR suppliers.name ILIKE :query', query: "%#{query}%")
     else
       where(nil)
     end

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -10,7 +10,7 @@
         Search
       .ccs-search-form-group
         %label.govuk-label.govuk-visually-hidden{for: 'search'} Search
-        %input#search.govuk-input{name: 'search', type: 'text'}
+        %input#search.govuk-input{name: 'search', type: 'text', value: params[:search]}
         %button.govuk-button Search
 
   .govuk-grid-column-one-third

--- a/spec/factories/framework.rb
+++ b/spec/factories/framework.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :framework do
-    sequence(:short_name) { |n| "RM#{n + 1000}" }
+    sequence(:short_name) { |n| "FM#{n + 1000}" }
     sequence(:name) { |n| "G Cloud #{n}" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,4 +30,38 @@ RSpec.describe User, type: :model do
       expect(user.auth_id).to eq(nil)
     end
   end
+
+  describe '.search' do
+    let!(:bob) { FactoryBot.create(:user, name: 'Bob Booker', email: 'bob@sheffield.com') }
+    let!(:bobby) { FactoryBot.create(:user, name: 'Bobby Brown', email: 'bobby_b_66@hotmail.com') }
+
+    before do
+      bob.suppliers << FactoryBot.create(:supplier, name: 'Brentford FC')
+    end
+
+    it 'returns users with names matching the supplied search term' do
+      expect(User.search('bob')).to match_array([bob, bobby])
+      expect(User.search('Frank')).to match_array([])
+    end
+
+    it 'returns users with email addresses matching the supplied search term' do
+      expect(User.search('sheffield.com')).to match_array([bob])
+      expect(User.search('bobby_b')).to match_array([bobby])
+      expect(User.search('foobar')).to match_array([])
+    end
+
+    it 'returns users linked to a supplier matching the supplied search term' do
+      expect(User.search('Brentford')).to match_array([bob])
+    end
+
+    context 'when user is associated with multiple suppliers' do
+      before do
+        bob.suppliers << FactoryBot.create(:supplier, name: 'Sheffield United')
+      end
+
+      it 'doesn’t return multiple results for the matching user' do
+        expect(User.search('booker')).to match_array([bob])
+      end
+    end
+  end
 end


### PR DESCRIPTION
- fixes a bug where users not associated with a supplier were excluded from results
- fixes a bug where users associated with more than one supplier appeared more than once in the results
- replay the search term in the form field to give the user feedback on what they are seeing search results for.

The last commit is a fix for a sporadically failing spec caused by short name clashes.