### PR TITLE
Link to the download a submission's file if there is one

### DIFF
--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -3,12 +3,17 @@
     = task.framework.short_name
   %td.govuk-table__cell
     = task.due_on.to_s(:month_year)
-  %td.govuk-table__cell
-    - if task.latest_submission
-      = task.latest_submission.created_at.to_s(:date_with_utc_time)
-  %td.govuk-table__cell
-    - if task.latest_submission
-      = task.latest_submission.aasm_state.titlecase
-    - else
-      = task.status.titlecase
 
+  - if task.latest_submission
+    %td.govuk-table__cell
+      = task.latest_submission.created_at.to_s(:date_with_utc_time)
+    %td.govuk-table__cell
+      = task.latest_submission.aasm_state.titlecase
+    %td.govuk-table__cell
+      - if task.latest_submission.files.any? && task.latest_submission.files.first.file.attached?
+        = link_to 'Download submission file', rails_blob_url(task.latest_submission.files.first.file)
+  - else
+    %td.govuk-table__cell
+    %td.govuk-table__cell
+      = task.status.titlecase
+    %td.govuk-table__cell

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -15,6 +15,7 @@
             %th.govuk-table__header Month
             %th.govuk-table__header Submitted
             %th.govuk-table__header Status
+            %th.govuk-table__header Submission file
         %tbody.govuk-table__body
           = render(collection: @tasks, partial: "task")
 

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
         create_list(:invoice_entry, 2, :valid, submission: submission, total_value: 10.00, management_charge: 0.1)
         create_list(:order_entry, 1, :valid, submission: submission, total_value: 3.00)
         if submission.files.empty?
-          create_list(:submission_file, 1, submission: submission, rows: submission.entries.count)
+          create_list(:submission_file, 1, :with_attachment, submission: submission, rows: submission.entries.count)
         end
       end
     end
@@ -41,7 +41,7 @@ FactoryBot.define do
         create_list(:invoice_entry, 2, :valid, submission: submission)
         create_list(:invoice_entry, 1, :errored, submission: submission)
         if submission.files.empty?
-          create_list(:submission_file, 1, submission: submission, rows: submission.entries.count)
+          create_list(:submission_file, 1, :with_attachment, submission: submission, rows: submission.entries.count)
         end
       end
     end
@@ -53,7 +53,7 @@ FactoryBot.define do
         create_list(:invoice_entry, 2, :valid, submission: submission)
         create_list(:invoice_entry, 1, submission: submission)
         if submission.files.empty?
-          create_list(:submission_file, 1, submission: submission, rows: submission.entries.count)
+          create_list(:submission_file, 1, :with_attachment, submission: submission, rows: submission.entries.count)
         end
       end
     end

--- a/spec/features/view_supplier_details_spec.rb
+++ b/spec/features/view_supplier_details_spec.rb
@@ -59,10 +59,9 @@ RSpec.feature 'Viewing a supplier' do
           task: task,
           aasm_state: 'in_review'
         )
-
         visit admin_supplier_path(supplier)
-
         expect(page).to have_content 'In Review'
+        expect(page).to have_content 'Download submission file'
       end
     end
 
@@ -78,13 +77,14 @@ RSpec.feature 'Viewing a supplier' do
         visit admin_supplier_path(supplier)
 
         expect(page).to have_content 'Validation Failed'
+        expect(page).to have_content 'Download submission file'
       end
     end
 
     context 'that is completed' do
       scenario 'shows the status completed' do
         FactoryBot.create(
-          :submission_with_positive_management_charge,
+          :submission_with_validated_entries,
           supplier: supplier,
           framework: framework,
           task: task,
@@ -94,6 +94,7 @@ RSpec.feature 'Viewing a supplier' do
         visit admin_supplier_path(supplier)
 
         expect(page).to have_content 'Completed'
+        expect(page).to have_content 'Download submission file'
       end
     end
   end


### PR DESCRIPTION
Admin users see a least of tasks and submissions on the supplier view.
This commit adds a link the the submission file, when there is one,
so that an admin user can download the file and troubleshoot any
supplier issues.

Updated the submission factory to include the attached file trait to
test against.

Used rails_blob_url which gets the appropriate file url for the
environment (S3 for dev and local for testing).

Shows the link on the task list on the supplier page.

Trello card:
https://trello.com/c/RcM02BJB