### PR TITLE
Validate and fix inclusion 'Spend Code' for RM858 & RM3710

### DIFF
--- a/app/models/framework/definition/RM3710.rb
+++ b/app/models/framework/definition/RM3710.rb
@@ -46,7 +46,7 @@ class Framework
         field 'Annual Service Maintenance & Repair Costs ex VAT', :string, ingested_numericality: true, allow_nil: true
         field 'Residual Value', :string, ingested_numericality: true, allow_nil: true
         field 'Total Manufacturer Discount (%)', :string, ingested_numericality: true, allow_nil: true
-        field 'Spend Code', :string, exports_to: 'PromotionCode'
+        field 'Spend Code', :string, exports_to: 'PromotionCode', inclusion: { in: ['Lease Rental', 'Fleet Management Fee', 'Damage', 'Other Re-charges'] }
       end
     end
   end

--- a/app/models/framework/definition/RM858.rb
+++ b/app/models/framework/definition/RM858.rb
@@ -23,7 +23,7 @@ class Framework
         field 'Invoice Line Total Value ex VAT', :string, exports_to: 'InvoiceValue', ingested_numericality: true
         field 'VAT Applicable', :string, exports_to: 'VATIncluded', case_insensitive_inclusion: { in: %w[Y N], message: "must be 'Y' or 'N'" }
         field 'VAT Amount Charged', :string, exports_to: 'VATCharged', ingested_numericality: true, allow_nil: true
-        field 'Spend Code', :string, exports_to: 'PromotionCode'
+        field 'Spend Code', :string, exports_to: 'PromotionCode', inclusion: { in: ['Lease Rental', 'Fleet Management Fee', 'Damage', 'Other Re-charges'] }
         field 'Invoice Line Product / Service Grouping', :string, exports_to: 'ProductGroup', presence: true
         field 'CAP Code', :string, exports_to: 'ProductCode'
         field 'Vehicle Make', :string, exports_to: 'ProductClass'

--- a/db/data_migrate/20181218112100_correct_other_recharges_typo.rb
+++ b/db/data_migrate/20181218112100_correct_other_recharges_typo.rb
@@ -1,0 +1,18 @@
+# Set the coda reference and lot details for RM1043.5
+#
+# Execute with:
+#
+#   rails runner db/data_migrate/20181218112100_correct_other_recharges_typo.rb
+#
+
+require 'progress_bar'
+
+puts 'Correcting Recharges to Re-charges'
+incorrect_data = SubmissionEntry.where("data->>'Spend Code' = 'Other Recharges'")
+bar = ProgressBar.new(incorrect_data.count)
+
+incorrect_data.find_each do |submission_entry|
+  submission_entry.data['Spend Code'] = 'Other Re-charges'
+  submission_entry.save!
+  bar.increment!
+end


### PR DESCRIPTION
We've had some incorrect data imported for 'Spend Code', specifically "Other Recharges" instead of the expected "Other Re-charges".

We now validate this mandatory field includes valid data.

Also includes a data migration to fix data that has already been imported with the incorrect 'Other Recharges'. Run with:

'rails runner db/data_migrate/20181218112100_correct_other_recharges_typo.rb'

For reference, there are currently 5047 SubmissionEntries on production that have this problem. This takes around 40 seconds to run on my local machine.