### PR TITLE
Skip user auth on validate submission action

### DIFF
--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -1,6 +1,8 @@
 class V1::SubmissionsController < APIController
   deserializable_resource :submission, only: %i[create update]
 
+  skip_before_action :reject_without_user!, only: %i[validate]
+
   def show
     submission = current_user.submissions.find(params[:id])
 


### PR DESCRIPTION
This is currently called by the ingest lambda, which does not have access to the current user.