### PR TITLE
Set skylight to ignore CheckController

### DIFF
--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,2 @@
+ignored_endpoints:
+  - CheckController#index


### PR DESCRIPTION
We don't need to analyze CheckController#index, and it will add a lot of unecessary requests.