### PR TITLE
(834) Expose the temporary_download_url for a SubmissionFile

### DIFF
--- a/app/controllers/v1/submission_file_blobs_controller.rb
+++ b/app/controllers/v1/submission_file_blobs_controller.rb
@@ -7,7 +7,9 @@ class V1::SubmissionFileBlobsController < APIController
     submission_file = SubmissionFile.find(params[:file_id])
     submission_file.file_blob = ActiveStorage::Blob.new(file_blob_params)
 
-    render jsonapi: submission_file, status: :created
+    render jsonapi: submission_file,
+           status: :created,
+           fields: { submission_files: %i[submission_id rows filename] }
   end
 
   private

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -7,4 +7,8 @@ class SubmissionFile < ApplicationRecord
   def filename
     file.attachment.filename.to_s if file.attached?
   end
+
+  def temporary_download_url
+    file.attachment.service_url if file.attached?
+  end
 end

--- a/app/serializable/serializable_submission_file.rb
+++ b/app/serializable/serializable_submission_file.rb
@@ -4,4 +4,5 @@ class SerializableSubmissionFile < JSONAPI::Serializable::Resource
   attribute :submission_id
   attribute :rows
   attribute :filename
+  attribute :temporary_download_url
 end

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -15,4 +15,18 @@ RSpec.describe SubmissionFile do
       expect(SubmissionFile.new.filename).to be_nil
     end
   end
+
+  describe '#temporary_download_url' do
+    it 'returns the temporary download URL of the attachment' do
+      submission_file = FactoryBot.create(:submission_file, :with_attachment, filename: 'not-really-an.xls')
+
+      expect(submission_file.temporary_download_url)
+        .to start_with('http://s3.example.com')
+        .and end_with('not-really-an.xls')
+    end
+
+    it 'returns nil if no file attachment exists' do
+      expect(SubmissionFile.new.temporary_download_url).to be_nil
+    end
+  end
 end

--- a/spec/serializable/serializable_submission_file_spec.rb
+++ b/spec/serializable/serializable_submission_file_spec.rb
@@ -2,11 +2,17 @@ require 'rails_helper'
 
 RSpec.describe SerializableSubmissionFile do
   context 'given a submission file with an attachment' do
-    let(:submission_file) { FactoryBot.create(:submission_file, :with_attachment) }
+    let(:submission_file) { FactoryBot.create(:submission_file, :with_attachment, filename: 'not-really-an.xls') }
     let(:serialized_submission_file) { SerializableSubmissionFile.new(object: submission_file) }
 
     it 'exposes the filename of the attached file' do
       expect(serialized_submission_file.as_jsonapi[:attributes][:filename]).to eql 'not-really-an.xls'
+    end
+
+    it 'exposes the temporary download URL of the attached file' do
+      expect(serialized_submission_file.as_jsonapi[:attributes][:temporary_download_url])
+        .to start_with('http://s3.example.com')
+        .and end_with('not-really-an.xls')
     end
   end
 end

--- a/spec/support/active_storage.rb
+++ b/spec/support/active_storage.rb
@@ -1,4 +1,8 @@
 RSpec.configure do |config|
+  config.before(:each) do
+    ActiveStorage::Current.host = 's3.example.com'
+  end
+
   config.after(:each) do
     FileUtils.rm_rf Rails.root.join('tmp', 'storage')
   end


### PR DESCRIPTION
In order for frontend to give a user to download their previous submissions, we need to expose the temporary download URL through the API.

This is generated using the `service_url` method which behaves differently in the test environment, because it attempts to generate a local filesystem path and fails because the hostname isn't set.

To workaround this, I've stubbed this method on `ActiveStorage::Blob` in order to test my new `temporary_download_url` method.

Note that I've modified the fields that are returned by the `POST /v1/files/blobs` endpoint to exclude `temporary_download_url` from the list of results to prevent test failures (it won't be used anyway)