### PR TITLE
(732) Column-based variable management charge

### DIFF
--- a/app/jobs/submission_management_charge_calculation_job.rb
+++ b/app/jobs/submission_management_charge_calculation_job.rb
@@ -7,7 +7,7 @@ class SubmissionManagementChargeCalculationJob < ApplicationJob
     framework_definition = submission.framework.definition
 
     submission.entries.invoices.find_each do |entry|
-      entry.update! management_charge: framework_definition.management_charge(entry.total_value)
+      entry.update! management_charge: framework_definition.calculate_management_charge(entry)
     end
 
     submission.ready_for_review!

--- a/app/models/export/coda_finance_report/row.rb
+++ b/app/models/export/coda_finance_report/row.rb
@@ -66,7 +66,7 @@ module Export
       end
 
       def commission_percent
-        percentage_as_decimal(management_charge_rate)
+        '#REMOVED'
       end
 
       def end_user
@@ -101,10 +101,6 @@ module Export
 
       def management_charge
         submission.entries.invoices.sector(sector).sum(:management_charge)
-      end
-
-      def management_charge_rate
-        framework.management_charge_rate
       end
 
       def numeric_string_to_number(numeric_string)

--- a/app/models/export/submissions/row.rb
+++ b/app/models/export/submissions/row.rb
@@ -45,7 +45,7 @@ module Export
       end
 
       def management_charge_rate
-        (framework_definition.management_charge_rate / 100).to_s
+        '#REMOVED'
       end
 
       def created_date

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -11,8 +11,6 @@ class Framework < ApplicationRecord
     message: 'must start with “40” and have four additional numbers, for example: “401234”'
   }
 
-  delegate :management_charge_rate, to: :definition
-
   def definition
     @definition ||= Definition[short_name]
   end

--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -40,8 +40,8 @@ class Framework
           @management_charge_rate ||= charge_rate
         end
 
-        def management_charge(value)
-          (value * (management_charge_rate / 100)).truncate(4)
+        def calculate_management_charge(entry)
+          (entry.total_value * (management_charge_rate / 100)).truncate(4)
         end
 
         def for_entry_type(entry_type)

--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -38,8 +38,14 @@ class Framework
 
         ##
         # E.g. BigDecimal.new('1.5')
-        def management_charge_rate(charge_rate = nil)
-          @management_charge_rate ||= ManagementChargeCalculator::FlatRate.new(percentage: charge_rate)
+        def management_charge_rate(calculator = nil)
+          @management_charge_rate ||= begin
+                                        if calculator.is_a?(BigDecimal)
+                                          ManagementChargeCalculator::FlatRate.new(percentage: calculator)
+                                        else
+                                          calculator
+                                        end
+                                      end
         end
 
         def calculate_management_charge(entry)

--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -21,6 +21,8 @@ class Framework
     ##
     # Base class for a framework definition with metadata methods
     class Base
+      include Framework::ManagementChargeCalculator
+
       class << self
         ##
         # E.g. "Rail Legal Services"
@@ -37,11 +39,11 @@ class Framework
         ##
         # E.g. BigDecimal.new('1.5')
         def management_charge_rate(charge_rate = nil)
-          @management_charge_rate ||= charge_rate
+          @management_charge_rate ||= ManagementChargeCalculator::FlatRate.new(percentage: charge_rate)
         end
 
         def calculate_management_charge(entry)
-          (entry.total_value * (management_charge_rate / 100)).truncate(4)
+          management_charge_rate.calculate_for(entry)
         end
 
         def for_entry_type(entry_type)

--- a/app/models/framework/definition/RM3710.rb
+++ b/app/models/framework/definition/RM3710.rb
@@ -4,7 +4,15 @@ class Framework
       framework_short_name 'RM3710'
       framework_name       'Vehicle Lease and Fleet Management'
 
-      management_charge_rate BigDecimal('0.5')
+      management_charge_rate ManagementChargeCalculator::ColumnBased.new(
+        column: 'Spend Code',
+        value_to_percentage: {
+          'Lease Rental': BigDecimal('0.5'),
+          'Fleet Management Fee': BigDecimal('0.5'),
+          'Damage': 0,
+          'Other Re-charges': 0,
+        }
+      )
 
       class Invoice < EntryData
         total_value_field 'Total Charge (Ex VAT)'

--- a/app/models/framework/definition/RM858.rb
+++ b/app/models/framework/definition/RM858.rb
@@ -4,7 +4,15 @@ class Framework
       framework_short_name 'RM858'
       framework_name       'Pan Govt Vehicle Leasing & Fleet Outsource Solutio'
 
-      management_charge_rate BigDecimal('0.5')
+      management_charge_rate ManagementChargeCalculator::ColumnBased.new(
+        column: 'Spend Code',
+        value_to_percentage: {
+          'Lease Rental': BigDecimal('0.5'),
+          'Fleet Management Fee': BigDecimal('0.5'),
+          'Damage': 0,
+          'Other Re-charges': 0,
+        }
+      )
 
       class Invoice < EntryData
         total_value_field 'Invoice Line Total Value ex VAT'

--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -1,0 +1,25 @@
+class Framework
+  module ManagementChargeCalculator
+    class ColumnBased
+      attr_reader :column, :value_to_percentage
+
+      def initialize(column:, value_to_percentage:)
+        @column = column
+        @value_to_percentage = prepare_hash(value_to_percentage)
+      end
+
+      def calculate_for(entry)
+        column_value_for_entry = entry.data.dig(column).to_s
+        percentage = value_to_percentage[column_value_for_entry.downcase]
+
+        (entry.total_value * (percentage / 100)).truncate(4)
+      end
+
+      private
+
+      def prepare_hash(hash)
+        hash.map { |k, v| [k.to_s.downcase, v] }.to_h
+      end
+    end
+  end
+end

--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -12,6 +12,15 @@ class Framework
         column_value_for_entry = entry.data.dig(column).to_s
         percentage = value_to_percentage[column_value_for_entry.downcase]
 
+        if percentage.nil?
+          Rollbar.error(
+            "Got value '#{column_value_for_entry}' for '#{column}' on #{entry.framework.short_name}"\
+            "from entry #{entry.id}. Missing validation?"
+          )
+
+          return 0.0
+        end
+
         (entry.total_value * (percentage / 100)).truncate(4)
       end
 

--- a/app/models/framework/management_charge_calculator/flat_rate.rb
+++ b/app/models/framework/management_charge_calculator/flat_rate.rb
@@ -1,0 +1,15 @@
+class Framework
+  module ManagementChargeCalculator
+    class FlatRate
+      attr_reader :percentage
+
+      def initialize(percentage:)
+        @percentage = BigDecimal(percentage)
+      end
+
+      def calculate_for(entry)
+        (entry.total_value * (percentage / 100)).truncate(4)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/export/submissions_spec.rb
+++ b/spec/lib/tasks/export/submissions_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'rake export:submissions', type: :task do
       expect(output_lines.length).to eql(3)
       expect(output_lines.find { |line| line.match('PO1234') }).to eql(
         "#{submission.task.id},#{submission.id},supplier_accepted,file,xls,1,804.00,1,179.12,1.79," \
-        '0.01,2018-09-18T14:20:35Z,CrForename CrSurname,2018-09-20T10:11:12Z,SubForename SubSurname,,PO1234'
+        '#REMOVED,2018-09-18T14:20:35Z,CrForename CrSurname,2018-09-20T10:11:12Z,SubForename SubSurname,,PO1234'
       )
     end
 

--- a/spec/models/export/coda_finance_report/row_spec.rb
+++ b/spec/models/export/coda_finance_report/row_spec.rb
@@ -52,10 +52,6 @@ RSpec.describe Export::CodaFinanceReport::Row do
     expect(cg_report_row.month).to eq 'August 2018'
   end
 
-  it 'reports the management charge rate as ‘Commission %’' do
-    expect(cg_report_row.commission_percent).to eq '0.005'
-  end
-
   it 'reports the sector as ‘End User’' do
     expect(cg_report_row.end_user).to eq 'UCGV'
     expect(wps_report_row.end_user).to eq 'UWPS'

--- a/spec/models/export/coda_finance_report_spec.rb
+++ b/spec/models/export/coda_finance_report_spec.rb
@@ -52,10 +52,10 @@ RSpec.describe Export::CodaFinanceReport do
   let(:expected_csv) do
     <<~CSV
       RunID,Nominal,Customer Code,Customer Name,Contract ID,Order Number,Lot Description,Inf Sales,Commission,Commission %,End User,Submitter,Month,M_Q
-      #{submission.id},409999,C011111,Mary,RM3787,PO-123,G CLOUD,802.00,12.02,0.015,UCGV,Mary,August 2018,M
-      #{submission.id},409999,C011111,Mary,RM3787,PO-123,G CLOUD,0.00,0.00,0.015,UWPS,Mary,August 2018,M
-      #{no_business_submission.id},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,0.015,UCGV,Bob,August 2018,M
-      #{no_business_submission.id},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,0.015,UWPS,Bob,August 2018,M
+      #{submission.id},409999,C011111,Mary,RM3787,PO-123,G CLOUD,802.00,12.02,#REMOVED,UCGV,Mary,August 2018,M
+      #{submission.id},409999,C011111,Mary,RM3787,PO-123,G CLOUD,0.00,0.00,#REMOVED,UWPS,Mary,August 2018,M
+      #{no_business_submission.id},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,#REMOVED,UCGV,Bob,August 2018,M
+      #{no_business_submission.id},409999,C099999,Bob,RM3787,,G CLOUD,0.00,0.00,#REMOVED,UWPS,Bob,August 2018,M
     CSV
   end
 

--- a/spec/models/export/submissions/row_spec.rb
+++ b/spec/models/export/submissions/row_spec.rb
@@ -75,13 +75,6 @@ RSpec.describe Export::Submissions::Row do
     end
   end
 
-  describe '#management_charge_rate' do
-    let(:submission) { double 'Submission', _framework_short_name: 'RM1031' }
-    it 'returns the rate for the framework identified by _framework_short_name as a decimal' do
-      expect(row.management_charge_rate).to eql('0.005')
-    end
-  end
-
   describe '#created_date' do
     let(:submission) { double 'Submission', created_at: Time.zone.local(2018, 9, 18, 14, 20, 35) }
 

--- a/spec/models/framework/definition_spec.rb
+++ b/spec/models/framework/definition_spec.rb
@@ -56,11 +56,13 @@ RSpec.describe Framework::Definition do
     end
   end
 
-  describe 'Base.management_charge' do
+  describe 'Base.calculate_management_charge' do
     it 'returns the management charge based on the framework’s management charge rate, rounded to 4 decimal places' do
-      expect(Framework::Definition::RM3756.management_charge(BigDecimal('102123.23'))).to eq BigDecimal('1531.8484')
-      expect(Framework::Definition::RM1070.management_charge(BigDecimal('102123.23'))).to eq BigDecimal('510.6161')
-      expect(Framework::Definition::CM_OSG_05_3565.management_charge(BigDecimal('102123.23'))).to eq BigDecimal('0')
+      entry = double('entry', total_value: BigDecimal('102123.23'))
+
+      expect(Framework::Definition::RM3756.calculate_management_charge(entry)).to eq BigDecimal('1531.8484')
+      expect(Framework::Definition::RM1070.calculate_management_charge(entry)).to eq BigDecimal('510.6161')
+      expect(Framework::Definition::CM_OSG_05_3565.calculate_management_charge(entry)).to eq BigDecimal('0')
     end
   end
 

--- a/spec/models/framework/definition_spec.rb
+++ b/spec/models/framework/definition_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Framework::Definition do
         end
 
         it 'reports the management charge' do
-          expect(definition.management_charge_rate).to eq(BigDecimal('1.5'))
+          expect(definition.management_charge_rate.percentage).to eq(BigDecimal('1.5'))
         end
       end
 
@@ -23,7 +23,7 @@ RSpec.describe Framework::Definition do
         end
 
         it 'reports the management charge' do
-          expect(definition.management_charge_rate).to eq(BigDecimal('0'))
+          expect(definition.management_charge_rate.percentage).to eq(BigDecimal('0'))
         end
       end
 
@@ -35,7 +35,7 @@ RSpec.describe Framework::Definition do
         end
 
         it 'reports the management charge' do
-          expect(definition.management_charge_rate). to eq(BigDecimal('1'))
+          expect(definition.management_charge_rate.percentage).to eq(BigDecimal('1'))
         end
       end
     end

--- a/spec/models/framework/management_charge_calculator/column_based_spec.rb
+++ b/spec/models/framework/management_charge_calculator/column_based_spec.rb
@@ -40,4 +40,18 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
 
     expect(calculator.calculate_for(entry)).to eq(0.2121) # 0.5% of 123.45
   end
+
+  it 'when the lookup fails, which should have been caught by validation, assume zero rate' do
+    entry = FactoryBot.create(:submission_entry, total_value: 42.424242, data: { test_value: 'invalid' })
+
+    calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
+      column: 'test_value',
+      value_to_percentage: {
+        'test': BigDecimal('0.5')
+      }
+    )
+
+    expect(Rollbar).to receive(:error)
+    expect(calculator.calculate_for(entry)).to eq(0)
+  end
 end

--- a/spec/models/framework/management_charge_calculator/column_based_spec.rb
+++ b/spec/models/framework/management_charge_calculator/column_based_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
+  it 'calculates the management charge for an entry, based on the value of a given column' do
+    entry = FactoryBot.create(:submission_entry, total_value: 123.45, data: { test_value: 'test' })
+
+    calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
+      column: 'test_value',
+      value_to_percentage: {
+        'other': 0,
+        'test': BigDecimal('10')
+      }
+    )
+
+    expect(calculator.calculate_for(entry)).to eq(12.345) # 10% of 123.45
+  end
+
+  it 'handles column values that have a different case to the rule' do
+    entry = FactoryBot.create(:submission_entry, total_value: 123.45, data: { test_value: 'TeST' })
+
+    calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
+      column: 'test_value',
+      value_to_percentage: {
+        'Test': BigDecimal('5')
+      }
+    )
+
+    expect(calculator.calculate_for(entry)).to eq(6.1725) # 5% of 123.45
+  end
+
+  it 'rounds to four decimal places' do
+    entry = FactoryBot.create(:submission_entry, total_value: 42.424242, data: { test_value: 'test' })
+
+    calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
+      column: 'test_value',
+      value_to_percentage: {
+        'test': BigDecimal('0.5')
+      }
+    )
+
+    expect(calculator.calculate_for(entry)).to eq(0.2121) # 0.5% of 123.45
+  end
+end

--- a/spec/models/framework/management_charge_calculator/flat_rate_spec.rb
+++ b/spec/models/framework/management_charge_calculator/flat_rate_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Framework::ManagementChargeCalculator::FlatRate do
+  it 'calculates the management charge for an entry, using a flat rate' do
+    entry = FactoryBot.create(:submission_entry, total_value: 180)
+    calculator = Framework::ManagementChargeCalculator::FlatRate.new(percentage: 5)
+
+    expect(calculator.calculate_for(entry)).to eql(9) # 5% of 180 = 9
+  end
+end

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -6,14 +6,6 @@ RSpec.describe Framework do
   it { is_expected.to have_many(:suppliers).through(:agreements) }
   it { is_expected.to have_many(:submissions) }
 
-  describe '#management_charge_rate' do
-    let(:rm3756) { Framework.new(short_name: 'RM3756') }
-
-    it 'reports the rate of the framework definition' do
-      expect(rm3756.management_charge_rate).to eq BigDecimal('1.5')
-    end
-  end
-
   describe 'validations' do
     subject { Framework.create(short_name: 'test') }
     it { is_expected.to validate_presence_of(:short_name) }


### PR DESCRIPTION
Allow framework definitions to contain management charges that change depending on the value of another column in the same entry.

e.g. RM858 and RM3710 both have `Spend Code` columns, which cause the entry to not receive any management charge when the value is 'Damage' or 'Other Re-charges', but 0.5% when the value is 'Lease Rental' or 'Fleet Management Fee'.