### PR TITLE
Create SubmissionInvoice model and save workday references

### DIFF
--- a/app/jobs/submission_invoice_creation_job.rb
+++ b/app/jobs/submission_invoice_creation_job.rb
@@ -1,5 +1,8 @@
 class SubmissionInvoiceCreationJob < ApplicationJob
   def perform(submission)
-    Workday::SubmitCustomerInvoiceRequest.new(submission).perform
+    raise "Submission #{submission.id} already has an invoice." if submission.invoice.present?
+
+    workday_reference = Workday::SubmitCustomerInvoiceRequest.new(submission).perform
+    submission.create_invoice!(workday_reference: workday_reference)
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -7,6 +7,7 @@ class Submission < ApplicationRecord
 
   has_many :files, dependent: :nullify, class_name: 'SubmissionFile'
   has_many :entries, dependent: :nullify, class_name: 'SubmissionEntry'
+  has_one :invoice, dependent: :nullify, class_name: 'SubmissionInvoice'
 
   aasm do
     state :pending, initial: true

--- a/app/models/submission_invoice.rb
+++ b/app/models/submission_invoice.rb
@@ -1,0 +1,3 @@
+class SubmissionInvoice < ApplicationRecord
+  belongs_to :submission
+end

--- a/db/migrate/20190121092757_create_submission_invoices.rb
+++ b/db/migrate/20190121092757_create_submission_invoices.rb
@@ -1,0 +1,10 @@
+class CreateSubmissionInvoices < ActiveRecord::Migration[5.2]
+  def change
+    create_table :submission_invoices, id: :uuid do |t|
+      t.references :submission, foreign_key: true, type: :uuid, null: false
+      t.string :workday_reference
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_10_134813) do
+ActiveRecord::Schema.define(version: 2019_01_21_092757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -137,6 +137,14 @@ ActiveRecord::Schema.define(version: 2018_12_10_134813) do
     t.index ["submission_id"], name: "index_submission_files_on_submission_id"
   end
 
+  create_table "submission_invoices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "submission_id", null: false
+    t.string "workday_reference"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["submission_id"], name: "index_submission_invoices_on_submission_id"
+  end
+
   create_table "submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "framework_id", null: false
     t.uuid "supplier_id", null: false
@@ -190,6 +198,7 @@ ActiveRecord::Schema.define(version: 2018_12_10_134813) do
   add_foreign_key "submission_entries", "submission_files"
   add_foreign_key "submission_entries", "submissions"
   add_foreign_key "submission_files", "submissions"
+  add_foreign_key "submission_invoices", "submissions"
   add_foreign_key "submissions", "frameworks"
   add_foreign_key "submissions", "suppliers"
   add_foreign_key "submissions", "tasks"

--- a/spec/factories/submission_invoices.rb
+++ b/spec/factories/submission_invoices.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :submission_invoice do
+    sequence(:workday_reference) { |n| "WORKDAY_REFERENCE##{n}" }
+    submission
+  end
+end

--- a/spec/jobs/submission_invoice_creation_job_spec.rb
+++ b/spec/jobs/submission_invoice_creation_job_spec.rb
@@ -14,5 +14,20 @@ RSpec.describe SubmissionInvoiceCreationJob do
 
       expect(submit_invoice_request_double).to have_received(:perform)
     end
+
+    it 'creates a SubmissionInvoice with the correct workday_reference' do
+      expect do
+        SubmissionInvoiceCreationJob.perform_now(submission)
+      end.to change { SubmissionInvoice.count }.by(1)
+      expect(submission.invoice.workday_reference).to eq('INVOICE_ID')
+    end
+
+    it 'raise if an invoice already exists' do
+      submission.invoice = FactoryBot.create(:submission_invoice)
+      expect do
+        SubmissionInvoiceCreationJob.perform_now(submission)
+      end.to raise_error(/already has an invoice/)
+      expect(submit_invoice_request_double).to_not have_received(:perform)
+    end
   end
 end


### PR DESCRIPTION
When we create an invoice on workday, we want to save the workday reference ID so we can access it in the future.