### PR TITLE
Add Rake task for generating email list for outstanding tasks

### DIFF
--- a/docs/generating-email-list-for-outstanding-tasks.md
+++ b/docs/generating-email-list-for-outstanding-tasks.md
@@ -1,0 +1,13 @@
+# Generating email list for outstanding tasks
+
+In order for suppliers to be contacted when they have outstanding tasks to
+complete, we have a Rake task to generate a list of the emails of users who
+should be contacted.
+
+## How to Use
+
+```
+rake chore:outstanding_task_emails
+```
+
+This generates a report that is written to /tmp/outstanding_task_emails.txt

--- a/lib/tasks/chore.rake
+++ b/lib/tasks/chore.rake
@@ -1,0 +1,28 @@
+namespace :chore do
+  desc 'Report email address of users who belong to suppliers with outstanding tasks'
+  task outstanding_task_emails: :environment do |_task|
+    month = (Time.zone.today - 1.month).month
+    year = Time.zone.today.year
+
+    supplier_ids = Task
+                   .where(period_month: month, period_year: year)
+                   .where.not(status: 'completed')
+                   .pluck(:supplier_id)
+                   .uniq
+
+    emails = User
+             .active
+             .joins(:memberships)
+             .merge(Membership.where(supplier_id: supplier_ids))
+             .pluck(:email)
+             .uniq
+             .sort
+
+    file = File.new('/tmp/outstanding_task_emails.txt', 'w')
+    emails.each { |email| file.puts(email) }
+    file.close
+
+    puts "Found #{supplier_ids.count} suppliers with outstanding tasks."
+    puts 'Email list written to /tmp/outstanding_task_emails.txt'
+  end
+end


### PR DESCRIPTION
We're often asked to get a list of the email address of users who belong to suppliers who have outstanding tasks for the current reporting period.

This adds a rake task 'chore:outstanding_task_emails' to make this repeatable.