### PR TITLE
Fix memory issue with exports

### DIFF
--- a/app/models/export/contracts/extract.rb
+++ b/app/models/export/contracts/extract.rb
@@ -6,7 +6,6 @@ module Export
                        .select('submission_entries.*, frameworks.short_name AS _framework_short_name')
                        .joins(submission: :framework)
                        .merge(Submission.completed)
-                       .order(:created_at)
       end
     end
   end

--- a/app/models/export/invoices/extract.rb
+++ b/app/models/export/invoices/extract.rb
@@ -6,7 +6,6 @@ module Export
                        .select('submission_entries.*, frameworks.short_name AS _framework_short_name')
                        .joins(submission: :framework)
                        .merge(Submission.completed)
-                       .order(:created_at)
       end
     end
   end

--- a/app/models/export/to_io.rb
+++ b/app/models/export/to_io.rb
@@ -9,7 +9,7 @@ module Export
 
     def run
       output.puts(CSV.generate_line(self.class::HEADER))
-      relation.each do |model|
+      relation.find_each do |model|
         output_row(model)
       end
     end

--- a/spec/lib/tasks/export/contracts_spec.rb
+++ b/spec/lib/tasks/export/contracts_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'rake export:contracts', type: :task do
 
     it 'writes each contract to that output' do
       expect(output_lines.length).to eql(3)
-      expect(output_lines[1]).to eql(
+      expect(output_lines).to include(
         "#{contract.submission_id},10010915,Government Legal Department,WC1B 4ZZ,471600.00001,"\
         'DWP - Claim by Mr I Dontexist,1,Contentious Employment,,,,,,,,,'\
         '2018-06-27,2020-06-27,5000.00,Further Competition,N/A,N,Central Government Department,'\
@@ -60,7 +60,7 @@ RSpec.describe 'rake export:contracts', type: :task do
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
-      expect(output_lines[2]).to eql(
+      expect(output_lines.find { |l| l.match 'NOTINDATA' }).to eql(
         "#{contract2.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA," \
         ',,,,,,,,,,,' \
         '#NOTINDATA,#NOTINDATA,,,,,,,,,,,,,,,,,,,,,,,,'

--- a/spec/lib/tasks/export/invoices_spec.rb
+++ b/spec/lib/tasks/export/invoices_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'rake export:invoices', type: :task do
 
     it 'writes each invoice to that output' do
       expect(output_lines.length).to eql(3)
-      expect(output_lines[1]).to eql(
+      expect(output_lines).to include(
         "#{invoice.submission_id},10012345,Department for Education,SW1P 3ZZ,2018-05-31,3307957,DEP/0008.00032,"\
         'GITIS Terms and Conditions,1,Contracts,Core,,Legal Director/Senior Solicitor,,Hourly,151.09,-0.9,-135.98,,'\
         '-27.2,,142.99,0.00,0.00,0.00,N/A,Time and Material,,,,,,,,,,,,,,,,,,,'
@@ -60,7 +60,7 @@ RSpec.describe 'rake export:invoices', type: :task do
     end
 
     it 'writes #NOTINDATA for fields it cannot map' do
-      expect(output_lines[2]).to eql(
+      expect(output_lines.find { |l| l.match 'NOTINDATA' }).to eql(
         "#{invoice.submission_id},#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,,,"\
         ',,,,,#NOTINDATA,#NOTINDATA,#NOTINDATA,#NOTINDATA,,#NOTINDATA,,'\
         ',,,,,,,,,,,,,,,,,,,,,,,,'

--- a/spec/lib/tasks/export/tasks_spec.rb
+++ b/spec/lib/tasks/export/tasks_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe 'rake export:tasks', type: :task do
       expect(output_lines.first).to eql(
         <<~HEADER.chomp
           TaskID,Month,SupplierID,FrameworkID,Status,TaskType,StartedDate,CompletedDate
-      HEADER
+        HEADER
       )
     end
 
     it 'writes each task to that output' do
       expect(output_lines.length).to eql(3)
-      expect(output_lines[1]).to eql(
+      expect(output_lines.find { |l| l.match '2018-08' }).to eql(
         <<~LINE.chomp
           #{first_task.id},2018-08,#{first_task.supplier.salesforce_id},#{first_task.framework.short_name},unstarted,1,,
         LINE


### PR DESCRIPTION
Long ago, we said we'd use `ActiveRecord::Relation#find_each` instead of
`#each`, because ordering things by creation date made things easier
to test and we were running out of time for the export and we couldn't
make the time to make this work in time at the time. Boom.

Now we have the time to make things work in good time in a timely
manner, do so in reasonable time *and* space by going to `find_each`
in `Export::ToIo` instead of `find`.  To do this we need to stop the
specs caring about order and remove any ordering from our extract
scopes (which will generate scope warnings and undue confusion
under `find_each`).

Before/after this commit:

`rake export:all` before -> peak ~2.5GB memory usage
`rake export:all` after  -> peak 180MB memory usage