### PR TITLE
Expose `submitted_at` on submissions

### DIFF
--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -28,6 +28,8 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
 
   attribute :report_no_business?
 
+  attribute :submitted_at
+
   private
 
   def submission


### PR DESCRIPTION
We want to be able to show this to users on the history page.