### PR TITLE
make "no business" API endpoint idompotent

### DIFF
--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -39,9 +39,13 @@ class V1::TasksController < APIController
 
   def no_business
     task = Task.find(params[:id])
-    task.file_no_business!
-    submission = task.latest_submission
-    render jsonapi: submission, status: :created
+    if task.completed?
+      render jsonapi: task.submissions.first, status: :not_modified
+    else
+      task.file_no_business!
+      submission = task.latest_submission
+      render jsonapi: submission, status: :created
+    end
   end
 
   def complete

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -210,6 +210,14 @@ RSpec.describe '/v1' do
       expect(json['data']).to have_id submission.id
       expect(json['data']['attributes']['status']).to eq 'completed'
     end
+
+    context 'if task already completed' do
+      let(:task) { FactoryBot.create(:task, status: 'completed') }
+
+      it 'should do nothing and return succesfully' do
+        expect(response).to have_http_status(:not_modified)
+      end
+    end
   end
 
   describe 'POST /v1/tasks/:task_id/complete' do


### PR DESCRIPTION
Some users were double clicking the button to submit a no business submission, which resulted in a 500 error when we tried to mark a task as completed for the second time.

This commit will ensure that you can call no_business on a task, and it will not create a new submission or try and update its status, instead returning a not_modified HTTP response.