### PR TITLE
(661) Prevent user creation with duplicate emails (differing case)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,15 @@ require './lib/auth0_api'
 class User < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :suppliers, through: :memberships
-  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email, presence: true, uniqueness: { case_sensitive: false }, format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  def name=(value)
+    super value.squish
+  end
+
+  def email=(value)
+    super value.squish
+  end
 
   def self.search(query)
     if query.present?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,32 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   it { is_expected.to have_many(:memberships) }
 
+  describe 'validations' do
+    it 'fails for duplicate email address, with differing case' do
+      FactoryBot.create(:user, email: 'Jo.Soap@example.com')
+      new_user = FactoryBot.build(:user, email: 'jo.soap@example.com')
+
+      expect(new_user).not_to be_valid
+      expect(new_user.errors[:email]).to be_present
+    end
+  end
+
+  describe '#name=' do
+    it 'strips whitespace when set' do
+      user = FactoryBot.create(:user, name: '   Jo   Soap ')
+
+      expect(user.name).to eql 'Jo Soap'
+    end
+  end
+
+  describe '#email=' do
+    it 'strips whitespace when set' do
+      user = FactoryBot.create(:user, email: '  jo.soap@example.com     ')
+
+      expect(user.email).to eql 'jo.soap@example.com'
+    end
+  end
+
   describe '#create_with_auth0' do
     let(:user) { FactoryBot.create(:user) }
     let!(:auth0_create_call) { stub_auth0_create_user_request(user.email) }


### PR DESCRIPTION
Auth0 treats both `user@example.com` and `USER@example.com` as the same address, so we should too. Previously, we'd create the new user in the local database but it would fail on Auth0, leaving the system in an incorrect state.

I've fixed this by adding `case_sensitive: false` to the uniqueness validation.

Additionally, I'm stripping any whitespace from the name and email address attributes by overriding their setters.