### PR TITLE
Chore/remove rubocop warning

### DIFF
--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -59,7 +59,7 @@ class Framework
     end
 
     # Require all the framework definitions up-front
-    Dir['app/models/framework/definition/*'].each do |definition|
+    Dir['app/models/framework/definition/*.rb'].each do |definition|
       # `Dir` needs an app-relative path argument, but `require` needs one relative to
       # the $LOAD_PATH. Remove app/models/ to e.g. only `require 'framework/definition/RM1234'`
       relative_definition = Pathname(definition).sub('app/models/', '').sub_ext('').to_s

--- a/app/validators/dependent_field_inclusion_validator.rb
+++ b/app/validators/dependent_field_inclusion_validator.rb
@@ -7,7 +7,7 @@ class DependentFieldInclusionValidator < ActiveModel::EachValidator
     mapping = options[:in]
 
     valid_values = mapping.dig(parent_field_name, parent_field_value_lookup)&.map(&:downcase) || []
-    return if value&.downcase.in?(valid_values)
+    return if value&.downcase&.in?(valid_values)
 
     record.errors.add(
       attribute,


### PR DESCRIPTION
There's a bit of build noise with a Rubocop warning that we can avoid, so remove it.

Also, make it easier to switch between the framework definition language branch and this one by only requiring `.rb` files as framework definitions – git leaves directories behind when @lozette and I switch, which breaks the build on every other branch, so introduce this to `develop` ahead of time.