### PR TITLE
Bulk entry creation endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,11 @@ Rails.application.routes.draw do
       end
 
       resources :files, only: %i[create update show], controller: 'submission_files'
-      resources :entries, only: %i[create], controller: 'submission_entries'
+      resources :entries, only: %i[create], controller: 'submission_entries' do
+        collection do
+          post :bulk
+        end
+      end
     end
     resources :tasks, only: %i[index show create update] do
       member do
@@ -40,7 +44,11 @@ Rails.application.routes.draw do
     end
 
     resources :files, only: [] do
-      resources :entries, only: %i[show create], controller: 'submission_entries'
+      resources :entries, only: %i[show create], controller: 'submission_entries' do
+        collection do
+          post :bulk
+        end
+      end
       resources :blobs, only: :create, controller: 'submission_file_blobs'
     end
 


### PR DESCRIPTION
We want to be able to support the creation of multiple SubmissionEntries in a single request, to help with performace.

The JSONAPI standard has the beginnings of a standard on how to handle this (https://github.com/json-api/json-api/blob/9c7a03dbc37f80f6ca81b16d444c960e96dd7a57/extensions/bulk/index.md), however the JSONAPI ruby library does not support this. We have tried to obey the JSONAPI standard however:

- As jsonapi-rb does not support it, it is at it's own endpoint to avoid jsonapi-deserialisation attempts
- There is no standard on what the response to this request should be. However, we currently do not do anything with these responses currently. While this should certainly be addressed soon (any errors are just ignored, which could lead to innacurate data), that is outside the scope of this task.

We have added this new endpoint to both the submission and file API resources.