### PR TITLE
(fix) Workday test submission is associated with correct task

### DIFF
--- a/spec/models/workday/submit_customer_invoice_adjustment_request_spec.rb
+++ b/spec/models/workday/submit_customer_invoice_adjustment_request_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Workday::SubmitCustomerInvoiceAdjustmentRequest do
   let(:submission) do
     FactoryBot.create(:submission_with_validated_entries,
                       purchase_order_number: '123',
-                      submitted_by: user)
+                      submitted_by: user,
+                      task: task)
   end
   let(:framework) { submission.framework }
   let(:task) { FactoryBot.create(:task, period_month: 12, period_year: 2018) }

--- a/spec/models/workday/submit_customer_invoice_request_spec.rb
+++ b/spec/models/workday/submit_customer_invoice_request_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Workday::SubmitCustomerInvoiceRequest do
   let(:submission) do
     FactoryBot.create(:submission_with_validated_entries,
                       purchase_order_number: '123',
-                      submitted_by: user)
+                      submitted_by: user,
+                      task: task)
   end
   let(:framework) { submission.framework }
   let(:task) { FactoryBot.create(:task, period_month: 12, period_year: 2018) }


### PR DESCRIPTION
Associate submissions with the task created in the test, rather than one created automatically by FactoryBot (which uses the current date to set `period_month` and `period_year`).

On February 1st, these tests started to fail because the task under test was now in a different period to the task associated with the submission.