### PR TITLE
Adjust AWS credentials configuration for ActiveStorage.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on Amazon S3
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,4 @@ local:
 
 amazon:
   service: S3
-  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
-  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-  region: <%= ENV['AWS_S3_REGION'] %>
   bucket: <%= ENV['AWS_S3_BUCKET'] %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -3,8 +3,11 @@ test:
   root: <%= Rails.root.join("tmp/storage") %>
 
 local:
-  service: Disk
-  root: <%= Rails.root.join("storage") %>
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: <%= ENV['AWS_S3_REGION'] %>
+  bucket: <%= ENV['AWS_S3_BUCKET'] %>
 
 amazon:
   service: S3

--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -1,8 +1,5 @@
 DATABASE_URL=postgres://postgres@db:5432/DataSubmissionServiceApi_development?template=template0&pool=5&encoding=unicode
 REDIS_URL=redis://redis:6379/
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_S3_REGION=eu-west-2
 AWS_S3_BUCKET=dss-infrastructure-development-storage
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=


### PR DESCRIPTION
The AWS credentials are now configured as part of the EC2 instance profile so we no longer need them set via Environment variables. This tidies up the ActiveStorage config to make it explicit what is and isn't needed in terms of environment variable.