### PR TITLE
(Chore) Remove AWS credential ENV

### DIFF
--- a/app/jobs/queue_size_metric_job.rb
+++ b/app/jobs/queue_size_metric_job.rb
@@ -3,9 +3,7 @@ require 'queue_size_metric'
 class QueueSizeMetricJob < ApplicationJob
   def perform
     QueueSizeMetric.new(
-      region: ENV['AWS_S3_REGION'],
-      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+      region: ENV['AWS_S3_REGION']
     ).publish
   end
 end


### PR DESCRIPTION
* Credentials will be provided through the attached IAM role when
running in AWS
* When running locally, the `~/.aws/credentials` will be used