### PR TITLE
Exceptions that occur in ActiveJob are sent to Rollbar

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,3 @@
 class ApplicationJob < ActiveJob::Base
+  include Rollbar::ActiveJob
 end


### PR DESCRIPTION
There have been occasions where the ingest/validation process has failed due to a bug, which means the user sees the "processing" screen forever.

When an exception occurs, we should probably set the submission to a different AASM state, which could then show the user relevant guidance that something has gone awry.

The first step is to understand the errors that occur, so this change enables Rollbar's ActiveJob support, which should give us better visibility of problems.