### PR TITLE
Support/776 RM858 and RM3710 changes to dw export

### DIFF
--- a/app/models/export/contracts.rb
+++ b/app/models/export/contracts.rb
@@ -23,14 +23,6 @@ module Export
       ContractEndDate
       ContractValue
       ContractAwardChannel
-      Additional1
-      Additional2
-      Additional3
-      Additional4
-      Additional5
-      Additional6
-      Additional7
-      Additional8
-    ].freeze
+    ].concat(SubmissionEntryRow.additional_field_names).freeze
   end
 end

--- a/app/models/export/csv_row.rb
+++ b/app/models/export/csv_row.rb
@@ -1,8 +1,6 @@
 module Export
   class CsvRow
-    MISSING = '#MISSING'.freeze       # fields that are needed for MVP that we don't have yet
     NOT_IN_DATA = '#NOTINDATA'.freeze # fields that we looked for in the JSONB data and could not find
-    BLANK_FOR_NOW = nil               # things that can be blank for MVP
 
     attr_reader :model
 

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -25,14 +25,6 @@ module Export
       VATCharged
       PromotionCode
       ManagementChargeValue
-      Additional1
-      Additional2
-      Additional3
-      Additional4
-      Additional5
-      Additional6
-      Additional7
-      Additional8
-    ].freeze
+    ].concat(SubmissionEntryRow.additional_field_names).freeze
   end
 end

--- a/app/models/export/submission_entry_row.rb
+++ b/app/models/export/submission_entry_row.rb
@@ -8,6 +8,8 @@ module Export
   #
   # These rows also define 8 additional ++AdditionalN++ fields.
   class SubmissionEntryRow < CsvRow
+    NUMBER_OF_ADDITIONAL_FIELDS = 8
+
     include StringUtils
 
     def value_for(destination_field, default: NOT_IN_DATA)
@@ -16,7 +18,7 @@ module Export
     end
 
     def values_for_additional
-      (1..8).map do |n|
+      (1..NUMBER_OF_ADDITIONAL_FIELDS).map do |n|
         value_for("Additional#{n}", default: nil)
       end
     end
@@ -30,6 +32,10 @@ module Export
 
       value = value.gsub(/([^0-9.\-]+)/, '').to_f if value.is_a?(String)
       value
+    end
+
+    def self.additional_field_names
+      (1..NUMBER_OF_ADDITIONAL_FIELDS).map { |n| "Additional#{n}" }
     end
 
     private

--- a/app/models/export/submission_entry_row.rb
+++ b/app/models/export/submission_entry_row.rb
@@ -8,7 +8,7 @@ module Export
   #
   # These rows also define 8 additional ++AdditionalN++ fields.
   class SubmissionEntryRow < CsvRow
-    NUMBER_OF_ADDITIONAL_FIELDS = 8
+    NUMBER_OF_ADDITIONAL_FIELDS = 24
 
     include StringUtils
 

--- a/app/models/framework/definition/RM3710.rb
+++ b/app/models/framework/definition/RM3710.rb
@@ -35,15 +35,15 @@ class Framework
         field 'Vehicle Conversion Type', :string, exports_to: 'Additional6'
         field 'Vehicle Type', :string, exports_to: 'Additional7'
         field 'Lease Start Date', :string, exports_to: 'Additional8', ingested_date: true, allow_nil: true
-        field 'Lease End Date', :string, ingested_date: true, allow_nil: true
-        field 'Lease Period (Months)', :string, ingested_numericality: { only_integer: true }, allow_nil: true
-        field 'Payment Profile', :string
-        field 'Annual Lease Mileage', :string, ingested_numericality: true, allow_nil: true
-        field 'Base Vehicle Price ex VAT', :string, ingested_numericality: true, allow_nil: true
-        field 'Lease Finance Charge ex VAT', :string, ingested_numericality: true, allow_nil: true
-        field 'Annual Service Maintenance & Repair Costs ex VAT', :string, ingested_numericality: true, allow_nil: true
-        field 'Residual Value', :string, ingested_numericality: true, allow_nil: true
-        field 'Total Manufacturer Discount (%)', :string, ingested_numericality: true, allow_nil: true
+        field 'Lease End Date', :string, exports_to: 'Additional9', ingested_date: true, allow_nil: true
+        field 'Lease Period (Months)', :string, exports_to: 'Additional10', ingested_numericality: { only_integer: true }, allow_nil: true
+        field 'Payment Profile', :string, exports_to: 'Additional11'
+        field 'Annual Lease Mileage', :string, exports_to: 'Additional12', ingested_numericality: true, allow_nil: true
+        field 'Base Vehicle Price ex VAT', :string, exports_to: 'Additional13', ingested_numericality: true, allow_nil: true
+        field 'Lease Finance Charge ex VAT', :string, exports_to: 'Additional14', ingested_numericality: true, allow_nil: true
+        field 'Annual Service Maintenance & Repair Costs ex VAT', :string, exports_to: 'Additional15', ingested_numericality: true, allow_nil: true
+        field 'Residual Value', :string, exports_to: 'Additional16', ingested_numericality: true, allow_nil: true
+        field 'Total Manufacturer Discount (%)', :string, exports_to: 'Additional17', ingested_numericality: true, allow_nil: true
         field 'Cost Centre', :string
         field 'Contract Number', :string
         field 'Spend Code', :string, exports_to: 'PromotionCode', inclusion: { in: ['Lease Rental', 'Fleet Management Fee', 'Damage', 'Other Re-charges'] }

--- a/app/models/framework/definition/RM858.rb
+++ b/app/models/framework/definition/RM858.rb
@@ -36,21 +36,21 @@ class Framework
         field 'Vehicle Type', :string, exports_to: 'Additional6'
         field 'Fuel Type', :string, exports_to: 'Additional7'
         field 'CO2 Emission Levels', :string, exports_to: 'Additional8'
-        field 'Lease Period', :string
-        field 'Lease Start Date', :string, ingested_date: true
-        field 'Lease End Date', :string, ingested_date: true
-        field 'Payment Profile', :string
-        field 'Annual Lease Mileage', :string, allow_nil: true, ingested_numericality: true
-        field 'Base Vehicle Price ex VAT', :string, allow_nil: true, ingested_numericality: true
-        field 'Lease Cost excluding Optional Extras and Conversion ex VAT', :string, allow_nil: true, ingested_numericality: true
-        field 'Lease Finance Charge ex VAT', :string, allow_nil: true, ingested_numericality: true
-        field 'Lease Finance Margin ex VAT', :string, allow_nil: true, ingested_numericality: true
-        field 'Vehicle Purchase Terms', :string
-        field 'Standard Vehicle Discount (%)', :string, allow_nil: true, ingested_numericality: true
-        field 'Enhanced Vehicle Discount (%)', :string, allow_nil: true, ingested_numericality: true
-        field 'Annual Service Maintenance & Repair Costs ex VAT', :string, allow_nil: true, ingested_numericality: true
-        field 'Annual Breakdown & Recovery Costs ex VAT', :string, allow_nil: true, ingested_numericality: true
-        field 'Residual Value', :string, allow_nil: true, ingested_numericality: true
+        field 'Lease Period', :string, exports_to: 'Additional9'
+        field 'Lease Start Date', :string, exports_to: 'Additional10', ingested_date: true
+        field 'Lease End Date', :string, exports_to: 'Additional11', ingested_date: true
+        field 'Payment Profile', :string, exports_to: 'Additional12'
+        field 'Annual Lease Mileage', :string, exports_to: 'Additional13', allow_nil: true, ingested_numericality: true
+        field 'Base Vehicle Price ex VAT', :string, exports_to: 'Additional14', allow_nil: true, ingested_numericality: true
+        field 'Lease Cost excluding Optional Extras and Conversion ex VAT', :string, exports_to: 'Additional15', allow_nil: true, ingested_numericality: true
+        field 'Lease Finance Charge ex VAT', :string, exports_to: 'Additional16', allow_nil: true, ingested_numericality: true
+        field 'Lease Finance Margin ex VAT', :string, exports_to: 'Additional17', allow_nil: true, ingested_numericality: true
+        field 'Vehicle Purchase Terms', :string, exports_to: 'Additional18'
+        field 'Standard Vehicle Discount (%)', :string, exports_to: 'Additional19', allow_nil: true, ingested_numericality: true
+        field 'Enhanced Vehicle Discount (%)', :string, exports_to: 'Additional20', allow_nil: true, ingested_numericality: true
+        field 'Annual Service Maintenance & Repair Costs ex VAT', :string, exports_to: 'Additional21', allow_nil: true, ingested_numericality: true
+        field 'Annual Breakdown & Recovery Costs ex VAT', :string, exports_to: 'Additional22', allow_nil: true, ingested_numericality: true
+        field 'Residual Value', :string, exports_to: 'Additional23', allow_nil: true, ingested_numericality: true
         field 'Cost Centre', :string
         field 'Contract Number', :string
       end

--- a/spec/lib/tasks/export/contracts_spec.rb
+++ b/spec/lib/tasks/export/contracts_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe 'rake export:contracts', type: :task do
         'CustomerReferenceNumber,LotNumber,ProductDescription,ProductGroup,ProductClass,ProductSubClass,ProductCode,'\
         'ProductLevel6,CustomerContactName,CustomerContactNumber,CustomerContactEmail,'\
         'ContractStartDate,ContractEndDate,ContractValue,ContractAwardChannel,'\
-        'Additional1,Additional2,Additional3,Additional4,Additional5,Additional6,Additional7,Additional8'
+        'Additional1,Additional2,Additional3,Additional4,Additional5,Additional6,Additional7,Additional8,'\
+        'Additional9,Additional10,Additional11,Additional12,Additional13,Additional14,Additional15,Additional16,'\
+        'Additional17,Additional18,Additional19,Additional20,Additional21,Additional22,Additional23,Additional24'
       )
     end
 
@@ -52,7 +54,8 @@ RSpec.describe 'rake export:contracts', type: :task do
       expect(output_lines[1]).to eql(
         "#{contract.submission_id},10010915,Government Legal Department,WC1B 4ZZ,471600.00001,"\
         'DWP - Claim by Mr I Dontexist,1,Contentious Employment,,,,,,,,,'\
-        '2018-06-27,2020-06-27,5000.00,Further Competition,N/A,N,Central Government Department,N,0.00,15,,'
+        '2018-06-27,2020-06-27,5000.00,Further Competition,N/A,N,Central Government Department,'\
+        'N,0.00,15,,,,,,,,,,,,,,,,,,'
       )
     end
 
@@ -60,7 +63,7 @@ RSpec.describe 'rake export:contracts', type: :task do
       expect(output_lines[2]).to eql(
         "#{contract2.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA," \
         ',,,,,,,,,,,' \
-        '#NOTINDATA,#NOTINDATA,,,,,,,,'
+        '#NOTINDATA,#NOTINDATA,,,,,,,,,,,,,,,,,,,,,,,,'
       )
     end
 

--- a/spec/lib/tasks/export/invoices_spec.rb
+++ b/spec/lib/tasks/export/invoices_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe 'rake export:invoices', type: :task do
         'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber,ProductDescription,'\
         'ProductGroup,ProductClass,ProductSubClass,ProductCode,UnitType,UnitPrice,UnitQuantity,'\
         'InvoiceValue,Expenses,VATCharged,PromotionCode,ManagementChargeValue,'\
-        'Additional1,Additional2,Additional3,Additional4,Additional5,Additional6,Additional7,Additional8'
+        'Additional1,Additional2,Additional3,Additional4,Additional5,Additional6,Additional7,Additional8,'\
+        'Additional9,Additional10,Additional11,Additional12,Additional13,Additional14,Additional15,Additional16,'\
+        'Additional17,Additional18,Additional19,Additional20,Additional21,Additional22,Additional23,Additional24'
       )
     end
 
@@ -53,7 +55,7 @@ RSpec.describe 'rake export:invoices', type: :task do
       expect(output_lines[1]).to eql(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,2018-05-31,3307957,DEP/0008.00032,"\
         'GITIS Terms and Conditions,1,Contracts,Core,,Legal Director/Senior Solicitor,,Hourly,151.09,-0.9,-135.98,,'\
-        '-27.2,,142.99,0.00,0.00,0.00,N/A,Time and Material,,,'
+        '-27.2,,142.99,0.00,0.00,0.00,N/A,Time and Material,,,,,,,,,,,,,,,,,,,'
       )
     end
 
@@ -61,7 +63,7 @@ RSpec.describe 'rake export:invoices', type: :task do
       expect(output_lines[2]).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,,,"\
         ',,,,,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,,'\
-        ',,,,,,,,'
+        ',,,,,,,,,,,,,,,,,,,,,,,,'
       )
     end
 


### PR DESCRIPTION
# [RM858 and RM3710 changes to DW export](https://trello.com/c/jziu1FNq/776-rm858-and-rm3710-changes-to-dw-export)

Expand the `AdditionalN` fields from 1-8 to 1-24.

Add 15 and 9 new framework-specific mappings to RM858 and RM3710 respectively with the space that this creates.

Also (first two commits), take the opportunity to delete unused constants and an empty `sheet_mappings.rb` file.