### PR TITLE
(fix) Show the correct value for the month column

### DIFF
--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -2,8 +2,7 @@
   %td.govuk-table__cell
     = task.framework.short_name
   %td.govuk-table__cell
-    = task.due_on.to_s(:month_year)
-
+    = task.period_date.to_s(:month_year)
   - if task.latest_submission
     %td.govuk-table__cell
       = task.latest_submission.created_at.to_s(:date_with_utc_time)


### PR DESCRIPTION
On the supplier task list we are showing the incorrect value for month,
it should be the period_date value and not the due_on value.

Trello Card:

https://trello.com/c/cMmn5TpU