### PR TITLE
685 invoice adjustments

### DIFF
--- a/app/jobs/submission_invoice_creation_job.rb
+++ b/app/jobs/submission_invoice_creation_job.rb
@@ -2,7 +2,11 @@ class SubmissionInvoiceCreationJob < ApplicationJob
   def perform(submission)
     raise "Submission #{submission.id} already has an invoice." if submission.invoice.present?
 
-    workday_reference = Workday::SubmitCustomerInvoiceRequest.new(submission).perform
+    workday_reference = if submission.management_charge.negative?
+                          Workday::SubmitCustomerInvoiceAdjustmentRequest.new(submission).perform
+                        else
+                          Workday::SubmitCustomerInvoiceRequest.new(submission).perform
+                        end
     submission.create_invoice!(workday_reference: workday_reference)
   end
 end

--- a/app/models/workday/base.rb
+++ b/app/models/workday/base.rb
@@ -1,0 +1,16 @@
+require 'lolsoap'
+require 'akami'
+
+module Workday
+  CCS_COMPANY_REFERENCE = 'Crown_Commercial_Service'.freeze
+
+  class Fault < StandardError; end
+
+  class Base
+    def set_wsse_header
+      wsse = Akami.wsse
+      wsse.credentials(Workday.api_username, Workday.api_password)
+      request.header.__node__.parent << wsse.to_xml
+    end
+  end
+end

--- a/app/models/workday/submit_customer_invoice_request.rb
+++ b/app/models/workday/submit_customer_invoice_request.rb
@@ -44,9 +44,8 @@ module Workday
             invoice_line.Line_Item_Description      line_item_description
             invoice_line.Extended_Amount            management_charge
             invoice_line.Analytical_Amount          total_spend
-            invoice_line.Revenue_Category_Reference.ID framework_revenue_category_id, 'ns0:type': 'WID'
-            invoice_line.Worktags_Reference.ID      framework_cost_center_id, 'ns0:type': 'WID'
             invoice_line.Worktags_Reference.ID      framework.short_name, 'ns0:type': 'Custom_Organization_Reference_ID'
+            invoice_line.Revenue_Category_Reference.ID framework_revenue_category_id, 'ns0:type': 'WID'
           end
         end
       end
@@ -55,11 +54,6 @@ module Workday
 
     def framework
       submission.framework
-    end
-
-    # NOTE: Hardcoded until we have access to the endpoint to identify this ID in Workday
-    def framework_cost_center_id
-      'd19d3c5849dc01dae8faf3b96d146f5f'
     end
 
     # NOTE: Hardcoded until we have access to the endpoint to identify this ID in Workday

--- a/app/models/workday/submit_customer_invoice_request.rb
+++ b/app/models/workday/submit_customer_invoice_request.rb
@@ -38,6 +38,7 @@ module Workday
           invoice.From_Date               task.period_date.to_s
           invoice.Customer_PO_Number      submission.purchase_order_number
           invoice.Memo                    invoice_memo
+          invoice.Submit                  false
 
           invoice.Customer_Invoice_Line_Replacement_Data do |invoice_line|
             invoice_line.Line_Item_Description      line_item_description

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -57,5 +57,17 @@ FactoryBot.define do
         end
       end
     end
+
+    factory :submission_with_positive_management_charge do
+      after(:create) do |submission, _evaluator|
+        create_list(:invoice_entry, 2, :valid, submission: submission, management_charge: 0.1)
+      end
+    end
+
+    factory :submission_with_negative_management_charge do
+      after(:create) do |submission, _evaluator|
+        create_list(:invoice_entry, 2, :valid, submission: submission, management_charge: -0.1)
+      end
+    end
   end
 end

--- a/spec/fixtures/created_invoice_adjustment_response.xml
+++ b/spec/fixtures/created_invoice_adjustment_response.xml
@@ -1,0 +1,10 @@
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+   <env:Body>
+      <wd:Submit_Customer_Invoice_Adjustment_Response wd:version="v31.0" xmlns:wd="urn:com.workday/bsvc">
+         <wd:Customer_Invoice_Adjustment_Reference>
+            <wd:ID wd:type="WID">2a743abbf5e3819a6451179ed62d1c06</wd:ID>
+            <wd:ID wd:type="Customer_Invoice_Adjustment_Reference_ID">CUSTOMER_INVOICE_ADJUSTMENT-6-7</wd:ID>
+         </wd:Customer_Invoice_Adjustment_Reference>
+      </wd:Submit_Customer_Invoice_Adjustment_Response>
+   </env:Body>
+</env:Envelope>

--- a/spec/jobs/submission_invoice_creation_job_spec.rb
+++ b/spec/jobs/submission_invoice_creation_job_spec.rb
@@ -2,32 +2,56 @@ require 'rails_helper'
 
 RSpec.describe SubmissionInvoiceCreationJob do
   describe '#perform' do
-    let(:submission) { FactoryBot.create(:submission) }
-    let(:submit_invoice_request_double) { double(perform: 'INVOICE_ID') }
-    before do
-      allow(Workday::SubmitCustomerInvoiceRequest).to receive(:new)
-        .with(submission).and_return(submit_invoice_request_double)
-    end
+    context 'with a positive management_charge' do
+      let(:submission) { FactoryBot.create(:submission_with_positive_management_charge) }
+      let(:submit_invoice_request_double) { double(perform: 'INVOICE_ID') }
+      before do
+        allow(Workday::SubmitCustomerInvoiceRequest).to receive(:new)
+          .with(submission).and_return(submit_invoice_request_double)
+      end
 
-    it 'calls SubmitCustomerInvoiceRequest with correct submission' do
-      SubmissionInvoiceCreationJob.perform_now(submission)
-
-      expect(submit_invoice_request_double).to have_received(:perform)
-    end
-
-    it 'creates a SubmissionInvoice with the correct workday_reference' do
-      expect do
+      it 'calls SubmitCustomerInvoiceRequest with correct submission' do
         SubmissionInvoiceCreationJob.perform_now(submission)
-      end.to change { SubmissionInvoice.count }.by(1)
-      expect(submission.invoice.workday_reference).to eq('INVOICE_ID')
+
+        expect(submit_invoice_request_double).to have_received(:perform)
+      end
+
+      it 'creates a SubmissionInvoice with the correct workday_reference' do
+        expect do
+          SubmissionInvoiceCreationJob.perform_now(submission)
+        end.to change { SubmissionInvoice.count }.by(1)
+        expect(submission.invoice.workday_reference).to eq('INVOICE_ID')
+      end
+
+      it 'raise if an invoice already exists' do
+        submission.invoice = FactoryBot.create(:submission_invoice)
+        expect do
+          SubmissionInvoiceCreationJob.perform_now(submission)
+        end.to raise_error(/already has an invoice/)
+        expect(submit_invoice_request_double).to_not have_received(:perform)
+      end
     end
 
-    it 'raise if an invoice already exists' do
-      submission.invoice = FactoryBot.create(:submission_invoice)
-      expect do
+    context 'with a negative management_charge' do
+      let(:submission) { FactoryBot.create(:submission_with_negative_management_charge) }
+      let(:submit_invoice_request_adjustment_double) { double(perform: 'INVOICE_ID') }
+      before do
+        allow(Workday::SubmitCustomerInvoiceAdjustmentRequest).to receive(:new)
+          .with(submission).and_return(submit_invoice_request_adjustment_double)
+      end
+
+      it 'calls SubmitCustomerInvoiceAdjustmentRequest with correct submission' do
         SubmissionInvoiceCreationJob.perform_now(submission)
-      end.to raise_error(/already has an invoice/)
-      expect(submit_invoice_request_double).to_not have_received(:perform)
+
+        expect(submit_invoice_request_adjustment_double).to have_received(:perform)
+      end
+
+      it 'creates a SubmissionInvoice with the correct workday_reference' do
+        expect do
+          SubmissionInvoiceCreationJob.perform_now(submission)
+        end.to change { SubmissionInvoice.count }.by(1)
+        expect(submission.invoice.workday_reference).to eq('INVOICE_ID')
+      end
     end
   end
 end

--- a/spec/models/workday/submit_customer_invoice_adjustment_request_spec.rb
+++ b/spec/models/workday/submit_customer_invoice_adjustment_request_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe Workday::SubmitCustomerInvoiceRequest do
+RSpec.describe Workday::SubmitCustomerInvoiceAdjustmentRequest do
   let(:submission) { FactoryBot.create(:submission_with_validated_entries, purchase_order_number: '123') }
   let(:framework) { submission.framework }
   let(:task) { FactoryBot.create(:task, period_month: 12, period_year: 2018) }
   let(:supplier) { submission.supplier }
-  let(:request) { Workday::SubmitCustomerInvoiceRequest.new(submission) }
+  let(:request) { Workday::SubmitCustomerInvoiceAdjustmentRequest.new(submission) }
 
   it_behaves_like 'a workday request'
 
@@ -83,7 +83,7 @@ RSpec.describe Workday::SubmitCustomerInvoiceRequest do
     end
 
     describe 'when successful' do
-      let(:response) { 'created_invoice_response.xml' }
+      let(:response) { 'created_invoice_adjustment_response.xml' }
 
       it 'makes the POST request to the Workday SOAP endpoint' do
         request.perform
@@ -91,7 +91,7 @@ RSpec.describe Workday::SubmitCustomerInvoiceRequest do
       end
 
       it 'it returns the ID for the invoice' do
-        expect(request.perform).to eq('25354762f7398134ecf5593c822aa50c')
+        expect(request.perform).to eq('2a743abbf5e3819a6451179ed62d1c06')
       end
     end
 

--- a/spec/support/shared_examples/workday.rb
+++ b/spec/support/shared_examples/workday.rb
@@ -1,0 +1,38 @@
+RSpec.shared_examples 'a workday request' do
+  describe '#url' do
+    it 'returns the URL for the Workday Revenue Management web service' do
+      expect(request.url).to eq 'https://wd3-impl-services1.workday.com/ccx/service/crowncommercialservice4/Revenue_Management/v31.0'
+    end
+  end
+end
+RSpec.shared_examples 'an authenticated workday request' do
+  describe 'Security header' do
+    let(:wsse_namespace) do
+      { 'xmlns:wsse' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' }
+    end
+
+    around(:example) do |example|
+      old_username = Workday.api_username
+      old_password = Workday.api_password
+      Workday.api_username = 'a_username'
+      Workday.api_password = 'some_password'
+
+      example.run
+
+      Workday.api_username = old_username
+      Workday.api_password = old_password
+    end
+
+    it 'sets a wsse:UsernameToken security header for authenticating against the API' do
+      header = Nokogiri::XML(request.content).at_xpath('//soap:Envelope//soap:Header')
+
+      expect(
+        header.at_xpath('//wsse:Security//wsse:UsernameToken//wsse:Username', wsse_namespace).text
+      ).to eq 'a_username'
+
+      expect(
+        header.at_xpath('//wsse:Security//wsse:UsernameToken//wsse:Password', wsse_namespace).text
+      ).to eq 'some_password'
+    end
+  end
+end


### PR DESCRIPTION
Relates to https://trello.com/c/mCjl77jt/685-completed-business-returns-in-credit-result-in-a-credit-note-in-workday

New Workday::SubmitCustomerInvoiceAdjustmentRequest class that is very similar to creating a normal Invoice, but to a different endpoint.

Also included in this PR is the removal of sending Cost Centre IDs in workday requests.