### PR TITLE
CHANGELOG for Release 48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [release-48] - 2019-02-20
+
+- Supplier can view list of history of tasks
+- Data migration: Delete 'test supplier' from prod
+
 ## [release-47] - 2019-02-19
 
 - ActiveJob exceptions are sent to Rollbar
@@ -311,6 +316,7 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
+[release-48]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-47...release-48
 [release-47]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-46...release-47
 [release-46]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-45...release-46
 [release-45]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-44...release-45


### PR DESCRIPTION
- Supplier can view list of history of tasks
- Data migration: Delete 'test supplier' from prod