### PR TITLE
Only pass submission ID to Sidekiq job

### DIFF
--- a/app/jobs/submission_invoice_creation_job.rb
+++ b/app/jobs/submission_invoice_creation_job.rb
@@ -1,5 +1,6 @@
 class SubmissionInvoiceCreationJob < ApplicationJob
-  def perform(submission)
+  def perform(submission_id)
+    submission = Submission.find(submission_id)
     raise "Submission #{submission.id} already has an invoice." if submission.invoice.present?
 
     workday_reference = Workday::SubmitCustomerInvoiceRequest.new(submission).perform

--- a/app/models/submission_completion.rb
+++ b/app/models/submission_completion.rb
@@ -10,7 +10,9 @@ class SubmissionCompletion
       submission.task.completed!
     end
 
-    SubmissionInvoiceCreationJob.perform_later(submission) if !submission.report_no_business? && ENV['SUBMIT_INVOICES']
+    if !submission.report_no_business? && ENV['SUBMIT_INVOICES']
+      SubmissionInvoiceCreationJob.perform_later(submission.id)
+    end
 
     submission
   end

--- a/spec/jobs/submission_invoice_creation_job_spec.rb
+++ b/spec/jobs/submission_invoice_creation_job_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe SubmissionInvoiceCreationJob do
     end
 
     it 'calls SubmitCustomerInvoiceRequest with correct submission' do
-      SubmissionInvoiceCreationJob.perform_now(submission)
+      SubmissionInvoiceCreationJob.perform_now(submission.id)
 
       expect(submit_invoice_request_double).to have_received(:perform)
     end
 
     it 'creates a SubmissionInvoice with the correct workday_reference' do
       expect do
-        SubmissionInvoiceCreationJob.perform_now(submission)
+        SubmissionInvoiceCreationJob.perform_now(submission.id)
       end.to change { SubmissionInvoice.count }.by(1)
       expect(submission.invoice.workday_reference).to eq('INVOICE_ID')
     end
@@ -25,7 +25,7 @@ RSpec.describe SubmissionInvoiceCreationJob do
     it 'raise if an invoice already exists' do
       submission.invoice = FactoryBot.create(:submission_invoice)
       expect do
-        SubmissionInvoiceCreationJob.perform_now(submission)
+        SubmissionInvoiceCreationJob.perform_now(submission.id)
       end.to raise_error(/already has an invoice/)
       expect(submit_invoice_request_double).to_not have_received(:perform)
     end

--- a/spec/models/submission_completion_spec.rb
+++ b/spec/models/submission_completion_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SubmissionCompletion do
 
           it 'creates a SubmissionInvoiceSubmissionJob' do
             complete_submission.perform!
-            expect(SubmissionInvoiceCreationJob).to have_been_enqueued.with(submission)
+            expect(SubmissionInvoiceCreationJob).to have_been_enqueued.with(submission.id)
           end
 
           context 'when submission is report_no_business' do


### PR DESCRIPTION
As noticed by @CristinaRO , I was passing the whole submission object to the sidekiq queue, which is sub-optimal (requires serializing and de-serializing the object), so am passing the submission ID instead.