### PR TITLE
(chore) Refactor UserController#create to have clearer exception handling

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -26,7 +26,7 @@ class Admin::UsersController < AdminController
     @user.create_with_auth0
   rescue Auth0::Exception => e
     flash[:alert] = 'There was an error adding the user to Auth0. Please try again.'
-    Rails.logger.warn("Error adding user #{@user.email} to Auth0 during User#edit, message: #{e.message}")
+    Rails.logger.error("Error adding user #{@user.email} to Auth0 during User#edit, message: #{e.message}")
   ensure
     redirect_to admin_user_path(@user)
   end
@@ -55,7 +55,7 @@ class Admin::UsersController < AdminController
         @user.create_with_auth0
       rescue Auth0::Exception => e
         flash[:alert] = 'There was an error adding the user to Auth0. Please try again.'
-        Rails.logger.warn("Error adding user #{@user.email} to Auth0 during User#create, message: #{e.message}")
+        Rails.logger.error("Error adding user #{@user.email} to Auth0 during User#create, message: #{e.message}")
         raise ActiveRecord::Rollback
       end
     end

--- a/spec/features/adding_a_user_spec.rb
+++ b/spec/features/adding_a_user_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Adding a user' do
   let(:email) { 'new@example.com' }
 
   before do
-    allow(Rails.logger).to receive(:warn)
+    allow(Rails.logger).to receive(:error)
     stub_auth0_token_request
     stub_auth0_create_user_request(email)
 
@@ -44,7 +44,7 @@ RSpec.feature 'Adding a user' do
 
     expect(page).to have_content('There was an error adding the user to Auth0.')
     expect(User.find_by(email: email)).to be_nil
-    expect(Rails.logger).to have_received(:warn)
+    expect(Rails.logger).to have_received(:error)
       .with(/Error adding user bla@example.com to Auth0 during User#create/)
   end
 end

--- a/spec/features/reactivating_a_user_spec.rb
+++ b/spec/features/reactivating_a_user_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Reactivating a user' do
   let(:user) { FactoryBot.create(:user, :inactive) }
 
   before do
-    allow(Rails.logger).to receive(:warn)
+    allow(Rails.logger).to receive(:error)
     stub_auth0_token_request
     sign_in_as_admin
   end
@@ -29,7 +29,7 @@ RSpec.feature 'Reactivating a user' do
     click_on 'Reactivate user'
 
     expect(page).to have_content('There was an error adding the user to Auth0.')
-    expect(Rails.logger).to have_received(:warn)
+    expect(Rails.logger).to have_received(:error)
       .with(/Error adding user #{user.email} to Auth0 during User#edit/)
   end
 end


### PR DESCRIPTION
Initially this controller was refactored when https://rollbar.com/dxw/ccs-reportmi-api/items/65/occurrences/66083571076/ indicated a user had somehow been created without an Auth0 id. However on closer inspection it transpires that the exception was raised on a double-submit of the User#destroy action.

However it's been decided to keep this refactor as the scoping of the exception handling is clearer than in the earlier implementation.