### PR TITLE
Suppress bootsnap require when a debugger is used

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,8 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+# Speed up boot time by caching expensive operations,
+# but allow disabling for debuggers like RubyMine 2018.1
+# that won't hit breakpoints when bootsnap is used.
+# This +unless+ can be removed from 2019.1 onwards.
+require 'bootsnap/setup' unless /ruby-debug-ide/.match?(ENV['RUBYLIB'])


### PR DESCRIPTION
Bootsnap interferes with debuggers to the extent that breakpoints can't
be hit, so optionally, don't set up bootsnap when a debugger using
`ruby-debug-ide` is detected.

This mirrors the [PR](https://github.com/dxw/DataSubmissionService/pull/165) merged into the front end.