### PR TITLE
(chore) Revert rubocop exclusion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,10 +18,6 @@ Rails/Output:
     Exclude:
         - 'db/data_migrate/**/*'
 
-Rails/HttpPositionalArguments:
-    Exclude:
-        - 'spec/requests/**/*'
-
 Style/AndOr:
     Enabled: false
 


### PR DESCRIPTION
The exclusion was added to get around an actual bug in rubocop. [1]

Now that a recent commit updated rubocop [2], we can revert the unnecessary exclusion.

[1] https://github.com/dxw/DataSubmissionServiceAPI/pull/201#discussion_r244940773
[2] https://github.com/dxw/DataSubmissionServiceAPI/commit/e5d8bc55e1c83943d9b1b37a0fdaceced96de2b8