### PR TITLE
Expose Sidekiq web UI

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,20 @@
 Rails.application.routes.draw do
+  require 'sidekiq/web'
+  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+    # Protect against timing attacks:
+    # - See https://codahale.com/a-lesson-in-timing-attacks/
+    # - See https://thisdata.com/blog/timing-attacks-against-string-comparison/
+    # - Use & (do not use &&) so that it doesn't short circuit.
+    # - Use digests to stop length information leaking
+    # (see also ActiveSupport::SecurityUtils.variable_size_secure_compare)
+    ActiveSupport::SecurityUtils.secure_compare(
+      ::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV['SIDEKIQ_USERNAME'])
+    ) &
+      ActiveSupport::SecurityUtils.secure_compare(
+        ::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV['SIDEKIQ_PASSWORD'])
+      )
+  end
+  mount Sidekiq::Web, at: '/admin/sidekiq'
   # Endpoint for Cloudwatch to check API is up and running
   get '/check', to: 'check#index', defaults: { format: :json }
 


### PR DESCRIPTION
Mounted at /admin/sidekiq to allow it to be accessed through existing production firewall settings.

Requires the setting of the SIDEKIQ_USERNAME and SIDEKIQ_PASSWORD ENV variables.