### PR TITLE
(815) Allow only selected fields for a Task to be returned

### DIFF
--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -3,6 +3,7 @@ class V1::TasksController < APIController
 
   def index
     tasks = current_user.tasks
+    tasks = tasks.includes(:supplier).includes(requested_associations)
     tasks = tasks.where(status: params.dig(:filter, :status)) if params.dig(:filter, :status)
 
     render jsonapi: tasks, include: params.dig(:include), fields: sparse_field_params
@@ -69,5 +70,9 @@ class V1::TasksController < APIController
 
   def replacement_return?
     params.dig('_jsonapi', 'replacement').to_s.downcase == 'true'
+  end
+
+  def requested_associations
+    params.fetch(:include, '').split(',').map(&:to_sym)
   end
 end

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -5,7 +5,7 @@ class V1::TasksController < APIController
     tasks = current_user.tasks
     tasks = tasks.where(status: params.dig(:filter, :status)) if params.dig(:filter, :status)
 
-    render jsonapi: tasks, include: params.dig(:include)
+    render jsonapi: tasks, include: params.dig(:include), fields: sparse_field_params
   end
 
   def show
@@ -60,6 +60,11 @@ class V1::TasksController < APIController
   def task_params
     params.require(:task).permit(:supplier_id, :framework_id, :status, :due_on,
                                  :period_month, :period_year, :description)
+  end
+
+  def sparse_field_params
+    fields_param = params.permit(fields: {}).to_h[:fields] || {}
+    Hash[fields_param.map { |k, v| [k.to_sym, v.split(',').map!(&:to_sym)] }]
   end
 
   def replacement_return?

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -4,7 +4,6 @@ class V1::TasksController < APIController
   def index
     tasks = current_user.tasks
     tasks = tasks.where(status: params.dig(:filter, :status)) if params.dig(:filter, :status)
-    tasks = tasks.where(supplier_id: params.dig(:filter, :supplier_id)) if params.dig(:filter, :supplier_id)
 
     render jsonapi: tasks, include: params.dig(:include)
   end

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -105,26 +105,6 @@ RSpec.describe '/v1' do
     end
   end
 
-  describe 'GET /tasks?filter[supplier_id]=' do
-    it 'returns a filtered list of tasks for a supplier' do
-      current_supplier = FactoryBot.create(:supplier)
-      another_supplier = FactoryBot.create(:supplier)
-
-      user.memberships.create(supplier: current_supplier)
-      user.memberships.create(supplier: another_supplier)
-
-      FactoryBot.create(:task, supplier: current_supplier, description: 'hello')
-      FactoryBot.create(:task, supplier: another_supplier)
-
-      get "/v1/tasks?filter[supplier_id]=#{current_supplier.id}", headers: { 'X-Auth-Id' => user.auth_id }
-
-      expect(response).to be_successful
-
-      expect(json['data'].size).to eql 1
-      expect(json['data'][0]).to have_attribute(:description).with_value('hello')
-    end
-  end
-
   describe 'GET /v1/tasks/:task_id' do
     it 'returns the details of a given task' do
       task = FactoryBot.create(


### PR DESCRIPTION
Implements JSON API's [sparse fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets) feature on the `GET /tasks` endpoint. This will us to control which model attributes are included in the response.

The frontend can then request only the attributes it needs, eliminating costly database queries on those it doesn't.