### PR TITLE
Supplier agreements can be toggled

### DIFF
--- a/app/controllers/admin/agreements_controller.rb
+++ b/app/controllers/admin/agreements_controller.rb
@@ -1,7 +1,15 @@
 class Admin::AgreementsController < AdminController
   before_action :load_supplier_agreement_records
 
+  def confirm_activation; end
+
   def confirm_deactivation; end
+
+  def activate
+    @agreement.activate!
+
+    redirect_to [:admin, @supplier], alert: "Activated on #{@framework.short_name}"
+  end
 
   def deactivate
     @agreement.deactivate!

--- a/app/controllers/admin/agreements_controller.rb
+++ b/app/controllers/admin/agreements_controller.rb
@@ -1,0 +1,19 @@
+class Admin::AgreementsController < AdminController
+  before_action :load_supplier_agreement_records
+
+  def confirm_deactivation; end
+
+  def deactivate
+    @agreement.deactivate!
+
+    redirect_to [:admin, @supplier], alert: "Deactivated from #{@framework.short_name}"
+  end
+
+  private
+
+  def load_supplier_agreement_records
+    @supplier = Supplier.find(params[:supplier_id])
+    @agreement = @supplier.agreements.find(params[:agreement_id])
+    @framework = @agreement.framework
+  end
+end

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -9,6 +9,8 @@ class Agreement < ApplicationRecord
             presence: true,
             uniqueness: { scope: :supplier_id, message: 'agreement already exists for this supplier' }
 
+  scope :active, -> { where(active: true) }
+
   def lot_numbers
     framework_lots.pluck(:number)
   end

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -12,4 +12,8 @@ class Agreement < ApplicationRecord
   def lot_numbers
     framework_lots.pluck(:number)
   end
+
+  def deactivate!
+    update!(active: false)
+  end
 end

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -13,6 +13,10 @@ class Agreement < ApplicationRecord
     framework_lots.pluck(:number)
   end
 
+  def activate!
+    update!(active: true)
+  end
+
   def deactivate!
     update!(active: false)
   end

--- a/app/models/task/generator.rb
+++ b/app/models/task/generator.rb
@@ -32,7 +32,7 @@ class Task
     private
 
     def agreements
-      Agreement.includes(:framework, :supplier)
+      Agreement.active.includes(:framework, :supplier)
     end
 
     def task_attributes_for_agreement(agreement)

--- a/app/views/admin/agreements/confirm_activation.html.haml
+++ b/app/views/admin/agreements/confirm_activation.html.haml
@@ -1,0 +1,17 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %fieldset.govuk-fieldset
+      %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
+        %h1.govuk-fieldset__heading
+          = "Activate #{@supplier.name} on #{@framework.short_name}?"
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %p
+      This supplier will be able to report management information on the
+      = @framework.name
+      framework and will receive a new task at the next submission window.
+      This supplier can be deactivated at any time.
+.govuk-grid-row
+  .govuk-grid-column-full
+    .govuk-form-group
+      = button_to "Activate #{@supplier.name} on #{@framework.short_name}", admin_supplier_agreement_activate_path(@supplier, @agreement), method: :put, class: 'govuk-button'

--- a/app/views/admin/agreements/confirm_deactivation.html.haml
+++ b/app/views/admin/agreements/confirm_deactivation.html.haml
@@ -1,0 +1,17 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %fieldset.govuk-fieldset
+      %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
+        %h1.govuk-fieldset__heading
+          = "Deactivate #{@supplier.name} from #{@framework.short_name}?"
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %p
+      This supplier will no longer be able to report management information on the
+      = @framework.name
+      framework and will not be asked to report any more returns. This supplier can be reactivated at any time.
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    .govuk-form-group
+      = button_to "Deactivate #{@supplier.name} from #{@framework.short_name}", admin_supplier_agreement_deactivate_path(@supplier, @agreement), method: :put, class: 'govuk-button'

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -69,7 +69,10 @@
               %td.govuk-table__cell
                 = agreement.active? ? 'Active' : 'Inactive'
               %td.govuk-table__cell
-                = link_to 'Deactivate', admin_supplier_agreement_confirm_deactivation_path(@supplier, agreement)
+                - if agreement.active?
+                  = link_to 'Deactivate', admin_supplier_agreement_confirm_deactivation_path(@supplier, agreement)
+                - else
+                  = link_to 'Activate', admin_supplier_agreement_confirm_activation_path(@supplier, agreement)
     -else
       %p
         No frameworks for

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -57,12 +57,19 @@
         %thead.govuk-table__head
           %tr.govuk-table__row
             %th.govuk-table__header Name
+            %th.govuk-table__header Status
+            %th.govuk-table__header Actions
         %tbody.govuk-table__body
-          - @supplier.frameworks.each do |framework|
-            %tr.govuk-table__row
+          - @supplier.agreements.includes(:framework).each do |agreement|
+            - framework = agreement.framework
+            %tr.govuk-table__row{:id => "framework-#{framework.id}" }
               %td.govuk-table__cell
                 = framework.short_name
                 = framework.name
+              %td.govuk-table__cell
+                = agreement.active? ? 'Active' : 'Inactive'
+              %td.govuk-table__cell
+                = link_to 'Deactivate', admin_supplier_agreement_confirm_deactivation_path(@supplier, agreement)
     -else
       %p
         No frameworks for

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root 'users#index'
+
     resources :users, only: %i[index show new create destroy] do
       resources :memberships, only: %i[new create show destroy]
       member do
@@ -68,7 +69,14 @@ Rails.application.routes.draw do
         get :confirm_reactivate
       end
     end
-    resources :suppliers, only: %i[index show]
+
+    resources :suppliers, only: %i[index show] do
+      resources :agreements, only: [] do
+        get :confirm_deactivation
+        put :deactivate
+      end
+    end
+
     get '/sign_in', to: 'sessions#new', as: :sign_in
     get '/sign_out', to: 'sessions#destroy', as: :sign_out
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,9 @@ Rails.application.routes.draw do
 
     resources :suppliers, only: %i[index show] do
       resources :agreements, only: [] do
+        get :confirm_activation
         get :confirm_deactivation
+        put :activate
         put :deactivate
       end
     end

--- a/db/migrate/20190225111223_add_active_to_agreements.rb
+++ b/db/migrate/20190225111223_add_active_to_agreements.rb
@@ -1,0 +1,6 @@
+class AddActiveToAgreements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :agreements, :active, :boolean, default: true
+    add_index :agreements, :active
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_29_173334) do
+ActiveRecord::Schema.define(version: 2019_02_25_111223) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -49,6 +49,8 @@ ActiveRecord::Schema.define(version: 2019_01_29_173334) do
   create_table "agreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "framework_id", null: false
     t.uuid "supplier_id", null: false
+    t.boolean "active", default: true
+    t.index ["active"], name: "index_agreements_on_active"
     t.index ["framework_id"], name: "index_agreements_on_framework_id"
     t.index ["supplier_id"], name: "index_agreements_on_supplier_id"
   end

--- a/spec/features/admin_can_view_suppliers_spec.rb
+++ b/spec/features/admin_can_view_suppliers_spec.rb
@@ -21,12 +21,6 @@ RSpec.feature 'Admin users can' do
       expect(page).to have_content 'Last Supplier'
     end
 
-    scenario 'view a supplier' do
-      visit admin_suppliers_path
-      click_on 'First Supplier'
-      expect(page).to have_content 'First Supplier'
-    end
-
     scenario 'find a supplier' do
       visit admin_suppliers_path
       fill_in 'Search', with: 'ast Supp'

--- a/spec/features/admin_can_view_suppliers_spec.rb
+++ b/spec/features/admin_can_view_suppliers_spec.rb
@@ -1,14 +1,6 @@
 require 'rails_helper'
 
 RSpec.feature 'Admin users can' do
-  context 'when there are no suppliers' do
-    scenario 'view the empty state' do
-      sign_in_as_admin
-      visit admin_suppliers_path
-      expect(page).to have_content 'No suppliers.'
-    end
-  end
-
   context 'when there are suppliers' do
     before do
       FactoryBot.create(:supplier, name: 'First Supplier')

--- a/spec/features/managing_supplier_frameworks_spec.rb
+++ b/spec/features/managing_supplier_frameworks_spec.rb
@@ -21,6 +21,27 @@ RSpec.describe 'Managing supplier frameworks' do
 
     within "#framework-#{framework.id}" do
       expect(page).to have_content('Inactive')
+      expect(page).to have_link 'Activate'
+    end
+  end
+
+  scenario 'a supplier can be re-activated on a framework' do
+    agreement.deactivate!
+
+    click_on 'Suppliers'
+    click_on supplier.name
+
+    within "#framework-#{framework.id}" do
+      click_on 'Activate'
+    end
+
+    click_on 'Activate Supplier Ltd on RM-ABC'
+
+    expect(page).to have_content('Activated on RM-ABC')
+
+    within "#framework-#{framework.id}" do
+      expect(page).to have_content('Active')
+      expect(page).to have_link 'Deactivate'
     end
   end
 end

--- a/spec/features/managing_supplier_frameworks_spec.rb
+++ b/spec/features/managing_supplier_frameworks_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Managing supplier frameworks' do
+  let!(:supplier) { FactoryBot.create(:supplier, name: 'Supplier Ltd') }
+  let!(:framework) { FactoryBot.create(:framework, short_name: 'RM-ABC') }
+  let!(:agreement) { FactoryBot.create(:agreement, supplier: supplier, framework: framework) }
+
+  before { sign_in_as_admin }
+
+  scenario 'a supplier can be deactivated from a framework' do
+    click_on 'Suppliers'
+    click_on supplier.name
+
+    within "#framework-#{framework.id}" do
+      click_on 'Deactivate'
+    end
+
+    click_on 'Deactivate Supplier Ltd from RM-ABC'
+
+    expect(page).to have_content('Deactivated from RM-ABC')
+
+    within "#framework-#{framework.id}" do
+      expect(page).to have_content('Inactive')
+    end
+  end
+end

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -14,4 +14,11 @@ RSpec.describe Agreement do
     agreement.deactivate!
     expect(agreement).not_to be_active
   end
+
+  it 'can be activated' do
+    agreement = FactoryBot.create(:agreement, active: false)
+
+    agreement.activate!
+    expect(agreement).to be_active
+  end
 end

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -3,9 +3,15 @@ require 'rails_helper'
 RSpec.describe Agreement do
   it 'does not allow a supplier to have more than one agreement against the same framework' do
     agreement = FactoryBot.create(:agreement)
-
     duplicate_agreement = agreement.supplier.agreements.new(framework: agreement.framework)
 
     expect(duplicate_agreement).not_to be_valid
+  end
+
+  it 'can be deactivated' do
+    agreement = FactoryBot.create(:agreement, active: true)
+
+    agreement.deactivate!
+    expect(agreement).not_to be_active
   end
 end

--- a/spec/models/task/generator_spec.rb
+++ b/spec/models/task/generator_spec.rb
@@ -7,12 +7,13 @@ RSpec.describe Task::Generator do
     context 'given some agreements' do
       let!(:agreement_1) { FactoryBot.create(:agreement) }
       let!(:agreement_2) { FactoryBot.create(:agreement) }
+      let!(:inactive_agreement) { FactoryBot.create(:agreement, active: false) }
       let!(:supplier_1) { agreement_1.supplier }
       let!(:supplier_2) { agreement_2.supplier }
       let!(:framework_1) { agreement_1.framework }
       let!(:framework_2) { agreement_2.framework }
 
-      it 'creates a new task for the specified period for each agreement, with a due date 7 days into the month' do
+      it 'creates a new task for the specified period for active agreements, with a due date 7 days into the month' do
         expect { Task::Generator.new(month: 8, year: 2018).generate! }.to change { Task.count }.by 2
 
         supplier_1_task = supplier_1.tasks.first


### PR DESCRIPTION
It's occasionally required that a supplier be "turned off" from a framework they have been participating in. This gives admin users the ability to deactivate/activate a supplier on their frameworks. An inactive agreement will not generate monthly task when submission window rolls around.

![screenshot 2019-02-25 at 14 21 08](https://user-images.githubusercontent.com/3687/53343624-ae66b900-3908-11e9-9abf-41ec8be8aa34.png)

https://trello.com/c/ctOIXvgz/721-admin-can-end-suppliers-involvement-in-framework