### PR TITLE
(734) Show admin users supplier tasks and lastest submission

### DIFF
--- a/app/controllers/admin/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers_controller.rb
@@ -5,5 +5,6 @@ class Admin::SuppliersController < AdminController
 
   def show
     @supplier = Supplier.find(params[:id])
+    @tasks = @supplier.tasks.includes(:framework, :latest_submission).order(due_on: :desc)
   end
 end

--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -1,0 +1,14 @@
+%tr.govuk-table__row
+  %td.govuk-table__cell
+    = task.framework.short_name
+  %td.govuk-table__cell
+    = task.due_on.to_s(:month_year)
+  %td.govuk-table__cell
+    - if task.latest_submission
+      = task.latest_submission.created_at.to_s(:date_with_utc_time)
+  %td.govuk-table__cell
+    - if task.latest_submission
+      = task.latest_submission.aasm_state.titlecase
+    - else
+      = task.status.titlecase
+

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -5,6 +5,27 @@
 .govuk-grid-row
   .govuk-grid-column-full
     %h2.govuk-heading-m{:class => 'govuk-!-margin-top-7'}
+      Tasks
+
+    -if @tasks.present?
+      %table.govuk-table
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header Framework
+            %th.govuk-table__header Month
+            %th.govuk-table__header Submitted
+            %th.govuk-table__header Status
+        %tbody.govuk-table__body
+          = render(collection: @tasks, partial: "task")
+
+    -else
+      %p
+        No tasks for
+        = @supplier.name
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-m{:class => 'govuk-!-margin-top-7'}
       Users
 
     -if @supplier.users.present?

--- a/config/initializers/date_format.rb
+++ b/config/initializers/date_format.rb
@@ -1,0 +1,2 @@
+Date::DATE_FORMATS[:month_year] = '%B %Y'
+Time::DATE_FORMATS[:date_with_utc_time] = '%e %B %Y %H:%M %Z'


### PR DESCRIPTION
So that an admin user can support supplier users with issues
they need to see the status of the latest submission a supplier
has made.

We've added a date and a time format to display the submission
date and time and the submission month correctly.

The supplier controller and view now have a partial to render the
task and submission based on it's status.

It looks like the submission factories may not be moving submissions
to the correct status so for now we are setting the status on submission
on creation in the test.

Resolves: https://trello.com/c/WwXTdsdD