### PR TITLE
Add lot details and Coda reference to DOS3

### DIFF
--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -1,6 +1,4 @@
 class Framework < ApplicationRecord
-  TMP_FIXED_CHARGE_RATE = BigDecimal('1.5') # percent
-
   has_many :lots, dependent: :nullify, class_name: 'FrameworkLot'
   has_many :submissions, dependent: :nullify
 

--- a/db/data_migrate/20181217095708_add_lots_and_coda_reference_to_dos3.rb
+++ b/db/data_migrate/20181217095708_add_lots_and_coda_reference_to_dos3.rb
@@ -1,0 +1,19 @@
+# Set the coda reference and lot details for RM1043.5
+#
+# Execute with:
+#
+#   rails runner db/data_migrate/20181217095708_add_lots_and_coda_reference_to_dos3.rb
+#
+
+dos3 = Framework.find_by!(short_name: 'RM1043.5')
+dos3.coda_reference = '400141'
+dos3.save!
+
+{
+  1 => 'Digital outcomes',
+  2 => 'Digital specialists',
+  3 => 'User research studios',
+  4 => 'User research participants'
+}.each_pair do |number, description|
+  dos3.lots.create!(number: number, description: description)
+end


### PR DESCRIPTION
A data migration to set the coda reference and the lot details on DOS3 (RM1043.5).  Execute with:

```
rails runner db/data_migrate/20181217095708_add_lots_and_coda_reference_to_dos3.rb
```