### PR TITLE
Make Analytical amounts negative again

### DIFF
--- a/app/models/workday/submit_customer_invoice_adjustment_request.rb
+++ b/app/models/workday/submit_customer_invoice_adjustment_request.rb
@@ -85,7 +85,7 @@ module Workday
     end
 
     def total_spend
-      format '%.2f', -submission.total_spend.truncate(2)
+      format '%.2f', submission.total_spend.truncate(2)
     end
 
     def supplier_salesforce_id

--- a/spec/models/workday/submit_customer_invoice_adjustment_request_spec.rb
+++ b/spec/models/workday/submit_customer_invoice_adjustment_request_spec.rb
@@ -63,11 +63,11 @@ RSpec.describe Workday::SubmitCustomerInvoiceAdjustmentRequest do
       it 'sets Line_Item_Description with a description of the charge' do
         expect(
           text_at_xpath('//ns0:Customer_Invoice_Line_Replacement_Data//ns0:Line_Item_Description')
-        ).to eq 'Management charge for December 2018 based on £20.00 spend'
+        ).to eq 'Management charge for December 2018 based on £-20.00 spend'
       end
 
       it 'sets Analytical_Amount as the total spend for the submission' do
-        expect(text_at_xpath('//ns0:Customer_Invoice_Line_Replacement_Data//ns0:Analytical_Amount')).to eq '20.00'
+        expect(text_at_xpath('//ns0:Customer_Invoice_Line_Replacement_Data//ns0:Analytical_Amount')).to eq '-20.00'
       end
 
       it 'sets Extended_Amount as the management charge for the submission' do


### PR DESCRIPTION
Submissions with negative management charge are submitted to Workday as InvoiceAdjustments. In a previous commit, we made a change that InvoiceAdjustments should be set to "Credit: true" and the negative amounts made positive.

It has been requested that while management charges (Extended Amount in Workday) remain positive, total spend (Analytical amount in Workday) is reverted back to negative. This also updates the Line Item Description as desired.