### PR TITLE
(chore) (729) cleanup the admin app

### DIFF
--- a/app/views/admin/memberships/new.html.haml
+++ b/app/views/admin/memberships/new.html.haml
@@ -12,7 +12,7 @@
         Search suppliers
       .ccs-search-form-group
         %label.govuk-label.govuk-visually-hidden{ for: 'search' } Search
-        %input#search.govuk-input{ name: 'search', type: 'text', value: params[:search], autofocus: true }
+        %input#search{ name: 'search', type: 'text', value: params[:search], autofocus: true, class: ['govuk-!-width-two-thirds', 'govuk-input'] }
         %button.govuk-button Search
 
 .govuk-grid-row

--- a/app/views/admin/memberships/show.html.haml
+++ b/app/views/admin/memberships/show.html.haml
@@ -4,12 +4,24 @@
     %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
       %h1.govuk-fieldset__heading
         Unlink user from a supplier
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h2.govuk-heading-m= @user.name
-    %p= @user.email
-    %p This user will no longer be able to complete tasks on behalf of the following supplier
-    %h2.govuk-heading-m= @membership.supplier.name
+    %p
+      The user
+      = @user.name
+      will no longer be able to complete tasks on behalf of the following supplier:
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %table.govuk-table
+      %thead.govuk-table__head
+        %tr.govuk-table__row
+          %th.govuk-table__header Name
+      %tbody.govuk-table__body
+        %tr.govuk-table__row
+          %td.govuk-table__cell=  @membership.supplier.name
+
     .govuk-form-group
       = form_for [:admin, @user, @membership], method: :delete do |form|
         = form.submit 'Unlink user', 'aria-label' => "Unlink user #{@user.name} from a #{@membership.supplier.name}", class: 'govuk-button'

--- a/app/views/admin/suppliers/index.html.haml
+++ b/app/views/admin/suppliers/index.html.haml
@@ -10,7 +10,7 @@
         Search
       .ccs-search-form-group
         %label.govuk-label.govuk-visually-hidden{for: 'search'} Search
-        %input#search.govuk-input{name: 'search', type: 'text', value: params[:search]}
+        %input#search.govuk-input{name: 'search', type: 'text', value: params[:search], class: ['govuk-!-width-two-thirds', 'govuk-input']}
         %button.govuk-button Search
 
   .govuk-grid-column-one-third

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -10,7 +10,7 @@
         Search
       .ccs-search-form-group
         %label.govuk-label.govuk-visually-hidden{for: 'search'} Search
-        %input#search.govuk-input{name: 'search', type: 'text', value: params[:search]}
+        %input#search{name: 'search', type: 'text', value: params[:search], class: ['govuk-!-width-two-thirds', 'govuk-input']}
         %button.govuk-button Search
 
   .govuk-grid-column-one-third

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -22,20 +22,27 @@
 
 .govuk-grid-row
   .govuk-grid-column-full
-    %table.govuk-table{:class => 'govuk-!-margin-top-7'}
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header Name
-          %th.govuk-table__header Email
-          %th.govuk-table__header Linked suppliers
-          %th.govuk-table__header Active?
-      %tbody.govuk-table__body
-        - @users.each do |user|
+    - if @users.present?
+      %table.govuk-table{:class => 'govuk-!-margin-top-7'}
+        %thead.govuk-table__head
           %tr.govuk-table__row
-            %td.govuk-table__cell= link_to user.name, admin_user_path(user)
-            %td.govuk-table__cell= user.email
-            %td.govuk-table__cell
-              = link_to_suppliers(user.suppliers)
-            %td.govuk-table__cell= user.active? ? 'Active' : 'Inactive'
+            %th.govuk-table__header Name
+            %th.govuk-table__header Email
+            %th.govuk-table__header Linked suppliers
+            %th.govuk-table__header Active?
+        %tbody.govuk-table__body
+          - @users.each do |user|
+            %tr.govuk-table__row
+              %td.govuk-table__cell= link_to user.name, admin_user_path(user)
+              %td.govuk-table__cell= user.email
+              %td.govuk-table__cell
+                = link_to_suppliers(user.suppliers)
+              %td.govuk-table__cell= user.active? ? 'Active' : 'Inactive'
 
-    = paginate @users
+      = paginate @users
+    - elsif params[:search]
+      %p
+        No users found for ‘#{params[:search]}’.
+    - else
+      %p
+        No users.

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -4,7 +4,7 @@
     %p= @user.email
     %p
       Created at:
-      = @user.created_at.to_s(:short)
+      = @user.created_at.to_s(:date_with_utc_time)
     - unless @user.active?
       %p Inactive user
   .govuk-grid-column-one-third


### PR DESCRIPTION
A couple of small tweaks to the admin UI:

- search fields have their width set explicitly
- when searching for a user and none are found, we show a 'no user found message' rather than an empty table.
- the unlink a user from supplier summary is now a table inline with the rest of the app
- the user creation date is shown with the year and time zone (UTC) to be clear

Trello card: https://trello.com/c/OqjWPvSB