### PR TITLE
(816) Supplier can replace submission with no business

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,3 +93,6 @@ Naming/FileName:
 Lint/AmbiguousBlockAssociation:
     Exclude:
         - 'spec/**/*'
+
+Performance/Casecmp:
+    Enabled: false

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -17,6 +17,7 @@ class Submission < ApplicationRecord
     state :validation_failed
     state :in_review
     state :completed
+    state :replaced
 
     event :ready_for_review do
       transitions from: %i[pending processing], to: :in_review, guard: :all_entries_valid?
@@ -30,10 +31,18 @@ class Submission < ApplicationRecord
         errors.add(:aasm_state, message: e.message)
       end
     end
+
+    event :replace_with_no_business do
+      transitions from: :completed, to: :replaced, guard: :replaceable?
+    end
   end
 
   def all_entries_valid?
     entries.validated.count == entries.count
+  end
+
+  def replaceable?
+    !report_no_business?
   end
 
   def sheet_names

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,7 +7,7 @@ class Task < ApplicationRecord
     state :completed
 
     event :completed do
-      transitions from: %i[unstarted in_progress], to: :completed
+      transitions from: %i[unstarted in_progress completed], to: :completed
     end
   end
 

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -34,6 +34,19 @@ FactoryBot.define do
       end
     end
 
+    factory :completed_submission do
+      aasm_state :completed
+      association :task, status: 'completed'
+
+      after(:create) do |submission, _evaluator|
+        create_list(:invoice_entry, 2, :valid, submission: submission, total_value: 10.00, management_charge: 0.1)
+        create_list(:order_entry, 1, :valid, submission: submission, total_value: 3.00)
+        if submission.files.empty?
+          create_list(:submission_file, 1, :with_attachment, submission: submission, rows: submission.entries.count)
+        end
+      end
+    end
+
     factory :submission_with_invalid_entries do
       aasm_state :validation_failed
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe Submission do
     end
   end
 
+  describe '#replace_with_no_business state machine event' do
+    it 'transitions from completed to replaced' do
+      submission = FactoryBot.create(:completed_submission)
+      submission.replace_with_no_business
+
+      expect(submission).to be_replaced
+    end
+  end
+
   describe '#sheet_names' do
     let(:submission) { FactoryBot.create(:submission) }
     let!(:invoice) { FactoryBot.create(:submission_entry, submission: submission, sheet_name: 'Invoices') }


### PR DESCRIPTION
- When confirmed, new no business submission is created against the task
- When confirmed, replaced submission get a new status of ‘replaced’
- Supplier cannot do this if the original return was also no business
