### PR TITLE
Fix spec time-bomb

### DIFF
--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :task do
     status 'unstarted'
-    period_month { Time.zone.today.last_month.month }
-    period_year  { Time.zone.today.last_month.year }
-    due_on { Time.zone.today.beginning_of_month + 7.days }
+    period_month 1
+    period_year  2019
+    due_on       Date.strptime('2019-02-28').beginning_of_month + 7.days
 
     supplier
     framework

--- a/spec/models/task/late_generator_spec.rb
+++ b/spec/models/task/late_generator_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe Task::LateGenerator do
         create :membership, user: alice, supplier: supplier_a
         create :membership, user: bob, supplier: supplier_b
 
-        create :task, supplier: supplier_a, framework: framework1
-        create :task, supplier: supplier_a, framework: framework2
-        create :task, supplier: supplier_b, framework: framework1
-        create :task, supplier: supplier_b, framework: framework2
+        create :task, supplier: supplier_a, framework: framework1, period_month: 1
+        create :task, supplier: supplier_a, framework: framework2, period_month: 1
+        create :task, supplier: supplier_b, framework: framework1, period_month: 1
+        create :task, supplier: supplier_b, framework: framework2, period_month: 1
 
         create :task, :completed, supplier: supplier_a, framework: framework3
 


### PR DESCRIPTION
late_generator_spec (now overdue_user_notification_list_spec)
stopped running on 1st March, because we weren't creating tasks for the
test period window, so the factories were creating tasks with a
period_month last_month, hence creating an expiring test.

Create overdue user spec tasks with an explicit period_month, and also
fix dates to Jan 2019 in the tasks factory such that it's harder to
accidentally create expiring tests.