### PR TITLE
Code to automate task creation

### DIFF
--- a/app/jobs/monthly_tasks_generation_job.rb
+++ b/app/jobs/monthly_tasks_generation_job.rb
@@ -1,0 +1,18 @@
+##
+# Generates supplier tasks for the current period
+#
+class MonthlyTasksGenerationJob < ApplicationJob
+  def perform
+    Task::Generator.new(month: submission_period_month, year: submission_period_year, logger: logger).generate!
+  end
+
+  private
+
+  def submission_period_month
+    Date.current.last_month.month
+  end
+
+  def submission_period_year
+    Date.current.last_month.year
+  end
+end

--- a/app/models/task/generator.rb
+++ b/app/models/task/generator.rb
@@ -1,3 +1,5 @@
+require 'bank_holidays'
+
 class Task
   # Used to generate the monthly tasks for suppliers and the frameworks they
   # have an agreement in place for.
@@ -44,7 +46,19 @@ class Task
     end
 
     def due_date
-      Date.new(year, month).end_of_month + 1.week
+      submission_window.last + offset_for_bank_holidays
+    end
+
+    def submission_window
+      Range.new(first_of_month, (first_of_month + 6.days))
+    end
+
+    def first_of_month
+      Date.new(year, month).end_of_month.next_day
+    end
+
+    def offset_for_bank_holidays
+      (submission_window.to_a & BankHolidays.all).size
     end
   end
 end

--- a/lib/bank_holidays.rb
+++ b/lib/bank_holidays.rb
@@ -1,0 +1,28 @@
+class BankHolidays
+  GOV_UK_BANK_HOLIDAYS_URL = 'https://www.gov.uk/bank-holidays.json'.freeze
+
+  # Returns the upcoming bank holidays for England and Wales as published
+  # on GOV.UK
+  def self.future
+    all.reject { |date| date < Date.current }
+  end
+
+  # Returns all the bank holidays (past and future) for England and Wales as
+  # published on GOV.UK
+  def self.all
+    Rails.cache.fetch 'bank_holiday_dates', expires_in: 12.hours do
+      bank_holidays_json['england-and-wales']['events'].map { |event| Date.parse(event['date']) }
+    end
+  end
+
+  def self.bank_holidays_json
+    url = URI(GOV_UK_BANK_HOLIDAYS_URL)
+    http = Net::HTTP.new(url.host, url.port)
+    http.use_ssl = true
+    request = Net::HTTP::Get.new(url)
+    request['content-type'] = 'application/json'
+
+    response = http.request(request)
+    JSON.parse(response.read_body)
+  end
+end

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -1,8 +1,6 @@
 namespace :generate do
-  desc 'Generate monthly tasks for agreements. call with [MM,YY] to specify period, e.g. rake generate:tasks[8,2018]'
-  task :tasks, %i[month year] => :environment do |_task, args|
-    month = args[:month] or raise 'Error: Month argument not specified!'
-    year = args[:year] or raise 'Error: Year argument not specified!'
-    Task::Generator.new(month: month.to_i, year: year.to_i, logger: Logger.new(STDOUT)).generate!
+  desc 'Queues a job to generate the tasks for the current month'
+  task tasks: :environment do
+    MonthlyTasksGenerationJob.perform_later
   end
 end

--- a/spec/fixtures/bank_holidays.json
+++ b/spec/fixtures/bank_holidays.json
@@ -1,0 +1,407 @@
+{
+  "england-and-wales": {
+    "division": "england-and-wales",
+    "events": [
+      {
+        "title": "Easter Monday",
+        "date": "2018-04-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2018-05-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2018-05-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2018-08-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2018-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2018-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2019-04-22",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true
+      }
+    ]
+  },
+  "scotland": {
+    "division": "scotland",
+    "events": [
+      {
+        "title": "Early May bank holiday",
+        "date": "2018-05-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2018-05-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2018-08-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2018-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2018-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2018-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2019-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2019-12-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2020-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2020-05-04",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2020-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      }
+    ]
+  },
+  "northern-ireland": {
+    "division": "northern-ireland",
+    "events": [
+      {
+        "title": "Easter Monday",
+        "date": "2018-04-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2018-05-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2018-05-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2018-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2018-08-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2018-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2018-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2019-03-18",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2019-04-22",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2019-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2020-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2020-04-13",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2020-05-04",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2020-07-13",
+        "notes": "Substitute day",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      }
+    ]
+  }
+}

--- a/spec/jobs/monthly_tasks_generation_job_spec.rb
+++ b/spec/jobs/monthly_tasks_generation_job_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe MonthlyTasksGenerationJob do
+  describe '#perform' do
+    let!(:agreement) { FactoryBot.create(:agreement) }
+    let!(:supplier) { agreement.supplier }
+    let!(:framework) { agreement.framework }
+
+    it 'generates tasks for the previous month’s submissions' do
+      travel_to Date.new(2017, 12, 1) do
+        MonthlyTasksGenerationJob.new.perform
+        supplier_task = supplier.tasks.first
+
+        expect(supplier_task.framework).to eq framework
+        expect(supplier_task.period_month).to eq 11
+        expect(supplier_task.period_year).to eq 2017
+        expect(supplier_task.due_on).to eq Date.new(2017, 12, 7)
+      end
+    end
+
+    it 'copes with crossing into a new year' do
+      travel_to Date.new(2019, 1, 1) do
+        MonthlyTasksGenerationJob.new.perform
+        supplier_task = supplier.tasks.first
+
+        expect(supplier_task.framework).to eq framework
+        expect(supplier_task.period_month).to eq 12
+        expect(supplier_task.period_year).to eq 2018
+        expect(supplier_task.due_on).to eq Date.new(2019, 1, 7)
+      end
+    end
+  end
+end

--- a/spec/jobs/monthly_tasks_generation_job_spec.rb
+++ b/spec/jobs/monthly_tasks_generation_job_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe MonthlyTasksGenerationJob do
+  before { stub_govuk_bank_holidays_request }
+
   describe '#perform' do
     let!(:agreement) { FactoryBot.create(:agreement) }
     let!(:supplier) { agreement.supplier }
@@ -26,7 +28,7 @@ RSpec.describe MonthlyTasksGenerationJob do
         expect(supplier_task.framework).to eq framework
         expect(supplier_task.period_month).to eq 12
         expect(supplier_task.period_year).to eq 2018
-        expect(supplier_task.due_on).to eq Date.new(2019, 1, 7)
+        expect(supplier_task.due_on).to eq Date.new(2019, 1, 8)
       end
     end
   end

--- a/spec/lib/bank_holidays_spec.rb
+++ b/spec/lib/bank_holidays_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+require 'bank_holidays'
+
+RSpec.describe BankHolidays do
+  before { stub_govuk_bank_holidays_request }
+
+  describe '.all' do
+    it 'returns an array of the dates for upcoming bank holidays in England and Wales' do
+      bank_holidays = [
+        Date.parse('2018-04-02'),
+        Date.parse('2018-05-07'),
+        Date.parse('2018-05-28'),
+        Date.parse('2018-08-27'),
+        Date.parse('2018-12-25'),
+        Date.parse('2018-12-26'),
+        Date.parse('2019-01-01'),
+        Date.parse('2019-04-19'),
+        Date.parse('2019-04-22'),
+        Date.parse('2019-05-06'),
+        Date.parse('2019-05-27'),
+        Date.parse('2019-08-26'),
+        Date.parse('2019-12-25'),
+        Date.parse('2019-12-26')
+      ]
+
+      expect(BankHolidays.all).to eq bank_holidays
+    end
+  end
+
+  describe '.future' do
+    it 'returns an array of the dates for upcoming bank holidays in England and Wales' do
+      travel_to Date.new(2018, 12, 12) do
+        future_bank_holidays = [
+          Date.parse('2018-12-25'),
+          Date.parse('2018-12-26'),
+          Date.parse('2019-01-01'),
+          Date.parse('2019-04-19'),
+          Date.parse('2019-04-22'),
+          Date.parse('2019-05-06'),
+          Date.parse('2019-05-27'),
+          Date.parse('2019-08-26'),
+          Date.parse('2019-12-25'),
+          Date.parse('2019-12-26')
+        ]
+
+        expect(BankHolidays.future).to eq future_bank_holidays
+      end
+    end
+  end
+
+  private
+
+  def stub_govuk_bank_holidays_request
+    stub_request(:get, 'https://www.gov.uk/bank-holidays.json')
+      .to_return(status: 200, body: bank_holidays_json)
+  end
+
+  def bank_holidays_json
+    File.read(Rails.root.join('spec', 'fixtures', 'bank_holidays.json'))
+  end
+end

--- a/spec/lib/bank_holidays_spec.rb
+++ b/spec/lib/bank_holidays_spec.rb
@@ -47,15 +47,4 @@ RSpec.describe BankHolidays do
       end
     end
   end
-
-  private
-
-  def stub_govuk_bank_holidays_request
-    stub_request(:get, 'https://www.gov.uk/bank-holidays.json')
-      .to_return(status: 200, body: bank_holidays_json)
-  end
-
-  def bank_holidays_json
-    File.read(Rails.root.join('spec', 'fixtures', 'bank_holidays.json'))
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.include Auth0Helpers
+  config.include BankHolidaysHelpers
   config.include SingleSignOnHelpers, type: :feature
   config.include JSONAPI::RSpec
   config.include StorageHelpers

--- a/spec/support/bank_holidays_helpers.rb
+++ b/spec/support/bank_holidays_helpers.rb
@@ -1,0 +1,10 @@
+module BankHolidaysHelpers
+  def stub_govuk_bank_holidays_request
+    stub_request(:get, 'https://www.gov.uk/bank-holidays.json')
+      .to_return(status: 200, body: bank_holidays_json)
+  end
+
+  def bank_holidays_json
+    File.read(Rails.root.join('spec', 'fixtures', 'bank_holidays.json'))
+  end
+end


### PR DESCRIPTION
This introduces a new `MonthlyTaskGenerationJob` that will generate the current month's tasks based on the existing agreements. We can schedule this job to be run on the first of every month so that the tasks are ready for suppliers to complete.

This PR also includes code that adjusts the due date for tasks based on the presence of bank holidays in the submission window.

A separate PR on https://github.com/dxw/DataSubmissionServiceTerraform will follow to actually schedule the job once a month.