### PR TITLE
Fetching and sending Revenue Categories to Workday

### DIFF
--- a/app/jobs/update_framework_revenue_categories_job.rb
+++ b/app/jobs/update_framework_revenue_categories_job.rb
@@ -1,0 +1,20 @@
+class UpdateFrameworkRevenueCategoriesJob < ApplicationJob
+  def perform
+    response = HTTP.basic_auth(
+      user: Workday.username,
+      pass: Workday.api_password
+    ).get(
+      'https://wd3-impl-services1.workday.com/ccx/service/customreport2/' +
+      Workday.tenant +
+      '/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category'
+    )
+    Nokogiri(response.to_s).xpath('//wd:Report_Entry').each do |framework_xml|
+      framework_number = framework_xml.at_xpath('wd:Framework_Number').text
+      revenue_category_wid_xml = framework_xml.at_xpath("wd:Revenue_Category_Level/wd:ID[@wd:type='WID']")
+      revenue_category_wid = revenue_category_wid_xml.present? ? revenue_category_wid_xml.text : nil
+      if (framework = Framework.find_by(short_name: framework_number))
+        framework.update(revenue_category_wid: revenue_category_wid)
+      end
+    end
+  end
+end

--- a/app/models/workday.rb
+++ b/app/models/workday.rb
@@ -26,4 +26,12 @@ module Workday
   def self.api_password
     config[:password]
   end
+
+  def self.username
+    api_username.split('@').first
+  end
+
+  def self.tenant
+    api_username.split('@').last
+  end
 end

--- a/app/models/workday/submit_customer_invoice_adjustment_request.rb
+++ b/app/models/workday/submit_customer_invoice_adjustment_request.rb
@@ -52,9 +52,8 @@ module Workday
       submission.framework
     end
 
-    # NOTE: Hardcoded until we have access to the endpoint to identify this ID in Workday
     def framework_revenue_category_id
-      'cab066ff165e0120b19039874b126b13'
+      framework.revenue_category_wid
     end
 
     def invoice_memo

--- a/app/models/workday/submit_customer_invoice_request.rb
+++ b/app/models/workday/submit_customer_invoice_request.rb
@@ -49,9 +49,8 @@ module Workday
       submission.framework
     end
 
-    # NOTE: Hardcoded until we have access to the endpoint to identify this ID in Workday
     def framework_revenue_category_id
-      'cab066ff165e0120b19039874b126b13'
+      framework.revenue_category_wid
     end
 
     def invoice_memo

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -2,3 +2,7 @@ queue_size_metric:
   cron: "*/30 * * * * *"
   class: "QueueSizeMetricJob"
   queue: default
+update_framework_revenue_categories:
+  cron: "0 12 * * 1-5"
+  class: "UpdateFrameworkRevenueCategoriesJob"
+  queue: default

--- a/db/migrate/20190129131835_add_revenue_category_wid_to_frameworks.rb
+++ b/db/migrate/20190129131835_add_revenue_category_wid_to_frameworks.rb
@@ -1,0 +1,5 @@
+class AddRevenueCategoryWidToFrameworks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :frameworks, :revenue_category_wid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_21_092757) do
+ActiveRecord::Schema.define(version: 2019_01_29_131835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 2019_01_21_092757) do
     t.string "name"
     t.string "short_name", null: false
     t.integer "coda_reference"
+    t.string "revenue_category_wid"
     t.index ["short_name"], name: "index_frameworks_on_short_name", unique: true
   end
 

--- a/spec/factories/framework.rb
+++ b/spec/factories/framework.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :framework do
     sequence(:short_name) { |n| "FM#{n + 1000}" }
     sequence(:name) { |n| "G Cloud #{n}" }
+    revenue_category_wid 'd19d3c5849dc01117ee5b3b96d141f5f'
 
     transient do
       lot_count 0

--- a/spec/fixtures/revenue_categories.xml
+++ b/spec/fixtures/revenue_categories.xml
@@ -1,0 +1,29 @@
+<wd:Report_Data xmlns:wd="urn:com.workday.report/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category">
+  <wd:Report_Entry>
+    <wd:Framework_Number>A206100</wd:Framework_Number>
+    <wd:Commercial_Agreement wd:Descriptor="A206100 Property & Facilities Management Services (inactive)">
+      <wd:ID wd:type="WID">d19d3c5849dc01429e67efc2fc14b6a9</wd:ID>
+      <wd:ID wd:type="Organization_Reference_ID">A206100</wd:ID>
+      <wd:ID wd:type="Custom_Organization_Reference_ID">A206100</wd:ID>
+    </wd:Commercial_Agreement>
+    <wd:Revenue_Category_Level wd:Descriptor="Workplace">
+      <wd:ID wd:type="WID">d19d3c5849dc016765bbae8dfc141ba8</wd:ID>
+      <wd:ID wd:type="Organization_Reference_ID">CAH_Workplace</wd:ID>
+      <wd:ID wd:type="Custom_Organization_Reference_ID">CAH_Workplace</wd:ID>
+    </wd:Revenue_Category_Level>
+    <wd:Revenue_Category_ID>CAH_Workplace</wd:Revenue_Category_ID>
+    <wd:Cost_Center wd:Descriptor="CC1042 Workplace">
+      <wd:ID wd:type="WID">d19d3c5849dc01117ee5b3b96d141f5f</wd:ID>
+      <wd:ID wd:type="Organization_Reference_ID">CC1042</wd:ID>
+      <wd:ID wd:type="Cost_Center_Reference_ID">CC1042</wd:ID>
+    </wd:Cost_Center>
+  </wd:Report_Entry>
+  <wd:Report_Entry>
+    <wd:Framework_Number>ZDNU WSDS</wd:Framework_Number>
+    <wd:Commercial_Agreement wd:Descriptor="ZDNU Whitehall Standby Distribution System (inactive)">
+      <wd:ID wd:type="WID">cab066ff165e017385343ed74a12b911</wd:ID>
+      <wd:ID wd:type="Organization_Reference_ID">ZDNU WSDS</wd:ID>
+      <wd:ID wd:type="Custom_Organization_Reference_ID">ZDNU WSDS</wd:ID>
+    </wd:Commercial_Agreement>
+  </wd:Report_Entry>
+</wd:Report_Data>

--- a/spec/jobs/update_framework_revenue_categories_job_spec.rb
+++ b/spec/jobs/update_framework_revenue_categories_job_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe UpdateFrameworkRevenueCategoriesJob do
+  describe '#perform' do
+    let!(:framework) { FactoryBot.create(:framework, short_name: 'A206100') }
+
+    before do
+      allow(Workday).to receive(:tenant).and_return('tenant')
+      stub_request(:get, 'https://wd3-impl-services1.workday.com/ccx/service/customreport2/tenant/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category')
+        .to_return(status: 200, body: File.read(Rails.root.join('spec', 'fixtures', 'revenue_categories.xml')))
+    end
+
+    it 'should update the revenue category level WID' do
+      UpdateFrameworkRevenueCategoriesJob.perform_now
+      framework.reload
+      expect(framework.revenue_category_wid).to eq('d19d3c5849dc016765bbae8dfc141ba8')
+    end
+  end
+end

--- a/spec/models/workday/submit_customer_invoice_adjustment_request_spec.rb
+++ b/spec/models/workday/submit_customer_invoice_adjustment_request_spec.rb
@@ -57,16 +57,10 @@ RSpec.describe Workday::SubmitCustomerInvoiceAdjustmentRequest do
         ).to eq framework.short_name
       end
 
-      pending 'sets Revenue_Category_Reference//ID as the revenue category Worday ID for the Framework' do
+      it 'sets Revenue_Category_Reference//ID as the revenue category Worday ID for the Framework' do
         expect(
           text_at_xpath("//ns0:Revenue_Category_Reference//ns0:ID[@ns0:type='WID']")
-        ).to eq 'A revenue category ID from workday'
-      end
-
-      pending 'sets a Worktags_Reference//ID with the cost center Workday ID for the Framework' do
-        expect(
-          text_at_xpath("//ns0:Worktags_Reference//ns0:ID[@ns0:type='WID']")
-        ).to eq 'A cost center ID from Workday'
+        ).to eq 'd19d3c5849dc01117ee5b3b96d141f5f'
       end
     end
 

--- a/spec/models/workday/submit_customer_invoice_request_spec.rb
+++ b/spec/models/workday/submit_customer_invoice_request_spec.rb
@@ -57,16 +57,10 @@ RSpec.describe Workday::SubmitCustomerInvoiceRequest do
         ).to eq framework.short_name
       end
 
-      pending 'sets Revenue_Category_Reference//ID as the revenue category Worday ID for the Framework' do
+      it 'sets Revenue_Category_Reference//ID as the revenue category Worday ID for the Framework' do
         expect(
           text_at_xpath("//ns0:Revenue_Category_Reference//ns0:ID[@ns0:type='WID']")
-        ).to eq 'A revenue category ID from workday'
-      end
-
-      pending 'sets a Worktags_Reference//ID with the cost center Workday ID for the Framework' do
-        expect(
-          text_at_xpath("//ns0:Worktags_Reference//ns0:ID[@ns0:type='WID']")
-        ).to eq 'A cost center ID from Workday'
+        ).to eq 'd19d3c5849dc01117ee5b3b96d141f5f'
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/IZE9YDyv/714-send-the-appropriate-cost-center-and-revenue-category-for-the-framework-when-generating-an-invoice

To submit invoices to Workday, we need a Framework's `revenue_category_wid`, which we need to get from Workday.

- Adds that field to frameworks
- Creates a scheduled (midday every weekday) sidekiq job to update all Frameworks with this ID
- Submit this ID when creating Invoices and InvoiceAdjustments in Workday