### PR TITLE
(fix) No business endpoint returns the submission

### DIFF
--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -29,7 +29,7 @@ class V1::TasksController < APIController
   def no_business
     task = current_user.tasks.find(params[:id])
     if task.completed?
-      render jsonapi: task.submissions.first, status: :not_modified
+      render jsonapi: task.submissions.first
     else
       task.file_no_business!
       submission = task.latest_submission

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -206,11 +206,14 @@ RSpec.describe '/v1' do
 
     context 'if task already completed' do
       it 'should do nothing and return succesfully' do
-        task = FactoryBot.create(:task, supplier: supplier, status: 'completed')
+        task = FactoryBot.create(:task, supplier: supplier)
+        task.file_no_business!
 
         post "/v1/tasks/#{task.id}/no_business", headers: { 'X-Auth-Id' => user.auth_id }
 
-        expect(response).to have_http_status(:not_modified)
+        submission = task.submissions.last
+
+        expect(json['data']).to have_id submission.id
       end
     end
   end


### PR DESCRIPTION
Previously, we were attempting to respond to a duplicate
`no_business` submission request with a status of ‘Not
Modified’ *and* send the submission in the body.

This was resulting in an error on the supplier facing app,
because Not Modified automatically returns an empty body.

This error was triggered by the user clicking the submission
button too quickly twice in a row, which fired off two requests.

The first request would result in a 201 Created status, while
the second would find the task already completed.

While ‘Not Modified’ would technically be the correct status
for this situation, we considered it more important that the
body be returned in the response, so the supplier gets
redirected to their completed task view.