### PR TITLE
Allow free login as admin in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,18 @@ To run the full test suite - Rubocop, Brakeman and Rspec - before pushing to Git
 
 `$ bundle exec rails s`
 
-The application will run on port 3000 by default
+The application will run on port 3000 by default.
+
+### The admin interface
+
+The admin interface is available at `/admin`. In production its use requires
+OAuth authentication via a Google provider, but there is a `DeveloperAdmin` provider
+which will let you log in locally to develop admin functions without credentials. You
+should not need to do anything to set this up; it will apply by default if either of
+`GOOGLE_CLIENT_ID` or `GOOGLE_CLIENT_SECRET` are missing from your development environment. 
+
+It will use the email address from `.env.development / ADMIN_EMAILS` by default with a 
+default user full name, either of which can be changed at login if you wish.
 
 ## API Endpoints
 

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,6 +1,10 @@
 class Admin::SessionsController < AdminController
   skip_before_action :ensure_user_signed_in
 
+  # Used with OmniAuth::Strategies::DeveloperAdmin as the dev-facing
+  # form it creates doesn't know (and doesn't need to in dev) about our CSRF token
+  skip_before_action :verify_authenticity_token, only: :create if OmniAuth::Strategies::DeveloperAdmin.applies?
+
   def new; end
 
   def create

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,6 @@
+module SessionsHelper
+  def auth_provider_path
+    strategy = OmniAuth::Strategies::DeveloperAdmin.applies? ? 'developer_admin' : 'google_oauth2'
+    "/auth/#{strategy}"
+  end
+end

--- a/app/views/admin/sessions/new.html.haml
+++ b/app/views/admin/sessions/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = link_to 'Start now', '/auth/google_oauth2', class: 'govuk-button govuk-button--start', id: 'start-now'
+    = link_to 'Start now', auth_provider_path, class: 'govuk-button govuk-button--start', id: 'start-now'
     %h2.govuk-heading-m
       Before you start
     %p

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,9 @@
+require 'omniauth/strategies/developer_admin'
+
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], prompt: 'consent'
+  if OmniAuth::Strategies::DeveloperAdmin.applies?
+    provider :developer_admin
+  else
+    provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], prompt: 'consent'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,4 +72,6 @@ Rails.application.routes.draw do
   end
 
   get '/auth/:provider/callback', to: 'admin/sessions#create'
+  # The "POST" version of the callback is required for OmniAuth::Strategies::DeveloperAdmin
+  post '/auth/:provider/callback', to: 'admin/sessions#create' if OmniAuth::Strategies::DeveloperAdmin.applies?
 end

--- a/lib/omniauth/strategies/developer_admin.rb
+++ b/lib/omniauth/strategies/developer_admin.rb
@@ -1,0 +1,55 @@
+module OmniAuth
+  module Strategies
+    # The DeveloperAdmin strategy is for use in development only.
+    # It allows us to load the admin interface without the need
+    # to talk to an external auth provider.
+    #
+    # You need to set ADMIN_EMAILS to a list with a single email
+    # address in it. When you go to log in it will show a form
+    # with that email address and a default developer name. You
+    # should just be able to click Sign In at that stage.
+    #
+    # It's set up from config/initializers/omniauth but also
+    # requires a POST route in config/routes.rb
+    #
+    #   use OmniAuth::Builder do
+    #     provider :developer_admin
+    #   end
+    class DeveloperAdmin
+      include OmniAuth::Strategy
+
+      DEFAULT_EMAIL = 'delia.veloper@dxw.com'.freeze
+
+      option :name, 'developer_admin'
+      option :email, ENV['ADMIN_EMAILS'] || DEFAULT_EMAIL
+      option :users_name, 'Delia Veloper'
+
+      uid { 'email' }
+
+      def request_phase
+        form = OmniAuth::Form.new(
+          title: 'Default developer admin credentials', url: callback_path
+        )
+        form.html "\n<input type='text' id='email' name='email' value='#{options[:email]}'/>"
+        form.html "\n<input type='text' id='name' name='name' value='#{options[:users_name]}'/>"
+        form.button 'Sign In'
+        form.to_response
+      end
+
+      info do
+        {
+          name: request.params['name'],
+          email: request.params['email']
+        }
+      end
+
+      ##
+      # This strategy only applies when the Google credentials are missing
+      # and we're in development
+      def self.applies?
+        Rails.env.development? &&
+          (ENV['GOOGLE_CLIENT_ID'].blank? || ENV['GOOGLE_CLIENT_SECRET'].blank?)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## [Add developer strategy to API/omniauth so that development doesn't require Google auth setup per-developer](https://trello.com/c/hIlL37AS/790-add-developer-strategy-to-api-omniauth-so-that-development-doesnt-require-google-auth-setup-per-developer)

To avoid devs needing to set up their own Google credentials, create
a custom OmniAuth DeveloperAdmin strategy. This takes a single email
address, usually set up in .env.development, for example
`ADMIN_EMAILS=my.email@example.com`. When it `applies?`, which is to
say in development and when either `GOOGLE_CLIENT_*` value is missing,
it requires:

- setup from config/initializers/omniauth.rb
- an extra POST route
- a link to the proper strategy on the sign-in button
- skipping CSRF protection for `admin/sessions#create`