### PR TITLE
Update Xpath location to revenue category ID

### DIFF
--- a/app/models/workday/commercial_agreements.rb
+++ b/app/models/workday/commercial_agreements.rb
@@ -3,7 +3,7 @@ class Workday::CommercialAgreements
     result = {}
     report_entries.each do |report_entry|
       framework_number = report_entry.at_xpath('wd:Framework_Number').text
-      revenue_category_wid_xml = report_entry.at_xpath('wd:Revenue_Category_ID')
+      revenue_category_wid_xml = report_entry.at_xpath('wd:Revenue_Category_ID/wd:ID[@wd:type="clRevenueCategory"]')
       result[framework_number] = revenue_category_wid_xml.text if revenue_category_wid_xml
     end
     result

--- a/spec/fixtures/revenue_categories.xml
+++ b/spec/fixtures/revenue_categories.xml
@@ -1,30 +1,34 @@
 <wd:Report_Data xmlns:wd="urn:com.workday.report/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category">
   <wd:Report_Entry>
     <wd:Framework_Number>A206100</wd:Framework_Number>
-    <wd:Commercial_Agreement wd:Descriptor="A206100 Property & Facilities Management Services (inactive)">
+    <wd:Commercial_Agreement wd:Descriptor="A206100 Property & Facilities Management Services">
       <wd:ID wd:type="WID">d19d3c5849dc01429e67efc2fc14b6a9</wd:ID>
       <wd:ID wd:type="Organization_Reference_ID">A206100</wd:ID>
       <wd:ID wd:type="Custom_Organization_Reference_ID">A206100</wd:ID>
     </wd:Commercial_Agreement>
-    <wd:Revenue_Category_Level wd:Descriptor="Workplace">
-      <wd:ID wd:type="WID">d19d3c5849dc016765bbae8dfc141ba8</wd:ID>
-      <wd:ID wd:type="Organization_Reference_ID">CAH_Workplace</wd:ID>
-      <wd:ID wd:type="Custom_Organization_Reference_ID">CAH_Workplace</wd:ID>
+    <wd:Revenue_Category_Level wd:Descriptor="Buildings">
+      <wd:ID wd:type="WID">d19d3c5849dc01bae1b19a8dfc1409a8</wd:ID>
+      <wd:ID wd:type="Organization_Reference_ID">CAH_Buildings</wd:ID>
+      <wd:ID wd:type="Custom_Organization_Reference_ID">CAH_Buildings</wd:ID>
     </wd:Revenue_Category_Level>
-    <wd:Revenue_Category_ID>CAH_Workplace</wd:Revenue_Category_ID>
+    <wd:Revenue_Category_ID wd:Descriptor="CAH_Workplace">
+      <wd:ID wd:type="WID">23d0733568d730309f9484196abe0089</wd:ID>
+      <wd:ID wd:type="clRevenueCategory">CAH_Workplace</wd:ID>
+    </wd:Revenue_Category_ID>
     <wd:Cost_Center wd:Descriptor="CC1042 Workplace">
       <wd:ID wd:type="WID">d19d3c5849dc01117ee5b3b96d141f5f</wd:ID>
       <wd:ID wd:type="Organization_Reference_ID">CC1042</wd:ID>
       <wd:ID wd:type="Cost_Center_Reference_ID">CC1042</wd:ID>
     </wd:Cost_Center>
     <wd:CO__Commercial_Agreement_Tax_Applicability wd:Descriptor="Sales">
-      <wd:ID wd:type="WID">f5aef56dd863302de6d8b8a0bf68cbcf</wd:ID>
+      <wd:ID wd:type="WID">23d0733568d73030963d0f9339190007</wd:ID>
       <wd:ID wd:type="commercialAgreementTaxApplicability">Sales</wd:ID>
     </wd:CO__Commercial_Agreement_Tax_Applicability>
     <wd:Tax_Code_Reference wd:Descriptor="GBC20">
-      <wd:ID wd:type="WID">f5aef56dd863302ebbb8e1fe2fb8f07c</wd:ID>
+      <wd:ID wd:type="WID">23d0733568d73030993b75e70ad70080</wd:ID>
       <wd:ID wd:type="commercialAgreementTaxCode">GBC20</wd:ID>
     </wd:Tax_Code_Reference>
+    <wd:L2_Revenue_Category_ID>CAH_Buildings</wd:L2_Revenue_Category_ID>
   </wd:Report_Entry>
   <wd:Report_Entry>
     <wd:Framework_Number>ZDNU WSDS</wd:Framework_Number>


### PR DESCRIPTION
Workday configuration has been changed to require a different revenue category ID, which has been added to the Commerical Agreements XML endpoint.