### PR TITLE
RM3710 should not validate lease dates

### DIFF
--- a/app/models/framework/definition/RM3710.rb
+++ b/app/models/framework/definition/RM3710.rb
@@ -36,8 +36,8 @@ class Framework
         field 'Vehicle Convertors Name', :string, exports_to: 'Additional5'
         field 'Vehicle Conversion Type', :string, exports_to: 'Additional6'
         field 'Vehicle Type', :string, exports_to: 'Additional7'
-        field 'Lease Start Date', :string, exports_to: 'Additional8', ingested_date: true
-        field 'Lease End Date', :string, ingested_date: true
+        field 'Lease Start Date', :string, exports_to: 'Additional8', ingested_date: true, allow_nil: true
+        field 'Lease End Date', :string, ingested_date: true, allow_nil: true
         field 'Lease Period (Months)', :string, ingested_numericality: { only_integer: true }, allow_nil: true
         field 'Payment Profile', :string
         field 'Annual Lease Mileage', :string, ingested_numericality: true, allow_nil: true

--- a/app/validators/ingested_date_validator.rb
+++ b/app/validators/ingested_date_validator.rb
@@ -4,6 +4,17 @@ class IngestedDateValidator < ActiveModel::EachValidator
   include StringUtils
 
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, :invalid_ingested_date) unless parse_date_string(value)
+    record.errors.add(attribute, error_message(record, attribute)) unless parse_date_string(value)
+  end
+
+  private
+
+  def error_message(record, attribute)
+    attribute_optional?(record, attribute) ? :invalid_optional_ingested_date : :invalid_ingested_date
+  end
+
+  def attribute_optional?(record, attribute)
+    validator = record.class.validators_on(attribute).find { |v| v.is_a?(IngestedDateValidator) }
+    validator.options[:allow_nil]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,3 +4,4 @@ en:
     messages:
       invalid_urn: 'is not a recognised URN'
       invalid_ingested_date: 'must be in the format dd/mm/yyyy'
+      invalid_optional_ingested_date: 'must be in the format dd/mm/yyyy or left blank'

--- a/spec/validators/ingested_date_validator_spec.rb
+++ b/spec/validators/ingested_date_validator_spec.rb
@@ -1,43 +1,75 @@
 require 'rails_helper'
 
 RSpec.describe IngestedDateValidator do
-  let(:sheet_class) do
-    Class.new(Framework::Sheet) do
-      extend ActiveModel::Naming
+  context 'validating a field' do
+    let(:sheet_class) do
+      Class.new(Framework::Sheet) do
+        extend ActiveModel::Naming
 
-      def self.name
-        'Validator'
+        def self.name
+          'Validator'
+        end
+
+        field 'An Ingested Date', :string, ingested_date: true
       end
-
-      field 'An Ingested Date', :string, ingested_date: true
     end
-  end
 
-  it 'validates DD/MM/YYYY date strings' do
-    ['12/10/2018', '1/1/2018', '21/9/2017'].each do |valid_date_string|
-      instance = sheet_class.new_from_params('An Ingested Date' => valid_date_string)
-      expect(instance).to be_valid
+    it 'validates DD/MM/YYYY date strings' do
+      ['12/10/2018', '1/1/2018', '21/9/2017'].each do |valid_date_string|
+        instance = sheet_class.new_from_params('An Ingested Date' => valid_date_string)
+        expect(instance).to be_valid
+      end
     end
-  end
 
-  it 'validates MM/DD/YY date strings' do
-    ['9/10/18', '8/1/18', '2/28/17', '3/28/19'].each do |valid_date_string|
-      instance = sheet_class.new_from_params('An Ingested Date' => valid_date_string)
-      expect(instance).to be_valid
+    it 'validates MM/DD/YY date strings' do
+      ['9/10/18', '8/1/18', '2/28/17', '3/28/19'].each do |valid_date_string|
+        instance = sheet_class.new_from_params('An Ingested Date' => valid_date_string)
+        expect(instance).to be_valid
+      end
     end
-  end
 
-  it 'does not validate correctly formatted but invalid dates' do
-    ['28/9/17', '9/21/2017'].each do |invalid_date_string|
-      instance = sheet_class.new_from_params('An Ingested Date' => invalid_date_string)
+    it 'does not validate correctly formatted but invalid dates' do
+      ['28/9/17', '9/21/2017'].each do |invalid_date_string|
+        instance = sheet_class.new_from_params('An Ingested Date' => invalid_date_string)
+        expect(instance).not_to be_valid
+        expect(instance.errors['An Ingested Date'].first).to eq 'must be in the format dd/mm/yyyy'
+      end
+    end
+
+    it 'does not validate values not formatted as a date' do
+      instance = sheet_class.new_from_params('An Ingested Date' => 'Bob')
       expect(instance).not_to be_valid
       expect(instance.errors['An Ingested Date'].first).to eq 'must be in the format dd/mm/yyyy'
     end
   end
 
-  it 'does not validate values not formatted as a date' do
-    instance = sheet_class.new_from_params('An Ingested Date' => 'Bob')
-    expect(instance).not_to be_valid
-    expect(instance.errors['An Ingested Date'].first).to eq 'must be in the format dd/mm/yyyy'
+  context 'validating an optional field' do
+    let(:sheet_class) do
+      Class.new(Framework::Sheet) do
+        extend ActiveModel::Naming
+
+        def self.name
+          'Validator'
+        end
+
+        field 'Optional Ingested Date', :string, ingested_date: true, allow_nil: true
+      end
+    end
+
+    it 'validates a correctly-formatted date string' do
+      instance = sheet_class.new_from_params('Optional Ingested Date' => '12/10/2018')
+      expect(instance).to be_valid
+    end
+
+    it 'validates a blank value' do
+      instance = sheet_class.new_from_params('Optional Ingested Date' => nil)
+      expect(instance).to be_valid
+    end
+
+    it 'mentions that the field is optional in the error message' do
+      instance = sheet_class.new_from_params('Optional Ingested Date' => 'Bad Date')
+      expect(instance).not_to be_valid
+      expect(instance.errors['Optional Ingested Date'].first).to eq 'must be in the format dd/mm/yyyy or left blank'
+    end
   end
 end


### PR DESCRIPTION
This PR makes `"Lease Start Date"` and `"Lease End Date"` on RM3710 optional so that the behaviour matches with the previous JS-based validations. Users will see an error message that mentions they should leave the field blank if it does not validate.