### PR TITLE
Remove unused aws-sdk-lambda gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'rails', '~> 5.2.1'
 # State machine
 gem 'aasm'
 
-gem 'aws-sdk-lambda'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,9 +65,6 @@ GEM
     aws-sdk-kms (1.5.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-lambda (1.8.0)
-      aws-sdk-core (~> 3)
-      aws-sigv4 (~> 1.0)
     aws-sdk-s3 (1.13.0)
       aws-sdk-core (~> 3, >= 3.21.2)
       aws-sdk-kms (~> 1)
@@ -387,7 +384,6 @@ DEPENDENCIES
   aasm
   activerecord-import
   auth0
-  aws-sdk-lambda
   aws-sdk-s3
   bootsnap (>= 1.1.0)
   brakeman
@@ -429,4 +425,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,7 +35,6 @@ RSpec.configure do |config|
   config.include StorageHelpers
   config.include RequestHelpers, type: :request
   config.include ActiveSupport::Testing::TimeHelpers
-  Aws.config[:stub_responses] = true
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
This gem was previously required to trigger the management charge calculation lambda. Since the charge is now calculated in Ruby this gem is no longer required.