### PR TITLE
Create workday invoice in bg job on submission completion

### DIFF
--- a/app/jobs/submission_invoice_creation_job.rb
+++ b/app/jobs/submission_invoice_creation_job.rb
@@ -1,0 +1,5 @@
+class SubmissionInvoiceCreationJob < ApplicationJob
+  def perform(submission)
+    Workday::SubmitCustomerInvoiceRequest.new(submission).perform
+  end
+end

--- a/app/models/submission_completion.rb
+++ b/app/models/submission_completion.rb
@@ -10,6 +10,8 @@ class SubmissionCompletion
       submission.task.completed!
     end
 
+    SubmissionInvoiceCreationJob.perform_later(submission) if !submission.report_no_business? && ENV['SUBMIT_INVOICES']
+
     submission
   end
 end

--- a/spec/jobs/submission_invoice_creation_job_spec.rb
+++ b/spec/jobs/submission_invoice_creation_job_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionInvoiceCreationJob do
+  describe '#perform' do
+    let(:submission) { FactoryBot.create(:submission) }
+    let(:submit_invoice_request_double) { double(perform: 'INVOICE_ID') }
+    before do
+      allow(Workday::SubmitCustomerInvoiceRequest).to receive(:new)
+        .with(submission).and_return(submit_invoice_request_double)
+    end
+
+    it 'calls SubmitCustomerInvoiceRequest with correct submission' do
+      SubmissionInvoiceCreationJob.perform_now(submission)
+
+      expect(submit_invoice_request_double).to have_received(:perform)
+    end
+  end
+end


### PR DESCRIPTION
Now that we have a class to submit an invoice to workday, we now create a background job to do so when a submission is completed.

Currently we only do this when an ENV variable is set, as we don't want to have this triggering on production just yet.