### PR TITLE
(feature) Validator for interdependent fields

### DIFF
--- a/app/models/framework/definition/RM1043_5.rb
+++ b/app/models/framework/definition/RM1043_5.rb
@@ -11,7 +11,7 @@ class Framework
         'Each'
       ].freeze
 
-      SERVICE_PROVIDED_VALUES = [
+      LOT_1_SERVICES = [
         'User Experience and Design',
         'Performance Analysis and Data',
         'Security',
@@ -20,6 +20,9 @@ class Framework
         'Support and Operations',
         'Testing and Auditing',
         'User Research',
+      ].freeze
+
+      LOT_2_SERVICES = [
         'Agile Coach',
         'Business Analyst',
         'Communications Manager',
@@ -40,9 +43,31 @@ class Framework
         'Technical Architect',
         'User Researcher',
         'Web Operations Engineer',
+      ].freeze
+
+      LOT_3_SERVICES = [
         'User Research Studios',
+      ].freeze
+
+      LOT_4_SERVICES = [
         'User Research Participants'
       ].freeze
+
+      SERVICE_PROVIDED_VALUES = (
+        LOT_1_SERVICES +
+        LOT_2_SERVICES +
+        LOT_3_SERVICES +
+        LOT_4_SERVICES
+      ).freeze
+
+      MAPPING = {
+        'Lot Number' => {
+          '1' => LOT_1_SERVICES,
+          '2' => LOT_2_SERVICES,
+          '3' => LOT_3_SERVICES,
+          '4' => LOT_4_SERVICES,
+        }
+      }.freeze
 
       class Invoice < EntryData
         total_value_field 'Total Cost (ex VAT)'
@@ -53,7 +78,7 @@ class Framework
         field 'Customer Invoice/Credit Note Date', :string, exports_to: 'Invoice Date', ingested_date: true, presence: true
         field 'Customer Invoice/Credit Note Number', :string, exports_to: 'InvoiceNumber', presence: true
         field 'Lot Number', :string, exports_to: 'LotNumber', presence: true, lot_in_agreement: true
-        field 'Service Provided', :string, exports_to: 'ProductGroup', presence: true, case_insensitive_inclusion: { in: SERVICE_PROVIDED_VALUES }
+        field 'Service Provided', :string, exports_to: 'ProductGroup', presence: true, dependent_field_inclusion: { parent: 'Lot Number', in: MAPPING }, case_insensitive_inclusion: { in: SERVICE_PROVIDED_VALUES }
         field 'Unit of Measure', :string, exports_to: 'UnitType', case_insensitive_inclusion: { in: UNIT_OF_MEASURE_VALUES }
         field 'Quantity', :string, exports_to: 'UnitQuantity', ingested_numericality: true, presence: true
         field 'Price per Unit', :string, exports_to: 'UnitPrice', ingested_numericality: true, presence: true

--- a/app/models/framework/definition/RM3756.rb
+++ b/app/models/framework/definition/RM3756.rb
@@ -12,10 +12,13 @@ class Framework
         'Mixture'
       ].freeze
 
-      PRIMARY_SPECIALISM_VALUES = [
+      CORE_SPECIALISMS = [
         'Regulatory Law',
         'Company, Commercial and Contract Law',
         'Public procurement law',
+      ].freeze
+
+      NON_CORE_SPECIALISMS = [
         'EU Law',
         'International Law',
         'Competition Law',
@@ -30,8 +33,21 @@ class Framework
         'Real Estate Law',
         'Restructuring/Insolvency Law',
         'Tax Law',
-        'Insurance Law'
+        'Insurance Law',
       ].freeze
+
+      PRIMARY_SPECIALISM_VALUES = (
+        CORE_SPECIALISMS +
+        NON_CORE_SPECIALISMS
+      ).freeze
+
+      MAPPING = {
+        'Service Type' => {
+          'core' => CORE_SPECIALISMS,
+          'non-core' => NON_CORE_SPECIALISMS,
+          'mixture' => PRIMARY_SPECIALISM_VALUES,
+        }
+      }.freeze
 
       PRACTITIONER_GRADE_VALUES = [
         'Partner',
@@ -68,7 +84,7 @@ class Framework
         field 'Customer Invoice Date', :string, exports_to: 'InvoiceDate', ingested_date: true
         field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber', presence: true
         field 'Service Type', :string, exports_to: 'ProductGroup', presence: true, case_insensitive_inclusion: { in: SERVICE_TYPE_VALUES }
-        field 'Primary Specialism', :string, exports_to: 'ProductDescription', presence: true, case_insensitive_inclusion: { in: PRIMARY_SPECIALISM_VALUES, message: 'must match the selected service type. For a list of service types and specialisms, check the lookups tab in the template.' }
+        field 'Primary Specialism', :string, exports_to: 'ProductDescription', presence: true, dependent_field_inclusion: { parent: 'Service Type', in: MAPPING }, case_insensitive_inclusion: { in: PRIMARY_SPECIALISM_VALUES, message: 'must match the selected service type. For a list of service types and specialisms, check the lookups tab in the template.' }
         field 'Practitioner Grade', :string, exports_to: 'ProductSubClass', presence: true, case_insensitive_inclusion: { in: PRACTITIONER_GRADE_VALUES }
         field 'UNSPSC', :string, exports_to: 'UNSPSC', ingested_numericality: { only_integer: true }
         field 'Unit of Purchase', :string, exports_to: 'UnitType', presence: true, case_insensitive_inclusion: { in: UNIT_OF_PURCHASE_VALUES }

--- a/app/models/framework/definition/RM3786.rb
+++ b/app/models/framework/definition/RM3786.rb
@@ -12,7 +12,7 @@ class Framework
         'Mixture'
       ].freeze
 
-      PRIMARY_SPECIALISM_VALUES = [
+      CORE_SPECIALISMS = [
         'Public Law',
         'Contracts',
         'Competition Law',
@@ -37,6 +37,9 @@ class Framework
         'Restructuring/Insolvency',
         'Tax Law',
         'Environmental Law',
+      ].freeze
+
+      NON_CORE_SPECIALISMS = [
         'Education Law',
         'Child Law',
         'Energy and Natural Resources',
@@ -50,6 +53,19 @@ class Framework
         'Law of International Trade, Investment and Regulation',
         'Public International Law'
       ].freeze
+
+      PRIMARY_SPECIALISM_VALUES = (
+        CORE_SPECIALISMS +
+        NON_CORE_SPECIALISMS
+      ).freeze
+
+      MAPPING = {
+        'Service Type' => {
+          'core' => CORE_SPECIALISMS,
+          'non-core' => NON_CORE_SPECIALISMS,
+          'mixture' => PRIMARY_SPECIALISM_VALUES,
+        }
+      }.freeze
 
       PRACTITIONER_GRADE_VALUES = [
         'Partner',
@@ -92,7 +108,7 @@ class Framework
         field 'Customer Invoice Date', :string, exports_to: 'InvoiceDate', ingested_date: true
         field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber', presence: true
         field 'Service Type', :string, exports_to: 'ProductGroup', presence: true, case_insensitive_inclusion: { in: SERVICE_TYPE_VALUES }
-        field 'Primary Specialism', :string, exports_to: 'ProductDescription', presence: true, case_insensitive_inclusion: { in: PRIMARY_SPECIALISM_VALUES, message: 'must match the selected service type. For a list of service types and specialisms, check the lookups tab in the template.' }
+        field 'Primary Specialism', :string, exports_to: 'ProductDescription', presence: true, dependent_field_inclusion: { parent: 'Service Type', in: MAPPING }, case_insensitive_inclusion: { in: PRIMARY_SPECIALISM_VALUES, message: 'must match the selected service type. For a list of service types and specialisms, check the lookups tab in the template.' }
         field 'Practitioner Grade', :string, exports_to: 'ProductSubClass', presence: true, case_insensitive_inclusion: { in: PRACTITIONER_GRADE_VALUES }
         field 'UNSPSC', :string, exports_to: 'UNSPSC', ingested_numericality: { only_integer: true }
         field 'Unit of Purchase', :string, exports_to: 'UnitType', presence: true, case_insensitive_inclusion: { in: UNIT_OF_PURCHASE_VALUES }

--- a/app/models/framework/definition/RM3787.rb
+++ b/app/models/framework/definition/RM3787.rb
@@ -12,15 +12,7 @@ class Framework
         'Mixture'
       ].freeze
 
-      PRICING_MECHANISM_VALUES = [
-        'Time and Material',
-        'Fixed',
-        'Risk-Reward',
-        'Gain-Share',
-        'Pro-Bono'
-      ].freeze
-
-      PRIMARY_SPECIALISM_VALUES = [
+      CORE_SPECIALISMS = [
         'Corporate Finance',
         'Rescue, Restructuring &  Insolvency',
         'Financial services, market and completion regulation',
@@ -33,12 +25,36 @@ class Framework
         'High Value or complex transactions and disputes',
         'High value or complex merger and acquisition activity',
         'Projects of exceptional innovation and complexity',
+      ].freeze
+
+      NON_CORE_SPECIALISMS = [
         'Sovereign debt restructuring including international and EU structures and processes',
         'International development/aid funding',
         'International Financial organisations',
         'All aspects of law and practice relating to international trade agreements investments and associated regulations, and to the United Kingdom’s exit from the European Union, in so far as they relate to the above projects',
         'Credit / bond insurance, counter indemnities, alternative risk transfer mechanisms'
       ].freeze
+
+      PRICING_MECHANISM_VALUES = [
+        'Time and Material',
+        'Fixed',
+        'Risk-Reward',
+        'Gain-Share',
+        'Pro-Bono'
+      ].freeze
+
+      PRIMARY_SPECIALISM_VALUES = (
+        CORE_SPECIALISMS +
+        NON_CORE_SPECIALISMS
+      ).freeze
+
+      MAPPING = {
+        'Service Type' => {
+          'core' => CORE_SPECIALISMS,
+          'non-core' => NON_CORE_SPECIALISMS,
+          'mixture' => PRIMARY_SPECIALISM_VALUES,
+        }
+      }.freeze
 
       PRACTITIONER_GRADE_VALUES = [
         'Partner',
@@ -73,7 +89,7 @@ class Framework
         field 'Customer Invoice Date', :string, exports_to: 'InvoiceDate', ingested_date: true
         field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber', presence: true
         field 'Service Type', :string, exports_to: 'ProductGroup', presence: true, case_insensitive_inclusion: { in: SERVICE_TYPE_VALUES }
-        field 'Primary Specialism', :string, exports_to: 'ProductClass', presence: true, case_insensitive_inclusion: { in: PRIMARY_SPECIALISM_VALUES, message: 'must match the selected service type. For a list of service types and specialisms, check the lookups tab in the template.' }
+        field 'Primary Specialism', :string, exports_to: 'ProductClass', presence: true, dependent_field_inclusion: { parent: 'Service Type', in: MAPPING }, case_insensitive_inclusion: { in: PRIMARY_SPECIALISM_VALUES, message: 'must match the selected service type. For a list of service types and specialisms, check the lookups tab in the template.' }
         field 'Practitioner Grade', :string, exports_to: 'ProductDescription', presence: true, case_insensitive_inclusion: { in: PRACTITIONER_GRADE_VALUES }
         field 'Pricing Mechanism', :string, exports_to: 'ProductSubClass', presence: true, case_insensitive_inclusion: { in: PRICING_MECHANISM_VALUES }
         field 'UNSPSC', :string, exports_to: 'UNSPSC', ingested_numericality: { only_integer: true }

--- a/app/validators/dependent_field_inclusion_validator.rb
+++ b/app/validators/dependent_field_inclusion_validator.rb
@@ -1,0 +1,20 @@
+class DependentFieldInclusionValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    parent_field_name = options[:parent]
+    parent_field_value = record.attributes[parent_field_name]
+    parent_field_value_lookup = parent_field_value.to_s.downcase
+    mapping = options[:in]
+
+    valid_values = mapping.dig(parent_field_name, parent_field_value_lookup).map(&:downcase)
+    return if value.downcase.in?(valid_values)
+
+    record.errors.add(
+      attribute,
+      :invalid_dependent_field,
+      value: value,
+      attr: attribute,
+      parent_field_name: parent_field_name,
+      parent_field_value: parent_field_value
+    )
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,4 @@ en:
       invalid_ingested_date: 'must be in the format dd/mm/yyyy'
       invalid_optional_ingested_date: 'must be in the format dd/mm/yyyy or left blank'
       invalid_lot_number: 'is not included in the supplier framework agreement'
+      invalid_dependent_field: '"%{value}" is not a valid %{attr} for the given %{parent_field_name} of "%{parent_field_value}"'


### PR DESCRIPTION
Things I'd like help with:

- The validator code seems a bit clunky, as I realised when trying to explain it to @rgarner . However, we do need all those attributes and their values in order to make a decision, and we need to test in a case-insensitive manner.

- Checking the existing `validated` submissions has marked some submission entries as invalid according to _existing_ validations, for example saying that "Total Cost (ex VAT)" with a value of " 2,163.19 " is not a number. I haven't changed anything about the existing validations, so I don't understand why they'd fail now.

Things to discuss:

- Checking the existing `validated` submissions has found a few submission entries that fail the _new_ validation, with, for example, some Primary Specialisms that belong to 'Core' services listed in a 'Non-core' entry row. What do we want to do about those cases?