### PR TITLE
Sidekiq queue metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'rubocop'
 gem 'progress_bar', require: false
 
 gem 'sidekiq'
+gem 'sidekiq-cron'
 
 gem 'activerecord-import'
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'kaminari'
 
+gem 'aws-sdk-cloudwatch', require: false
 gem 'aws-sdk-s3', require: false
 
 # Exception tracking

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,8 @@ GEM
       railties (>= 3.2, < 6.0)
     erubi (1.7.1)
     erubis (2.7.0)
+    et-orbi (1.1.6)
+      tzinfo
     execjs (2.7.0)
     factory_bot (4.10.0)
       activesupport (>= 3.0.0)
@@ -112,6 +114,9 @@ GEM
     faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.23)
+    fugit (1.1.6)
+      et-orbi (~> 1.1, >= 1.1.6)
+      raabro (~> 1.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     haml (5.0.4)
@@ -229,6 +234,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
+    raabro (1.1.6)
     rack (2.0.6)
     rack-protection (2.0.4)
       rack
@@ -343,6 +349,9 @@ GEM
       connection_pool (~> 2.2, >= 2.2.2)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    sidekiq-cron (1.0.4)
+      fugit (~> 1.1)
+      sidekiq (>= 4.2.1)
     skylight (4.0.0.alpha)
       skylight-core (= 4.0.0.alpha)
     skylight-core (4.0.0.alpha)
@@ -421,6 +430,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   shoulda-matchers
   sidekiq
+  sidekiq-cron
   skylight (= 4.0.0.alpha)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,8 +56,11 @@ GEM
     auth0 (4.4.0)
       rest-client (~> 2.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.95.0)
-    aws-sdk-core (3.22.1)
+    aws-partitions (1.129.0)
+    aws-sdk-cloudwatch (1.7.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-core (3.44.2)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -386,6 +389,7 @@ DEPENDENCIES
   aasm
   activerecord-import
   auth0
+  aws-sdk-cloudwatch
   aws-sdk-s3
   bootsnap (>= 1.1.0)
   brakeman

--- a/app/jobs/queue_size_metric_job.rb
+++ b/app/jobs/queue_size_metric_job.rb
@@ -1,0 +1,11 @@
+require 'queue_size_metric'
+
+class QueueSizeMetricJob < ApplicationJob
+  def perform
+    QueueSizeMetric.new(
+      region: ENV['AWS_S3_REGION'],
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+    ).publish
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,5 @@
+Sidekiq.configure_server do |_config|
+  Sidekiq.options[:poll_interval] = 5
+  schedule_file = 'config/sidekiq_schedule.yml'
+  Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   require 'sidekiq/web'
+  require 'sidekiq/cron/web'
+
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|
     # Protect against timing attacks:
     # - See https://codahale.com/a-lesson-in-timing-attacks/

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -1,0 +1,4 @@
+queue_size_metric:
+  cron: "*/30 * * * * *"
+  class: "QueueSizeMetricJob"
+  queue: default

--- a/lib/queue_size_metric.rb
+++ b/lib/queue_size_metric.rb
@@ -1,0 +1,27 @@
+require 'aws-sdk-cloudwatch'
+
+class QueueSizeMetric
+  attr_reader :aws_client
+
+  def initialize(aws_client_options = {})
+    @aws_client = Aws::CloudWatch::Client.new(aws_client_options)
+  end
+
+  def publish
+    @aws_client.put_metric_data(
+      namespace: "api-worker-#{Rails.env}",
+      metric_data: [{
+        metric_name: 'Queue Size',
+        timestamp: Time.zone.now,
+        value: queue_size,
+        unit: 'Count'
+      }]
+    )
+  end
+
+  private
+
+  def queue_size
+    Sidekiq::Stats.new.enqueued
+  end
+end

--- a/spec/lib/queue_size_metric_spec.rb
+++ b/spec/lib/queue_size_metric_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'queue_size_metric'
+
+RSpec.describe QueueSizeMetric do
+  describe '#publish' do
+    it 'puts the Sidekiq queue size as a CloudWatch Metric, namespaced with the Rails environment' do
+      stub_sidekiq_stats
+
+      metric = QueueSizeMetric.new(stub_responses: true)
+      metric.publish
+      executed_request = metric.aws_client.api_requests[0]
+
+      expect(executed_request[:operation_name]).to eq :put_metric_data
+      expect(executed_request[:params][:namespace]).to eq "api-worker-#{Rails.env}"
+      expect(executed_request[:params][:metric_data][0][:metric_name]).to eq 'Queue Size'
+      expect(executed_request[:params][:metric_data][0][:value]).to eq Sidekiq::Stats.new.enqueued
+    end
+  end
+
+  def stub_sidekiq_stats
+    allow_any_instance_of(Sidekiq::Stats).to receive(:enqueued).and_return(23)
+    allow_any_instance_of(Sidekiq::Stats).to receive(:fetch_stats!)
+  end
+end


### PR DESCRIPTION
This introduces a background job that will report the size of the background job queue to AWS every thirty seconds. Specifics can be found in the commit messages.

Part of delivering https://trello.com/c/rYLizZ1W/543-add-metrics-to-infrastructure-that-we-can-scale-against