### PR TITLE
(feature) Users should be deactivated ('soft deleted') not completely removed

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,11 +1,10 @@
 class Admin::UsersController < AdminController
-  before_action :find_user, except: %i[index create new]
-
   def index
     @users = User.search(params[:search]).page(params[:page])
   end
 
   def show
+    @user = User.find(params[:id])
     @memberships = @user.memberships.includes(:supplier)
   end
 
@@ -31,6 +30,7 @@ class Admin::UsersController < AdminController
   end
 
   def edit
+    @user = User.find(params[:id])
     @user.create_with_auth0
   rescue Auth0::Exception
     flash[:alert] = 'There was an error adding the user to Auth0. Please try again.'
@@ -38,21 +38,22 @@ class Admin::UsersController < AdminController
     redirect_to admin_user_path(@user)
   end
 
-  def confirm_delete; end
+  def confirm_delete
+    @user = User.find(params[:id])
+  end
 
-  def confirm_reactivate; end
+  def confirm_reactivate
+    @user = User.find(params[:id])
+  end
 
   def destroy
+    @user = User.find(params[:id])
     @user.deactivate
     flash[:alert] = 'User has been deactivated'
     redirect_to admin_users_path
   end
 
   private
-
-  def find_user
-    @user = User.find(params[:id])
-  end
 
   def user_params
     params.require(:user).permit(:name, :email)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,8 +1,8 @@
 class Admin::UsersController < AdminController
-  before_action :find_user, only: %i[show edit confirm_delete destroy]
+  before_action :find_user, except: %i[index create new]
 
   def index
-    @users = User.active.search(params[:search]).page(params[:page])
+    @users = User.search(params[:search]).page(params[:page])
   end
 
   def show
@@ -40,9 +40,11 @@ class Admin::UsersController < AdminController
 
   def confirm_delete; end
 
+  def confirm_reactivate; end
+
   def destroy
     @user.deactivate
-    flash[:alert] = 'User has been deleted'
+    flash[:alert] = 'User has been deactivated'
     redirect_to admin_users_path
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,8 +35,7 @@ class Admin::UsersController < AdminController
 
   def destroy
     @user = User.find(params[:id])
-    @user.delete_on_auth0
-    @user.destroy
+    @user.deactivate
     flash[:alert] = 'User has been deleted'
     redirect_to admin_users_path
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -22,8 +22,9 @@ class Admin::UsersController < AdminController
       else
         render action: :new
       end
-    rescue Auth0::Exception
+    rescue Auth0::Exception => e
       flash[:alert] = 'There was an error adding the user to Auth0. Please try again.'
+      Rails.logger.warn("Error adding user #{@user.email} to Auth0 during User#create, message: #{e.message}")
       render action: :new
       raise ActiveRecord::Rollback
     end
@@ -32,8 +33,9 @@ class Admin::UsersController < AdminController
   def edit
     @user = User.find(params[:id])
     @user.create_with_auth0
-  rescue Auth0::Exception
+  rescue Auth0::Exception => e
     flash[:alert] = 'There was an error adding the user to Auth0. Please try again.'
+    Rails.logger.warn("Error adding user #{@user.email} to Auth0 during User#edit, message: #{e.message}")
   ensure
     redirect_to admin_user_path(@user)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,9 @@ class User < ApplicationRecord
   has_many :tasks, through: :suppliers
   validates :email, presence: true, uniqueness: { case_sensitive: false }, format: { with: URI::MailTo::EMAIL_REGEXP }
 
+  scope :active, -> { where.not(auth_id: nil) }
+  scope :inactive, -> { where(auth_id: nil) }
+
   def name=(value)
     super value.squish
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,8 @@ class User < ApplicationRecord
   end
 
   def create_with_auth0
-    auth0_client = Auth0Api.new.client
+    return if active?
+
     auth0_response = auth0_client.create_user(
       name,
       email: email,
@@ -44,7 +45,6 @@ class User < ApplicationRecord
   end
 
   def delete_on_auth0
-    auth0_client = Auth0Api.new.client
     auth0_client.delete_user(auth_id)
     update auth_id: nil
   end
@@ -55,10 +55,17 @@ class User < ApplicationRecord
 
   def deactivate
     return unless active?
+
     delete_on_auth0
   end
 
   def temporary_password
     "#{SecureRandom.urlsafe_base64}aA1!"
+  end
+
+  private
+
+  def auth0_client
+    @auth0_client ||= Auth0Api.new.client
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,15 @@ class User < ApplicationRecord
     update auth_id: nil
   end
 
+  def active?
+    !auth_id.nil?
+  end
+
+  def deactivate
+    return unless active?
+    delete_on_auth0
+  end
+
   def temporary_password
     "#{SecureRandom.urlsafe_base64}aA1!"
   end

--- a/app/views/admin/users/confirm_reactivate.html.haml
+++ b/app/views/admin/users/confirm_reactivate.html.haml
@@ -8,7 +8,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %p
-        This user will be recreated on Auth0 and will be sent a new password
+        Reactivating this user will allow them to sign into the service and submit management information on behalf of any linked suppliers.
 
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/admin/users/confirm_reactivate.html.haml
+++ b/app/views/admin/users/confirm_reactivate.html.haml
@@ -1,14 +1,14 @@
-= form_for [:admin, @user], method: :delete do |form|
+= form_for [:admin, @user], url: edit_admin_user_path(@user), method: :post do |form|
   .govuk-grid-row
     .govuk-grid-column-full
       %fieldset.govuk-fieldset
         %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
           %h1.govuk-fieldset__heading
-            Deactivate this User?
+            Reactivate this User?
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       %p
-        This user will no longer have access to the service. However their user record will be retained for auditing purposes.
+        This user will be recreated on Auth0 and will be sent a new password
 
   .govuk-grid-row
     .govuk-grid-column-full
@@ -22,4 +22,4 @@
             %td.govuk-table__cell= @user.name
             %td.govuk-table__cell= @user.email
       .govuk-form-group
-        = form.submit 'Deactivate user', class: 'govuk-button'
+        = form.submit 'Reactivate user', class: 'govuk-button'

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -28,6 +28,7 @@
           %th.govuk-table__header Name
           %th.govuk-table__header Email
           %th.govuk-table__header Linked suppliers
+          %th.govuk-table__header Active?
       %tbody.govuk-table__body
         - @users.each do |user|
           %tr.govuk-table__row
@@ -35,5 +36,6 @@
             %td.govuk-table__cell= user.email
             %td.govuk-table__cell
               = link_to_suppliers(user.suppliers)
+            %td.govuk-table__cell= user.active? ? 'Active' : 'Inactive'
 
     = paginate @users

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -3,16 +3,22 @@
     %h1.govuk-heading-xl= @user.name
     %p= @user.email
     %p
-      Account active since:
+      Created at:
       = @user.created_at.to_s(:short)
+    - unless @user.active?
+      %p Inactive user
   .govuk-grid-column-one-third
     %nav.govuk-page-actions{"aria-labelledby" => "page-actions-title"}
       %h2#page-actions-title.govuk-heading-s{"aria-label" => "Page actions"} Actions
       %ul.govuk-page-actions--actions
-        %li.govuk-page-actions--action
-          = link_to 'Link to a supplier', new_admin_user_membership_path(@user)
-        %li.govuk-page-actions--action
-          = link_to 'Delete user', confirm_delete_admin_user_path(@user)
+        - if @user.active?
+          %li.govuk-page-actions--action
+            = link_to 'Link to a supplier', new_admin_user_membership_path(@user)
+          %li.govuk-page-actions--action
+            = link_to 'Deactivate user', confirm_delete_admin_user_path(@user)
+        - else
+          %li.govuk-page-actions--action
+            = link_to 'Reactivate user', confirm_reactivate_admin_user_path(@user)
 
 .govuk-grid-row{:class => 'govuk-!-margin-top-7'}
   .govuk-grid-column-full

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root 'users#index'
-    resources :users, only: %i[index show new create destroy] do
+    resources :users, only: %i[index show new edit create destroy] do
       resources :memberships, only: %i[new create show destroy]
       member do
         get :confirm_delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,10 +60,12 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root 'users#index'
-    resources :users, only: %i[index show new edit create destroy] do
+    resources :users, only: %i[index show new create destroy] do
       resources :memberships, only: %i[new create show destroy]
       member do
+        post :edit
         get :confirm_delete
+        get :confirm_reactivate
       end
     end
     resources :suppliers, only: %i[index show]

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     sequence :email do |n|
       "user#{n}@example.com"
     end
+
+    trait :inactive do
+      auth_id nil
+    end
   end
 end

--- a/spec/features/adding_a_user_spec.rb
+++ b/spec/features/adding_a_user_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Adding a user' do
   let(:email) { 'new@example.com' }
 
   before do
+    allow(Rails.logger).to receive(:warn)
     stub_auth0_token_request
     stub_auth0_create_user_request(email)
 
@@ -43,5 +44,7 @@ RSpec.feature 'Adding a user' do
 
     expect(page).to have_content('There was an error adding the user to Auth0.')
     expect(User.find_by(email: email)).to be_nil
+    expect(Rails.logger).to have_received(:warn)
+      .with(/Error adding user bla@example.com to Auth0 during User#create/)
   end
 end

--- a/spec/features/deactivating_a_user_spec.rb
+++ b/spec/features/deactivating_a_user_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Delating a user' do
+RSpec.feature 'Deactivating a user' do
   let(:user) { FactoryBot.create(:user) }
 
   before do
@@ -12,9 +12,9 @@ RSpec.feature 'Delating a user' do
     sign_in_as_admin
     click_on 'Users'
     click_on user.name
-    click_on 'Delete user'
-    click_on 'Delete user'
+    click_on 'Deactivate user'
+    click_on 'Deactivate user'
 
-    expect(page).to have_content('User has been deleted')
+    expect(page).to have_content('User has been deactivated')
   end
 end

--- a/spec/features/finding_a_user_spec.rb
+++ b/spec/features/finding_a_user_spec.rb
@@ -14,12 +14,12 @@ RSpec.feature 'Finding a user' do
     sign_in_as_admin
   end
 
-  scenario 'Viewing all active users' do
+  scenario 'Viewing all users' do
     visit admin_users_path
     expect(page).to have_content 'User One'
     expect(page).to have_content 'User Two'
     expect(page).to have_content 'User Three'
-    expect(page).to_not have_content 'Inactive User'
+    expect(page).to have_content 'Inactive User'
   end
 
   scenario 'Searching by name' do
@@ -29,6 +29,14 @@ RSpec.feature 'Finding a user' do
     expect(page).to have_content 'User One'
     expect(page).to_not have_content 'User Two'
     expect(page).to_not have_content 'User Three'
+  end
+
+  scenario 'Searching for inactive users by name' do
+    visit admin_users_path
+    fill_in 'Search', with: 'inactive'
+    click_button 'Search'
+    expect(page).to_not have_content 'User One'
+    expect(page).to have_content 'Inactive User'
   end
 
   scenario 'Searching by email' do

--- a/spec/features/finding_a_user_spec.rb
+++ b/spec/features/finding_a_user_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Finding a user' do
     @user1 = FactoryBot.create(:user, name: 'User One', email: 'email_one@ccs.co.uk')
     @user2 = FactoryBot.create(:user, name: 'User Two', email: 'email_two@ccs.co.uk')
     @user3 = FactoryBot.create(:user, name: 'User Three', email: 'email_three@ccs.co.uk')
+    @user4 = FactoryBot.create(:user, name: 'Inactive User', email: 'email_four@ccs.co.uk', auth_id: nil)
     @supplier1 = FactoryBot.create(:supplier, name: 'Supplier Alpha')
     @supplier2 = FactoryBot.create(:supplier, name: 'Supplier Beta')
     @user1.suppliers << @supplier1
@@ -13,11 +14,12 @@ RSpec.feature 'Finding a user' do
     sign_in_as_admin
   end
 
-  scenario 'viewing all' do
+  scenario 'Viewing all active users' do
     visit admin_users_path
     expect(page).to have_content 'User One'
     expect(page).to have_content 'User Two'
     expect(page).to have_content 'User Three'
+    expect(page).to_not have_content 'Inactive User'
   end
 
   scenario 'Searching by name' do

--- a/spec/features/reactivating_a_user_spec.rb
+++ b/spec/features/reactivating_a_user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Reactivating a user' do
-  let(:user) { FactoryBot.create(:user, auth_id: nil) }
+  let(:user) { FactoryBot.create(:user, :inactive) }
 
   before do
     stub_auth0_token_request

--- a/spec/features/reactivating_a_user_spec.rb
+++ b/spec/features/reactivating_a_user_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.feature 'Reactivating a user' do
+  let(:user) { FactoryBot.create(:user, auth_id: nil) }
+
+  before do
+    stub_auth0_token_request
+    sign_in_as_admin
+  end
+
+  scenario 'successfully' do
+    stub_auth0_create_user_request(user.email)
+
+    click_on 'Users'
+    click_on user.name
+    click_on 'Reactivate user'
+    click_on 'Reactivate user'
+
+    expect(page).to_not have_content('Inactive user')
+  end
+
+  scenario 'unsuccessfully with Auth0 error' do
+    stub_auth0_create_user_request_failure(user.email)
+
+    click_on 'Users'
+    click_on user.name
+    click_on 'Reactivate user'
+    click_on 'Reactivate user'
+
+    expect(page).to have_content('There was an error adding the user to Auth0.')
+  end
+end

--- a/spec/features/reactivating_a_user_spec.rb
+++ b/spec/features/reactivating_a_user_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Reactivating a user' do
   let(:user) { FactoryBot.create(:user, :inactive) }
 
   before do
+    allow(Rails.logger).to receive(:warn)
     stub_auth0_token_request
     sign_in_as_admin
   end
@@ -28,5 +29,7 @@ RSpec.feature 'Reactivating a user' do
     click_on 'Reactivate user'
 
     expect(page).to have_content('There was an error adding the user to Auth0.')
+    expect(Rails.logger).to have_received(:warn)
+      .with(/Error adding user #{user.email} to Auth0 during User#edit/)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,6 +54,24 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#active?' do
+    context 'an active user' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'returns true' do
+        expect(user.active?).to be_truthy
+      end
+    end
+
+    context 'an inactive user' do
+      let(:user) { FactoryBot.create(:user, :inactive) }
+
+      it 'returns false' do
+        expect(user.active?).to be_falsy
+      end
+    end
+  end
+
   describe '#delete_on_auth0' do
     let(:user) { FactoryBot.create(:user) }
     let!(:auth0_delete_call) { stub_auth0_delete_user_request(user) }
@@ -65,6 +83,34 @@ RSpec.describe User, type: :model do
 
       expect(auth0_delete_call).to have_been_requested
       expect(user.auth_id).to eq(nil)
+    end
+  end
+
+  describe '#deactivate' do
+    let!(:auth0_delete_call) { stub_auth0_delete_user_request(user) }
+
+    before { stub_auth0_token_request }
+
+    context 'an active user' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'deletes user on Auth0 and nils auth_id' do
+        user.deactivate
+
+        expect(auth0_delete_call).to have_been_requested
+        expect(user.auth_id).to eq(nil)
+      end
+    end
+
+    context 'an inactive user' do
+      let(:user) { FactoryBot.create(:user, :inactive) }
+
+      it 'does not do anything' do
+        user.deactivate
+
+        expect(auth0_delete_call).not_to have_been_requested
+        expect(user.auth_id).to eq(nil)
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe User, type: :model do
   end
 
   describe '#create_with_auth0' do
-    let(:user) { FactoryBot.create(:user, auth_id: nil) }
+    let(:user) { FactoryBot.create(:user, :inactive) }
     let!(:auth0_create_call) { stub_auth0_create_user_request(user.email) }
 
     before { stub_auth0_token_request }
@@ -55,20 +55,18 @@ RSpec.describe User, type: :model do
   end
 
   describe '#active?' do
+    subject { user.active? }
+
     context 'an active user' do
       let(:user) { FactoryBot.create(:user) }
 
-      it 'returns true' do
-        expect(user.active?).to be_truthy
-      end
+      it { is_expected.to be_truthy }
     end
 
     context 'an inactive user' do
       let(:user) { FactoryBot.create(:user, :inactive) }
 
-      it 'returns false' do
-        expect(user.active?).to be_falsy
-      end
+      it { is_expected.to be_falsy }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -147,4 +147,21 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  context 'scopes' do
+    let!(:active_user) { FactoryBot.create(:user) }
+    let!(:inactive_user) { FactoryBot.create(:user, :inactive) }
+
+    describe '.active' do
+      it 'returns only active users' do
+        expect(User.active.count).to eq(1)
+      end
+    end
+
+    describe '.inactive' do
+      it 'returns only inactive users' do
+        expect(User.inactive.count).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe User, type: :model do
   end
 
   describe '#create_with_auth0' do
-    let(:user) { FactoryBot.create(:user) }
+    let(:user) { FactoryBot.create(:user, auth_id: nil) }
     let!(:auth0_create_call) { stub_auth0_create_user_request(user.email) }
 
     before { stub_auth0_token_request }


### PR DESCRIPTION
Trello: https://trello.com/c/ACjDmR0l/771-users-should-be-soft-deleted

Deleting a user from the admin app used to completely delete the user record. As the user is linked to submission data, we need to retain the user record for auditing purposes. 

Users are now "deactivated", not deleted. Their Auth0 accounts are removed but a user record is retained in our database. The user index shows if a user is Active/Inactive

<img width="1148" alt="screenshot 2019-02-12 at 15 51 29" src="https://user-images.githubusercontent.com/1089521/52648507-95104680-2ede-11e9-89e6-bc7f36c50389.png">

An active user show page remains unchanged, apart from the wording changing to "Deactivate user" instead of "Delete user"

<img width="1121" alt="screenshot 2019-02-12 at 15 51 04" src="https://user-images.githubusercontent.com/1089521/52648554-a6595300-2ede-11e9-9aa0-2e10b3a65f91.png">

An inactive user show page allows an admin to reactivate a user, and also says "Inactive user" to make it clear this user is inactive

<img width="1197" alt="screenshot 2019-02-12 at 15 50 56" src="https://user-images.githubusercontent.com/1089521/52648710-e02a5980-2ede-11e9-865e-c2dbee61ecc1.png">

Reactivating a user has an interstitial step which informs the admin that the user will be recreated on Auth0 and sent a new password

<img width="1101" alt="screenshot 2019-02-12 at 15 51 16" src="https://user-images.githubusercontent.com/1089521/52648848-17006f80-2edf-11e9-8cf1-22d5a3abbfcb.png">
