### PR TITLE
Submit Revenue Category and Tax Code IDs to Workday

### DIFF
--- a/app/models/workday.rb
+++ b/app/models/workday.rb
@@ -26,4 +26,12 @@ module Workday
   def self.api_password
     config[:password]
   end
+
+  def self.username
+    api_username.split('@').first if api_username.present?
+  end
+
+  def self.tenant
+    api_username.split('@').last if api_username.present?
+  end
 end

--- a/app/models/workday/commercial_agreements.rb
+++ b/app/models/workday/commercial_agreements.rb
@@ -1,0 +1,38 @@
+class Workday::CommercialAgreements
+  def revenue_category_ids
+    result = {}
+    report_entries.each do |report_entry|
+      framework_number = report_entry.at_xpath('wd:Framework_Number').text
+      revenue_category_wid_xml = report_entry.at_xpath('wd:Revenue_Category_ID')
+      result[framework_number] = revenue_category_wid_xml.text if revenue_category_wid_xml
+    end
+    result
+  end
+
+  def tax_code_ids
+    result = {}
+    report_entries.each do |report_entry|
+      framework_number = report_entry.at_xpath('wd:Framework_Number').text
+      tax_code_xml = report_entry.at_xpath('wd:Tax_Code_Reference/wd:ID[@wd:type="commercialAgreementTaxCode"]')
+      result[framework_number] = tax_code_xml.text if tax_code_xml
+    end
+    result
+  end
+
+  private
+
+  def report_entries
+    @report_entries ||= Nokogiri(commercial_agreement_xml).xpath('//wd:Report_Entry')
+  end
+
+  def commercial_agreement_xml
+    @commercial_agreement_xml ||= HTTP.basic_auth(
+      user: Workday.username,
+      pass: Workday.api_password
+    ).get(
+      'https://wd3-impl-services1.workday.com/ccx/service/customreport2/' +
+      Workday.tenant +
+      '/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category'
+    ).to_s
+  end
+end

--- a/app/models/workday/submit_customer_invoice_adjustment_request.rb
+++ b/app/models/workday/submit_customer_invoice_adjustment_request.rb
@@ -44,7 +44,8 @@ module Workday
             invoice_line.Extended_Amount            management_charge
             invoice_line.Analytical_Amount          total_spend
             invoice_line.Worktags_Reference.ID      framework.short_name, 'ns0:type': 'Custom_Organization_Reference_ID'
-            invoice_line.Revenue_Category_Reference.ID framework_revenue_category_id, 'ns0:type': 'WID'
+            invoice_line.Tax_Code_Reference.ID      tax_code_id, 'ns0:type': 'Tax_Code_ID'
+            invoice_line.Revenue_Category_Reference.ID framework_revenue_category_id, 'ns0:type': 'Revenue_Category_ID'
           end
         end
       end
@@ -55,9 +56,16 @@ module Workday
       submission.framework
     end
 
-    # NOTE: Hardcoded until we have access to the endpoint to identify this ID in Workday
+    def workday_commercial_agreements
+      Workday::CommercialAgreements.new
+    end
+
     def framework_revenue_category_id
-      'cab066ff165e0120b19039874b126b13'
+      workday_commercial_agreements.revenue_category_ids[framework.short_name]
+    end
+
+    def tax_code_id
+      workday_commercial_agreements.tax_code_ids[framework.short_name]
     end
 
     def invoice_memo

--- a/app/models/workday/submit_customer_invoice_request.rb
+++ b/app/models/workday/submit_customer_invoice_request.rb
@@ -40,7 +40,8 @@ module Workday
             invoice_line.Extended_Amount            management_charge
             invoice_line.Analytical_Amount          total_spend
             invoice_line.Worktags_Reference.ID      framework.short_name, 'ns0:type': 'Custom_Organization_Reference_ID'
-            invoice_line.Revenue_Category_Reference.ID framework_revenue_category_id, 'ns0:type': 'WID'
+            invoice_line.Tax_Code_Reference.ID      tax_code_id, 'ns0:type': 'Tax_Code_ID'
+            invoice_line.Revenue_Category_Reference.ID framework_revenue_category_id, 'ns0:type': 'Revenue_Category_ID'
           end
         end
       end
@@ -51,9 +52,16 @@ module Workday
       submission.framework
     end
 
-    # NOTE: Hardcoded until we have access to the endpoint to identify this ID in Workday
+    def workday_commercial_agreements
+      Workday::CommercialAgreements.new
+    end
+
     def framework_revenue_category_id
-      'cab066ff165e0120b19039874b126b13'
+      workday_commercial_agreements.revenue_category_ids[framework.short_name]
+    end
+
+    def tax_code_id
+      workday_commercial_agreements.tax_code_ids[framework.short_name]
     end
 
     def invoice_memo

--- a/spec/fixtures/revenue_categories.xml
+++ b/spec/fixtures/revenue_categories.xml
@@ -1,0 +1,37 @@
+<wd:Report_Data xmlns:wd="urn:com.workday.report/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category">
+  <wd:Report_Entry>
+    <wd:Framework_Number>A206100</wd:Framework_Number>
+    <wd:Commercial_Agreement wd:Descriptor="A206100 Property & Facilities Management Services (inactive)">
+      <wd:ID wd:type="WID">d19d3c5849dc01429e67efc2fc14b6a9</wd:ID>
+      <wd:ID wd:type="Organization_Reference_ID">A206100</wd:ID>
+      <wd:ID wd:type="Custom_Organization_Reference_ID">A206100</wd:ID>
+    </wd:Commercial_Agreement>
+    <wd:Revenue_Category_Level wd:Descriptor="Workplace">
+      <wd:ID wd:type="WID">d19d3c5849dc016765bbae8dfc141ba8</wd:ID>
+      <wd:ID wd:type="Organization_Reference_ID">CAH_Workplace</wd:ID>
+      <wd:ID wd:type="Custom_Organization_Reference_ID">CAH_Workplace</wd:ID>
+    </wd:Revenue_Category_Level>
+    <wd:Revenue_Category_ID>CAH_Workplace</wd:Revenue_Category_ID>
+    <wd:Cost_Center wd:Descriptor="CC1042 Workplace">
+      <wd:ID wd:type="WID">d19d3c5849dc01117ee5b3b96d141f5f</wd:ID>
+      <wd:ID wd:type="Organization_Reference_ID">CC1042</wd:ID>
+      <wd:ID wd:type="Cost_Center_Reference_ID">CC1042</wd:ID>
+    </wd:Cost_Center>
+    <wd:CO__Commercial_Agreement_Tax_Applicability wd:Descriptor="Sales">
+      <wd:ID wd:type="WID">f5aef56dd863302de6d8b8a0bf68cbcf</wd:ID>
+      <wd:ID wd:type="commercialAgreementTaxApplicability">Sales</wd:ID>
+    </wd:CO__Commercial_Agreement_Tax_Applicability>
+    <wd:Tax_Code_Reference wd:Descriptor="GBC20">
+      <wd:ID wd:type="WID">f5aef56dd863302ebbb8e1fe2fb8f07c</wd:ID>
+      <wd:ID wd:type="commercialAgreementTaxCode">GBC20</wd:ID>
+    </wd:Tax_Code_Reference>
+  </wd:Report_Entry>
+  <wd:Report_Entry>
+    <wd:Framework_Number>ZDNU WSDS</wd:Framework_Number>
+    <wd:Commercial_Agreement wd:Descriptor="ZDNU Whitehall Standby Distribution System (inactive)">
+      <wd:ID wd:type="WID">cab066ff165e017385343ed74a12b911</wd:ID>
+      <wd:ID wd:type="Organization_Reference_ID">ZDNU WSDS</wd:ID>
+      <wd:ID wd:type="Custom_Organization_Reference_ID">ZDNU WSDS</wd:ID>
+    </wd:Commercial_Agreement>
+  </wd:Report_Entry>
+</wd:Report_Data>

--- a/spec/models/workday/commercial_agreements_spec.rb
+++ b/spec/models/workday/commercial_agreements_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Workday::CommercialAgreements do
+  before do
+    allow(Workday).to receive(:tenant).and_return('tenant')
+    allow(Workday).to receive(:username).and_return('user')
+    allow(Workday).to receive(:api_password).and_return('password')
+    stub_request(:get, 'https://wd3-impl-services1.workday.com/ccx/service/customreport2/tenant/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category')
+      .with(headers: { 'Authorization' => 'Basic dXNlcjpwYXNzd29yZA==' })
+      .to_return(status: 200, body: File.read(Rails.root.join('spec', 'fixtures', 'revenue_categories.xml')))
+  end
+
+  describe '#revenue_category_ids' do
+    it 'should return Revenue Category IDs' do
+      expect(subject.revenue_category_ids).to eq(
+        'A206100' => 'CAH_Workplace'
+      )
+    end
+  end
+
+  describe '#tax_code_ids' do
+    it 'should return Tax Code IDs' do
+      expect(subject.tax_code_ids).to eq(
+        'A206100' => 'GBC20'
+      )
+    end
+  end
+end

--- a/spec/models/workday/submit_customer_invoice_adjustment_request_spec.rb
+++ b/spec/models/workday/submit_customer_invoice_adjustment_request_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Workday::SubmitCustomerInvoiceAdjustmentRequest do
   let(:supplier) { submission.supplier }
   let(:request) { Workday::SubmitCustomerInvoiceAdjustmentRequest.new(submission) }
 
+  before do
+    commercial_agreements = double(
+      revenue_category_ids: { framework.short_name => 'Revenue_Category_WID' },
+      tax_code_ids: { framework.short_name => 'GBC20' }
+    )
+    allow(Workday::CommercialAgreements).to receive(:new).and_return(commercial_agreements)
+  end
+
   it_behaves_like 'a workday request'
 
   describe '#content' do
@@ -72,16 +80,16 @@ RSpec.describe Workday::SubmitCustomerInvoiceAdjustmentRequest do
         ).to eq framework.short_name
       end
 
-      pending 'sets Revenue_Category_Reference//ID as the revenue category Worday ID for the Framework' do
+      it 'sets Revenue_Category_Reference//ID as the revenue category Workday ID for the Framework' do
         expect(
-          text_at_xpath("//ns0:Revenue_Category_Reference//ns0:ID[@ns0:type='WID']")
-        ).to eq 'A revenue category ID from workday'
+          text_at_xpath("//ns0:Revenue_Category_Reference//ns0:ID[@ns0:type='Revenue_Category_ID']")
+        ).to eq 'Revenue_Category_WID'
       end
 
-      pending 'sets a Worktags_Reference//ID with the cost center Workday ID for the Framework' do
+      it 'sets Tax_Code_Reference//ID as the tax code Workday ID for the Framework' do
         expect(
-          text_at_xpath("//ns0:Worktags_Reference//ns0:ID[@ns0:type='WID']")
-        ).to eq 'A cost center ID from Workday'
+          text_at_xpath("//ns0:Tax_Code_Reference//ns0:ID[@ns0:type='Tax_Code_ID']")
+        ).to eq 'GBC20'
       end
     end
 

--- a/spec/models/workday/submit_customer_invoice_request_spec.rb
+++ b/spec/models/workday/submit_customer_invoice_request_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Workday::SubmitCustomerInvoiceRequest do
   let(:supplier) { submission.supplier }
   let(:request) { Workday::SubmitCustomerInvoiceRequest.new(submission) }
 
+  before do
+    commercial_agreements = double(
+      revenue_category_ids: { framework.short_name => 'Revenue_Category_WID' },
+      tax_code_ids: { framework.short_name => 'GBC20' }
+    )
+    allow(Workday::CommercialAgreements).to receive(:new).and_return(commercial_agreements)
+  end
+
   it_behaves_like 'a workday request'
 
   describe '#content' do
@@ -72,16 +80,16 @@ RSpec.describe Workday::SubmitCustomerInvoiceRequest do
         ).to eq framework.short_name
       end
 
-      pending 'sets Revenue_Category_Reference//ID as the revenue category Worday ID for the Framework' do
+      it 'sets Revenue_Category_Reference//ID as the revenue category Workday ID for the Framework' do
         expect(
-          text_at_xpath("//ns0:Revenue_Category_Reference//ns0:ID[@ns0:type='WID']")
-        ).to eq 'A revenue category ID from workday'
+          text_at_xpath("//ns0:Revenue_Category_Reference//ns0:ID[@ns0:type='Revenue_Category_ID']")
+        ).to eq 'Revenue_Category_WID'
       end
 
-      pending 'sets a Worktags_Reference//ID with the cost center Workday ID for the Framework' do
+      it 'sets Tax_Code_Reference//ID as the tax code Workday ID for the Framework' do
         expect(
-          text_at_xpath("//ns0:Worktags_Reference//ns0:ID[@ns0:type='WID']")
-        ).to eq 'A cost center ID from Workday'
+          text_at_xpath("//ns0:Tax_Code_Reference//ns0:ID[@ns0:type='Tax_Code_ID']")
+        ).to eq 'GBC20'
       end
     end
 


### PR DESCRIPTION
Workday needs us to submit the correct Revenue Category and Tax Code IDs for the relevant framework. This data is retrieved from Workday.

We create a new helper class called "Workday::CommercialAgreements" to retrieve and extract those IDs from Workday, and use them to add it to the Invoice and InvoiceAdjustment XML that is submitted.