### PR TITLE
rake generate:late_tasks

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,6 +11,8 @@ class Task < ApplicationRecord
     end
   end
 
+  scope :incomplete, -> { where.not(status: 'completed') }
+
   validates :status, presence: true
 
   belongs_to :framework, optional: true

--- a/app/models/task/late_generator.rb
+++ b/app/models/task/late_generator.rb
@@ -1,0 +1,63 @@
+require 'csv'
+
+class Task
+  # Used to generate a 'late' CSV for all users
+  # of suppliers with incomplete submissions in the
+  # given year/month period. Outputs via +puts+ objects
+  # that respond_to? it (+STDOUT+ or +File+ being usual)
+  class LateGenerator
+    HEADER = [
+      'User Name',
+      'Email Address',
+      'Framework Number'
+    ].freeze
+
+    attr_reader :logger, :output, :month, :year
+
+    def initialize(month:, year:, output: STDOUT, logger: Rails.logger)
+      @month = month
+      @year = year
+      @output = output
+      @logger = logger
+    end
+
+    delegate :info, :warn, to: :logger
+
+    ##
+    # NB should become its own class if this becomes an
+    # admin front end confection. This class should be concerned
+    # with generating CSV, not getting the records
+    def user_framework_lates
+      Task
+        .incomplete
+        .where(period_month: month, period_year: year)
+        .select('
+          tasks.id,
+          frameworks.short_name AS framework_short_name,
+          users.name AS user_name,
+          users.email AS user_email
+        ')
+        .joins(
+          :framework,
+          supplier: { memberships: :user }
+        )
+    end
+
+    def generate
+      logger.info "Generating late contacts for #{year}, #{month}"
+
+      output.puts(CSV.generate_line(HEADER))
+      user_framework_lates.find_each do |user_framework|
+        output.puts(
+          CSV.generate_line(
+            [
+              user_framework.user_name,
+              user_framework.user_email,
+              user_framework.framework_short_name
+            ]
+          )
+        )
+      end
+    end
+  end
+end

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -3,4 +3,12 @@ namespace :generate do
   task tasks: :environment do
     MonthlyTasksGenerationJob.perform_later
   end
+
+  desc 'Generates CSV of late submission contacts for a given window'
+  task :late_tasks, %i[period_month year] => [:environment] do |_task, args|
+    year         = args[:year]&.to_i         || Time.zone.today.year
+    period_month = args[:period_month]&.to_i || (Time.zone.today - 1.month).month
+
+    Task::LateGenerator.new(year: year, month: period_month).generate
+  end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
 
     supplier
     framework
+
+    trait :completed do
+      status 'completed'
+    end
   end
 end

--- a/spec/models/task/late_generator_spec.rb
+++ b/spec/models/task/late_generator_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+require 'stringio'
+
+RSpec.describe Task::LateGenerator do
+  subject(:generator) { Task::LateGenerator.new(year: year, month: month, output: output) }
+
+  describe '#generate' do
+    let(:output) { StringIO.new }
+
+    context 'there are incomplete submissions for the month in question' do
+      let(:year)  { 2019 }
+      let(:month) { 1 }
+
+      let(:alice)      { create :user, name: 'Alice Example', email: 'alice@example.com' }
+      let(:bob)        { create :user, name: 'Bob Example', email: 'bob@example.com' }
+
+      before do
+        # Warning! Data creation yak ahead. In short:
+        # Create two frameworks and two suppliers. Each supplier
+        # has two incomplete tasks, and one of them has a completed
+        # task. Each of the users with a membership in a supplier
+        # needs to be told about the fact that something is wrong
+        # with their submission for that framework
+        # (the period is implied)
+        framework1 = create :framework, short_name: 'RM0001'
+        framework2 = create :framework, short_name: 'RM0002'
+
+        framework3 = create :framework, short_name: 'COMPLETE0001'
+
+        supplier_a = create :supplier
+        supplier_b = create :supplier
+
+        create :membership, user: alice, supplier: supplier_a
+        create :membership, user: bob, supplier: supplier_b
+
+        create :task, supplier: supplier_a, framework: framework1
+        create :task, supplier: supplier_a, framework: framework2
+        create :task, supplier: supplier_b, framework: framework1
+        create :task, supplier: supplier_b, framework: framework2
+
+        create :task, :completed, supplier: supplier_a, framework: framework3
+
+        generator.generate
+      end
+
+      subject(:lines) { output.string.split("\n") }
+
+      it 'has a header' do
+        expect(lines.first).to eql('User Name,Email Address,Framework Number')
+      end
+
+      it 'has a line for each user in that supplier for each framework' do
+        expect(lines).to include('Alice Example,alice@example.com,RM0001')
+        expect(lines).to include('Alice Example,alice@example.com,RM0002')
+        expect(lines).to include('Bob Example,bob@example.com,RM0001')
+        expect(lines).to include('Bob Example,bob@example.com,RM0002')
+      end
+
+      it 'does not include completed tasks' do
+        expect(lines).not_to include('Alice Example,alice@example.com,COMPLETE0001')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## [Generate CSV for late notification](https://trello.com/c/zkqPeEg9/868-generate-csv-for-late-notification)

For every incomplete task in a given year/month period window,
find all the users' emails in combination with all the frameworks that
are late and send them to a file that is Notify-friendly.

Generates to CSV to STDOUT by default (pipe to a file if
you know where it's going; no standard location is implied)