### PR TITLE
Respond with latest submission for nochange

### DIFF
--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -30,7 +30,7 @@ class V1::TasksController < APIController
     task = current_user.tasks.find(params[:id])
 
     if task.completed? && !correcting_submission?
-      render jsonapi: task.submissions.first
+      render jsonapi: task.latest_submission
       return
     end
 

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -229,12 +229,11 @@ RSpec.describe '/v1' do
     end
 
     context 'if task already completed' do
-      it 'should do nothing and return succesfully' do
-        task.file_no_business!(user)
+      it 'should do nothing and return the latest submission' do
+        FactoryBot.create(:submission, task: task)
+        submission = task.file_no_business!(user)
 
         post "/v1/tasks/#{task.id}/no_business", headers: { 'X-Auth-Id' => user.auth_id }
-
-        submission = task.submissions.last
 
         expect(json['data']).to have_id submission.id
       end


### PR DESCRIPTION
Previously, when a user tried to resubmit no business against a task which already had a completed no business return, we did nothing and returned the *first* submission against that task.

This may not have been the latest submission. This commit ensures that we always return the latest submission, rather than a random one.

This has no Trello card.