### PR TITLE
Sidekiq queue reporting tweak

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -66,7 +66,7 @@ Rollbar.configure do |config|
   # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
   # setup for Heroku. See:
   # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
-  config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+  config.environment = ENV['INFRASTRUCTURE_ENVIRONMENT'].presence || Rails.env
 
   config.anonymize_user_ip = true
 end

--- a/lib/queue_size_metric.rb
+++ b/lib/queue_size_metric.rb
@@ -9,7 +9,7 @@ class QueueSizeMetric
 
   def publish
     @aws_client.put_metric_data(
-      namespace: "api-worker-#{Rails.env}",
+      namespace: namespace,
       metric_data: [{
         metric_name: 'Queue Size',
         timestamp: Time.zone.now,
@@ -20,6 +20,10 @@ class QueueSizeMetric
   end
 
   private
+
+  def namespace
+    "api-worker-#{ENV['INFRASTRUCTURE_ENVIRONMENT'] || Rails.env}"
+  end
 
   def queue_size
     Sidekiq::Stats.new.enqueued

--- a/spec/lib/queue_size_metric_spec.rb
+++ b/spec/lib/queue_size_metric_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe QueueSizeMetric do
       expect(executed_request[:params][:metric_data][0][:metric_name]).to eq 'Queue Size'
       expect(executed_request[:params][:metric_data][0][:value]).to eq Sidekiq::Stats.new.enqueued
     end
+
+    it 'can override the namespace with an environment variable' do
+      stub_sidekiq_stats
+      metric = QueueSizeMetric.new(stub_responses: true)
+
+      ClimateControl.modify INFRASTRUCTURE_ENVIRONMENT: 'bob' do
+        metric.publish
+        executed_request = metric.aws_client.api_requests[0]
+        expect(executed_request[:params][:namespace]).to eq 'api-worker-bob'
+      end
+    end
   end
 
   def stub_sidekiq_stats


### PR DESCRIPTION
We can't rely on `Rails.env` to define the namespace for the queue size metric reporting as it's `"production"` in both staging and production environments. Instead we introduce a new environment variable that can be used to override the name for the environment being reported against. We can use this same environment variable for Rollbar, removing the need to set `ROLLBAR_ENV`. There is also an equivalent `SKYLIGHT_ENV`, but there doesn't appear to be a way to configure the reporting name directly for Skylight – it can only be set using `SKYLIGHT_ENV`.

**Note the new environment variable needs to be set on staging before this is merged.**