### PR TITLE
Add rake db:restore/reset_to_production rake tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore database backups
+/backups
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/docs/get-prod-db-backup.md
+++ b/docs/get-prod-db-backup.md
@@ -1,0 +1,54 @@
+# Getting a local copy of the prod DB
+
+This is a fairly manual process with a tiny bit of rake help at the end. 
+Hopefully we'll automate daily backups. In the meantime, there's this. 
+
+## Create a backup (currently manual)
+
+SSH into bastion with 
+
+`ssh ccs.production`
+
+SSH into dss-infrastructure-production with something like
+
+`ssh ec2-user@<PublicDNS>`
+e.g.
+`ssh ec2-user@ec2-3-8-197-87.eu-west-2.compute.amazonaws.com`
+
+The Public DNS of the container instance can be found in
+```
+  Clusters >  dss-infrastructure-production > choose container (dss-infrastructure-production) >
+      ECS instances tab > lists 2 identical containers (pick either) > copy <Public DNS>
+```       
+
+We now need 2 things:
+- RDS ENDPOINT: Find by going to RDS > Databases > dssinfrastructureproductionapi > Endpoint. 
+  Looks something like dssinfrastructureproductionapi.cwixmd5p744n.eu-west-2.rds.amazonaws.com
+- The postgres password, which we get from `echo $DATABASE_URL` on one of the docker instances
+  - `docker exec -it <container ID, e.g. 06f047454282 from docker ps, pick API production> /bin/bash`
+  - `echo $DATABASE_URL`
+  - Copy the password from the URL
+  - `exit` the docker container
+
+Then:
+  - Choose a name for the backup that corresponds to the naming convention in the `rake db:restore` task,
+    e.g. `production-backup-20190130.tar`
+  - `docker run -i postgres /usr/bin/pg_dump -F tar -h <RDS ENDPOINT> -U root dss_api > production-backup-20190130.tar`
+  - paste the password
+  - gzip the tar file `gzip production-backup-20190130.tar`
+  - Copy the `.gz` file to bastion:
+    - `exit` from AWS
+    - `scp ec2-user@<PUBLIC_DNS_NAME>:production-backup-20190130.tar.gz .`
+    - `exit` from Bastion to your local machine
+    - assuming you're in your local API working dir, `mkdir backups`
+    - `scp ccs.production:production-backup-20190130.tar.gz backups`
+    - Don't forget to remove the backup from Bastion when you are done with it
+  
+## Restore the backup
+
+- Since AWS has a `root` Postgres role, you'll need to create one locally.
+  The first time you do this, create one with 
+  `bash# psql postgres -c "CREATE ROLE root WITH SUPERUSER LOGIN;"`
+- `DISABLE_DATABASE_ENVIRONMENT_CHECK=1 be rake db:reset_to_production` will drop your db, 
+  create a new one and restore from the gzipped backup
+- To restore from a specific backup, use `rake db:restore[path_to_gzipped_backup]`

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,24 @@
+namespace :db do
+  PRODUCTION_BACKUP_TAR_GZS = 'backups/production-backup-*.tar.gz'.freeze
+
+  def find_latest_backup
+    Dir[PRODUCTION_BACKUP_TAR_GZS].sort.reverse.first
+  end
+
+  desc 'Restore from a gzipped backup'
+  task :restore, %i[filename user] => :environment do |_task, args|
+    filename = args[:filename] || find_latest_backup or
+      raise ArgumentError, "[filename] required when no #{PRODUCTION_BACKUP_TAR_GZS} found"
+
+    user = args[:user] || 'postgres'
+
+    STDERR.puts("Unzipping / restoring from #{filename}")
+    system(
+      "gunzip -c #{filename} | pg_restore -h localhost -U #{user} " \
+      '-d DataSubmissionServiceApi_development'
+    )
+  end
+
+  desc 'Wipe out your local DB and replace with latest from ./backups'
+  task reset_to_production: %i[environment db:drop db:create db:restore]
+end


### PR DESCRIPTION
This is one half of a strategy to make restoring backups a bit less of a
pain. If we take regular GZipped backups named, for example

`backups/production-backup-2019-01-23.tar.gz`

then

`DISABLE_DATABASE_ENVIRONMENT_CHECK=1 be rake db:reset_to_production`

will find the most recent backup in `backups/`, drop and recreate your DB
and restore without leaving a large unzipped backup on your SSD.

`rake db:restore[somebackup.tar.gz]` will restore a specific backup.
Note that it won't drop your DB or recreate it.

You will need a `root` user on your Postgres instance because the RDS
instances use one.  Create one with

`bash# psql postgres -c "CREATE ROLE root WITH SUPERUSER LOGIN;"`