### PR TITLE
(639) add RM1043.5 framework definition

### DIFF
--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -11,7 +11,7 @@ class Framework
       end
 
       def [](framework_short_name)
-        sanitized_framework_short_name = framework_short_name.tr('/', '_')
+        sanitized_framework_short_name = framework_short_name.tr('/.', '_')
         "Framework::Definition::#{sanitized_framework_short_name}".constantize
       rescue NameError
         raise Framework::Definition::MissingError, %(Please run rails g framework:definition "#{framework_short_name}")

--- a/app/models/framework/definition/RM1043_5.rb
+++ b/app/models/framework/definition/RM1043_5.rb
@@ -1,0 +1,76 @@
+class Framework
+  module Definition
+    class RM1043_5 < Base
+      framework_short_name 'RM1043.5'
+      framework_name 'Digital Outcomes and Specialists 3'
+
+      management_charge_rate BigDecimal('1')
+
+      UNIT_OF_MEASURE_VALUES = [
+        'Day',
+        'Each'
+      ].freeze
+
+      SERVICE_PROVIDED_VALUES = [
+        'User Experience and Design',
+        'Performance Analysis and Data',
+        'Security',
+        'Service Delivery',
+        'Software Development',
+        'Support and Operations',
+        'Testing and Auditing',
+        'User Research',
+        'Agile Coach',
+        'Business Analyst',
+        'Communications Manager',
+        'Content Designer or Copywriter',
+        'Cyber Security Consultant',
+        'Data Architect',
+        'Data Engineer',
+        'Data Scientist',
+        'Delivery Manager or Project Manager',
+        'Designer',
+        'Developer',
+        'Performance Analyst',
+        'Portfolio Manager',
+        'Product Manager',
+        'Programme Delivery Manager',
+        'Quality Assurance Analyst',
+        'Service Manager',
+        'Technical Architect',
+        'User Researcher',
+        'Web Operations Engineer',
+        'User Research Studios',
+        'User Research Participants'
+      ].freeze
+
+      class Invoice < EntryData
+        total_value_field 'Total Cost (ex VAT)'
+
+        field 'Opportunity ID', :string, exports_to: 'SupplierReferenceNumber', presence: true, length: { minimum: 4 }, ingested_numericality: { only_integer: true }
+        field 'Customer Organisation Name', :string, exports_to: 'CustomerName', presence: true
+        field 'Customer Unique Reference Number (URN)', :integer, exports_to: 'CustomerURN', urn: true
+        field 'Customer Invoice/Credit Note Date', :string, exports_to: 'Invoice Date', ingested_date: true, presence: true
+        field 'Customer Invoice/Credit Note Number', :string, exports_to: 'InvoiceNumber', presence: true
+        field 'Lot Number', :string, exports_to: 'LotNumber', presence: true, lot_in_agreement: true
+        field 'Service Provided', :string, exports_to: 'ProductGroup', presence: true, case_insensitive_inclusion: { in: SERVICE_PROVIDED_VALUES }
+        field 'Unit of Measure', :string, exports_to: 'UnitType', case_insensitive_inclusion: { in: UNIT_OF_MEASURE_VALUES }
+        field 'Quantity', :string, exports_to: 'UnitQuantity', ingested_numericality: true, presence: true
+        field 'Price per Unit', :string, exports_to: 'UnitPrice', ingested_numericality: true, presence: true
+        field 'Total Cost (ex VAT)', :string, exports_to: 'InvoiceValue', ingested_numericality: true, presence: true
+      end
+
+      class Order < EntryData
+        total_value_field 'Total Contract Value'
+
+        field 'Opportunity ID', :string, exports_to: 'SupplierReferenceNumber', presence: true, length: { minimum: 4 }, ingested_numericality: { only_integer: true }
+        field 'Customer Organisation Name', :string, exports_to: 'CustomerName', presence: true
+        field 'Customer Unique Reference Number (URN)', :integer, exports_to: 'CustomerURN', urn: true
+        field 'Lot Number', :string, exports_to: 'LotNumber', presence: true, lot_in_agreement: true
+        field 'Contract Start Date', :string, exports_to: 'ContractStartDate', ingested_date: true, presence: true
+        field 'Contract End Date', :string, exports_to: 'ContractEndDate', ingested_date: true, presence: true
+        field 'Total Contract Value', :string, exports_to: 'ContractValue', ingested_numericality: true, presence: true
+      end
+    end
+  end
+end

--- a/db/data_migrate/20181212144312_add_dos3_framework.rb
+++ b/db/data_migrate/20181212144312_add_dos3_framework.rb
@@ -1,0 +1,3 @@
+exit if Framework.exists?(short_name: 'RM1043.5')
+
+Framework.create!(short_name: 'RM1043.5', name: 'Digital Outcomes and Specialists 3')

--- a/spec/models/framework/definition_spec.rb
+++ b/spec/models/framework/definition_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Framework::Definition do
           expect(definition.management_charge_rate).to eq(BigDecimal('0'))
         end
       end
+
+      context 'and it has full-stops in it' do
+        let(:framework_short_name) { 'RM1043.5' }
+
+        it 'returns that framework' do
+          expect(definition.framework_short_name).to eql(framework_short_name)
+        end
+
+        it 'reports the management charge' do
+          expect(definition.management_charge_rate). to eq(BigDecimal('1'))
+        end
+      end
     end
 
     context 'the framework does not exist' do


### PR DESCRIPTION
Adding the framework definition for RM1043.5 (aka DOS3)

Requires a data migration to be run to make the framework available:

```
bundle exec rails runner db/data_migrate/20181212144312_add_dos3_framework.rb
```