### PR TITLE
(chore) Remove `case_insensitive_inclusion` validator where it is redundant

### DIFF
--- a/app/models/framework/definition/RM1043_5.rb
+++ b/app/models/framework/definition/RM1043_5.rb
@@ -53,13 +53,6 @@ class Framework
         'User Research Participants'
       ].freeze
 
-      SERVICE_PROVIDED_VALUES = (
-        LOT_1_SERVICES +
-        LOT_2_SERVICES +
-        LOT_3_SERVICES +
-        LOT_4_SERVICES
-      ).freeze
-
       MAPPING = {
         'Lot Number' => {
           '1' => LOT_1_SERVICES,
@@ -78,7 +71,7 @@ class Framework
         field 'Customer Invoice/Credit Note Date', :string, exports_to: 'Invoice Date', ingested_date: true, presence: true
         field 'Customer Invoice/Credit Note Number', :string, exports_to: 'InvoiceNumber', presence: true
         field 'Lot Number', :string, exports_to: 'LotNumber', presence: true, lot_in_agreement: true
-        field 'Service Provided', :string, exports_to: 'ProductGroup', presence: true, dependent_field_inclusion: { parent: 'Lot Number', in: MAPPING }, case_insensitive_inclusion: { in: SERVICE_PROVIDED_VALUES }
+        field 'Service Provided', :string, exports_to: 'ProductGroup', presence: true, dependent_field_inclusion: { parent: 'Lot Number', in: MAPPING }
         field 'Unit of Measure', :string, exports_to: 'UnitType', case_insensitive_inclusion: { in: UNIT_OF_MEASURE_VALUES }
         field 'Quantity', :string, exports_to: 'UnitQuantity', ingested_numericality: true, presence: true
         field 'Price per Unit', :string, exports_to: 'UnitPrice', ingested_numericality: true, presence: true

--- a/app/models/framework/definition/RM3756.rb
+++ b/app/models/framework/definition/RM3756.rb
@@ -84,7 +84,7 @@ class Framework
         field 'Customer Invoice Date', :string, exports_to: 'InvoiceDate', ingested_date: true
         field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber', presence: true
         field 'Service Type', :string, exports_to: 'ProductGroup', presence: true, case_insensitive_inclusion: { in: SERVICE_TYPE_VALUES }
-        field 'Primary Specialism', :string, exports_to: 'ProductDescription', presence: true, dependent_field_inclusion: { parent: 'Service Type', in: MAPPING }, case_insensitive_inclusion: { in: PRIMARY_SPECIALISM_VALUES, message: 'must match the selected service type. For a list of service types and specialisms, check the lookups tab in the template.' }
+        field 'Primary Specialism', :string, exports_to: 'ProductDescription', presence: true, dependent_field_inclusion: { parent: 'Service Type', in: MAPPING }
         field 'Practitioner Grade', :string, exports_to: 'ProductSubClass', presence: true, case_insensitive_inclusion: { in: PRACTITIONER_GRADE_VALUES }
         field 'UNSPSC', :string, exports_to: 'UNSPSC', ingested_numericality: { only_integer: true }
         field 'Unit of Purchase', :string, exports_to: 'UnitType', presence: true, case_insensitive_inclusion: { in: UNIT_OF_PURCHASE_VALUES }

--- a/app/models/framework/definition/RM3786.rb
+++ b/app/models/framework/definition/RM3786.rb
@@ -108,7 +108,7 @@ class Framework
         field 'Customer Invoice Date', :string, exports_to: 'InvoiceDate', ingested_date: true
         field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber', presence: true
         field 'Service Type', :string, exports_to: 'ProductGroup', presence: true, case_insensitive_inclusion: { in: SERVICE_TYPE_VALUES }
-        field 'Primary Specialism', :string, exports_to: 'ProductDescription', presence: true, dependent_field_inclusion: { parent: 'Service Type', in: MAPPING }, case_insensitive_inclusion: { in: PRIMARY_SPECIALISM_VALUES, message: 'must match the selected service type. For a list of service types and specialisms, check the lookups tab in the template.' }
+        field 'Primary Specialism', :string, exports_to: 'ProductDescription', presence: true, dependent_field_inclusion: { parent: 'Service Type', in: MAPPING }
         field 'Practitioner Grade', :string, exports_to: 'ProductSubClass', presence: true, case_insensitive_inclusion: { in: PRACTITIONER_GRADE_VALUES }
         field 'UNSPSC', :string, exports_to: 'UNSPSC', ingested_numericality: { only_integer: true }
         field 'Unit of Purchase', :string, exports_to: 'UnitType', presence: true, case_insensitive_inclusion: { in: UNIT_OF_PURCHASE_VALUES }

--- a/app/models/framework/definition/RM3787.rb
+++ b/app/models/framework/definition/RM3787.rb
@@ -89,7 +89,7 @@ class Framework
         field 'Customer Invoice Date', :string, exports_to: 'InvoiceDate', ingested_date: true
         field 'Customer Invoice Number', :string, exports_to: 'InvoiceNumber', presence: true
         field 'Service Type', :string, exports_to: 'ProductGroup', presence: true, case_insensitive_inclusion: { in: SERVICE_TYPE_VALUES }
-        field 'Primary Specialism', :string, exports_to: 'ProductClass', presence: true, dependent_field_inclusion: { parent: 'Service Type', in: MAPPING }, case_insensitive_inclusion: { in: PRIMARY_SPECIALISM_VALUES, message: 'must match the selected service type. For a list of service types and specialisms, check the lookups tab in the template.' }
+        field 'Primary Specialism', :string, exports_to: 'ProductClass', presence: true, dependent_field_inclusion: { parent: 'Service Type', in: MAPPING }
         field 'Practitioner Grade', :string, exports_to: 'ProductDescription', presence: true, case_insensitive_inclusion: { in: PRACTITIONER_GRADE_VALUES }
         field 'Pricing Mechanism', :string, exports_to: 'ProductSubClass', presence: true, case_insensitive_inclusion: { in: PRICING_MECHANISM_VALUES }
         field 'UNSPSC', :string, exports_to: 'UNSPSC', ingested_numericality: { only_integer: true }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,4 +6,4 @@ en:
       invalid_ingested_date: 'must be in the format dd/mm/yyyy'
       invalid_optional_ingested_date: 'must be in the format dd/mm/yyyy or left blank'
       invalid_lot_number: 'is not included in the supplier framework agreement'
-      invalid_dependent_field: '"%{value}" is not a valid %{attr} for the given %{parent_field_name} of "%{parent_field_value}"'
+      invalid_dependent_field: '"%{value}" is not a valid %{attr} for the given %{parent_field_name} of "%{parent_field_value}". Please refer to the lookups tab in the template.'

--- a/spec/validators/dependent_field_inclusion_validator_spec.rb
+++ b/spec/validators/dependent_field_inclusion_validator_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe DependentFieldInclusionValidator do
     it { is_expected.to_not be_valid }
 
     it 'has an error message' do
-      expect(entry_data.errors['Primary Specialism'].first).to eql(
-        '"Equity Capital Markets" is not a valid Primary Specialism for the given Service Type of "Core"'
+      expect(entry_data.errors['Primary Specialism'].first).to include(
+        '"Equity Capital Markets" is not a valid Primary Specialism for the given Service Type of "Core".'
       )
     end
   end
@@ -61,8 +61,8 @@ RSpec.describe DependentFieldInclusionValidator do
     it { is_expected.to_not be_valid }
 
     it 'has an error message' do
-      expect(entry_data.errors['Primary Specialism'].first).to eql(
-        '"something else" is not a valid Primary Specialism for the given Service Type of "Core"'
+      expect(entry_data.errors['Primary Specialism'].first).to include(
+        '"something else" is not a valid Primary Specialism for the given Service Type of "Core".'
       )
     end
   end


### PR DESCRIPTION
Remove `case_insensitive_inclusion` from fields where the `dependent_field_inclusion` validator is also used.

When both validators were present, the error message from `case_insensitive_inclusion` was unhelpful and redundant, because the `dependent_field_inclusion` error message provided all the needed validation and information to the user.

I have removed the `case_insensitive_inclusion` validator from fields where both were present, to make error messages less confusing to the user. Unfortunately it’s hard to prove with a test, so hopefully the  screenshots suffice.

With both validators: `got errors: Service provided "Foof" is not a valid Service Provided for the given Lot Number of "1", Service provided is not included in the list`

![screenshot 2019-02-21 at 17 12 45](https://user-images.githubusercontent.com/1089521/53332253-c29bbd80-38ea-11e9-97d6-d59db28d5c55.png)

With one validator: `got errors: Service provided "Foof" is not a valid Service Provided for the given Lot Number of "1"`

![screenshot 2019-02-21 at 17 13 07](https://user-images.githubusercontent.com/1089521/53332270-ce877f80-38ea-11e9-8194-7236fb3d6cc1.png)
