### PR TITLE
841 task generation scheduled with sidekiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,15 @@ A [full list of the API endpoints](endpoints.md) is available in a separate docu
 See [this guide](docs/onboarding-suppliers.md) for details on onboarding suppliers
 and their users.
 
+## Scheduled jobs
+
+Job scheduling is handled using the sidekiq-cron gem, with the schedule
+defined in config/sidekiq_schedule.yml.
+
 ## Generating monthly tasks
 
-Monthly tasks are be generated manually using the following rake task:
-
-```
-  # Generates tasks based on existing agreements for September 2018
-  $ rake generate:tasks[9,2018]
-```
+The monthly tasks for suppliers are generated on the 1st of the month via the
+sidekiq schedule described above.
 
 ## Reporting rake tasks
 

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -2,3 +2,7 @@ queue_size_metric:
   cron: "*/30 * * * * *"
   class: "QueueSizeMetricJob"
   queue: default
+monthly_tasks_generation:
+  cron: '0 2 1 * *'
+  class: 'MonthlyTasksGenerationJob'
+  queue: default

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -1,9 +1,4 @@
 namespace :generate do
-  desc 'Queues a job to generate the tasks for the current month'
-  task tasks: :environment do
-    MonthlyTasksGenerationJob.perform_later
-  end
-
   desc 'Generates CSV of late submission contacts for a given window'
   task :late_tasks, %i[period_month year] => [:environment] do |_task, args|
     year         = args[:year]&.to_i         || Time.zone.today.year


### PR DESCRIPTION
Now we have the sidekick-cron gem, we can generate monthly tasks using a job schedule, which is both lighter-weight and also more visible than the old way, which was defined in the project terraform and worked by spinning up a container to run the rake task on a schedule.