### PR TITLE
Fix random rspec/json_expectations failure

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+# the following require 'forwardable' is to avoid rspec/json_expectations randomly failing.
+# It can be removed if https://github.com/waterlink/rspec-json_expectations/pull/26 is merged.
+require 'forwardable'
 require 'rspec/json_expectations'
 require 'aasm/rspec'
 require 'webmock/rspec'


### PR DESCRIPTION
rspec/json_expectations depends on, and should require, 'forwardable'.
It works by coincidence in many cases but a small variation in developer
setup can cause it to fail by not finding `Forwardable`.

Ensure we require 'forwardable' ourselves before requiring
json_expectations.

This can be removed if
https://github.com/waterlink/rspec-json_expectations/pull/26 is merged.