### PR TITLE
891 Alternative column management charge calculation

### DIFF
--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -36,20 +36,12 @@ class Framework
           @framework_short_name ||= framework_short_name
         end
 
-        ##
-        # E.g. BigDecimal.new('1.5')
-        def management_charge_rate(calculator = nil)
-          @management_charge_rate ||= begin
-                                        if calculator.is_a?(BigDecimal)
-                                          ManagementChargeCalculator::FlatRate.new(percentage: calculator)
-                                        else
-                                          calculator
-                                        end
-                                      end
+        def management_charge(calculator = nil)
+          @management_charge ||= calculator
         end
 
         def calculate_management_charge(entry)
-          management_charge_rate.calculate_for(entry)
+          management_charge.calculate_for(entry)
         end
 
         def for_entry_type(entry_type)

--- a/app/models/framework/definition/CM_OSG_05_3565.rb
+++ b/app/models/framework/definition/CM_OSG_05_3565.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'CM/OSG/05/3565'
       framework_name       'Laundry Services - Wave 2'
 
-      management_charge_rate BigDecimal('0')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('0'))
 
       class Invoice < EntryData
         total_value_field 'Total Spend'

--- a/app/models/framework/definition/RM1031.rb
+++ b/app/models/framework/definition/RM1031.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM1031'
       framework_name       'Laundry and Linen Services (RM1031)'
 
-      management_charge_rate BigDecimal('0.5')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('0.5'))
 
       class Invoice < EntryData
         total_value_field 'Total Charge (Ex VAT)'

--- a/app/models/framework/definition/RM1043_5.rb
+++ b/app/models/framework/definition/RM1043_5.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM1043.5'
       framework_name 'Digital Outcomes and Specialists 3'
 
-      management_charge_rate BigDecimal('1')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('1'))
 
       UNIT_OF_MEASURE_VALUES = [
         'Day',

--- a/app/models/framework/definition/RM1070.rb
+++ b/app/models/framework/definition/RM1070.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM1070'
       framework_name       'Vehicle Purchase (RM1070)'
 
-      management_charge_rate BigDecimal('0.5')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('0.5'))
 
       class Invoice < EntryData
         total_value_field 'Total Supplier price including standard factory fit options but excluding conversion costs and work ex VAT'

--- a/app/models/framework/definition/RM3710.rb
+++ b/app/models/framework/definition/RM3710.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM3710'
       framework_name       'Vehicle Lease and Fleet Management'
 
-      management_charge_rate ManagementChargeCalculator::ColumnBased.new(
+      management_charge ManagementChargeCalculator::ColumnBased.new(
         column: 'Spend Code',
         value_to_percentage: {
           'Lease Rental': BigDecimal('0.5'),

--- a/app/models/framework/definition/RM3754.rb
+++ b/app/models/framework/definition/RM3754.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM3754'
       framework_name       'Vehicle Telematics'
 
-      management_charge_rate BigDecimal('0.5')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('0.5'))
 
       PAYMENT_PROFILES = [
         'Monthly',

--- a/app/models/framework/definition/RM3756.rb
+++ b/app/models/framework/definition/RM3756.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM3756'
       framework_name       'Rail Legal Services'
 
-      management_charge_rate BigDecimal('1.5')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('1.5'))
 
       SERVICE_TYPE_VALUES = [
         'Core',

--- a/app/models/framework/definition/RM3767.rb
+++ b/app/models/framework/definition/RM3767.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM3767'
       framework_name       'Supply and Fit of Tyres (RM3767)'
 
-      management_charge_rate BigDecimal('1')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('1'))
 
       PRODUCT_TYPES = [
         'Tyre - Supply ONLY',

--- a/app/models/framework/definition/RM3772.rb
+++ b/app/models/framework/definition/RM3772.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM3772'
       framework_name       'Specialist Laundry Services (for Surgical Gowns, D'
 
-      management_charge_rate BigDecimal('0.5')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('0.5'))
 
       class Invoice < EntryData
         total_value_field 'Total Charge (Ex VAT)'

--- a/app/models/framework/definition/RM3786.rb
+++ b/app/models/framework/definition/RM3786.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM3786'
       framework_name       'General Legal Advice Services'
 
-      management_charge_rate BigDecimal('1.5')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('1.5'))
 
       SERVICE_TYPE_VALUES = [
         'Core',

--- a/app/models/framework/definition/RM3787.rb
+++ b/app/models/framework/definition/RM3787.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM3787'
       framework_name       'Finance & Complex Legal Services'
 
-      management_charge_rate BigDecimal('1.5')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('1.5'))
 
       SERVICE_TYPE_VALUES = [
         'Core',

--- a/app/models/framework/definition/RM3797.rb
+++ b/app/models/framework/definition/RM3797.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM3797'
       framework_name       'Journal Subscriptions'
 
-      management_charge_rate BigDecimal('1')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('1'))
 
       PRODUCT_GROUPS = [
         'Print Journal',

--- a/app/models/framework/definition/RM6060.rb
+++ b/app/models/framework/definition/RM6060.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM6060'
       framework_name       'Vehicle Purchase'
 
-      management_charge_rate BigDecimal('0.5')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('0.5'))
 
       LOT_1_SEGMENTS = [
         '4x4/SUV',

--- a/app/models/framework/definition/RM6060.rb
+++ b/app/models/framework/definition/RM6060.rb
@@ -4,7 +4,9 @@ class Framework
       framework_short_name 'RM6060'
       framework_name       'Vehicle Purchase'
 
-      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('0.5'))
+      management_charge ManagementChargeCalculator::FlatRate.new(
+        column: 'Supplier Price', percentage: BigDecimal('0.5')
+      )
 
       LOT_1_SEGMENTS = [
         '4x4/SUV',

--- a/app/models/framework/definition/RM807.rb
+++ b/app/models/framework/definition/RM807.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM807'
       framework_name       'Vehicle Hire (RM807)'
 
-      management_charge_rate BigDecimal('0.5')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('0.5'))
 
       class Invoice < EntryData
         total_value_field 'Total Charges (ex VAT)'

--- a/app/models/framework/definition/RM849.rb
+++ b/app/models/framework/definition/RM849.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM849'
       framework_name       'Laundry & Linen Services Framework'
 
-      management_charge_rate BigDecimal('0.5')
+      management_charge ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('0.5'))
 
       class Invoice < EntryData
         total_value_field 'Invoice Line Total Value ex VAT and Expenses'

--- a/app/models/framework/definition/RM858.rb
+++ b/app/models/framework/definition/RM858.rb
@@ -4,7 +4,7 @@ class Framework
       framework_short_name 'RM858'
       framework_name       'Pan Govt Vehicle Leasing & Fleet Outsource Solutio'
 
-      management_charge_rate ManagementChargeCalculator::ColumnBased.new(
+      management_charge ManagementChargeCalculator::ColumnBased.new(
         column: 'Spend Code',
         value_to_percentage: {
           'Lease Rental': BigDecimal('0.5'),

--- a/app/models/framework/management_charge_calculator/flat_rate.rb
+++ b/app/models/framework/management_charge_calculator/flat_rate.rb
@@ -1,14 +1,31 @@
 class Framework
   module ManagementChargeCalculator
+    # Calculates flat-rate management charges.
+    #
+    # By default the calculation is made against the total_value of the
+    # submission entry. For frameworks where the management charge needs to be
+    # calculated against another column, that can be specified with the `column`
+    # attribute.
     class FlatRate
       attr_reader :percentage
 
-      def initialize(percentage:)
+      def initialize(percentage:, column: nil)
         @percentage = BigDecimal(percentage)
+        @column = column
       end
 
       def calculate_for(entry)
-        (entry.total_value * (percentage / 100)).truncate(4)
+        (entry_value(entry) * (percentage / 100)).truncate(4)
+      end
+
+      private
+
+      def entry_value(entry)
+        overridding_calculation_column? ? entry.data[@column].to_d : entry.total_value
+      end
+
+      def overridding_calculation_column?
+        @column.present?
       end
     end
   end

--- a/db/data_migrate/20190306141656_recalculate_rm6060_submissions.rb
+++ b/db/data_migrate/20190306141656_recalculate_rm6060_submissions.rb
@@ -1,0 +1,17 @@
+# Re-calculates the management charge on all RM6060 submissons that have had
+# their management charge calculated, i.e. those that are in_review or completed.
+#
+# Execute with:
+#
+#   rails runner db/data_migrate/20190306141656_recalculate_rm6060_submissions.rb
+#
+rm6060 = Framework.find_by(short_name: 'RM6060')
+submissions = Submission.where(framework: rm6060, aasm_state: %i[in_review completed])
+
+submissions.each do |submission|
+  puts "Submission #{submission.id} charge: #{submission.management_charge}"
+  submission.entries.invoices.find_each do |entry|
+    entry.update! management_charge: rm6060.definition.calculate_management_charge(entry)
+  end
+  puts "Recalculated charge: #{submission.management_charge}"
+end

--- a/spec/models/framework/definition_spec.rb
+++ b/spec/models/framework/definition_spec.rb
@@ -44,10 +44,23 @@ RSpec.describe Framework::Definition do
     end
   end
 
+  describe 'Base.management_charge' do
+    let(:definition_class) do
+      Class.new(Framework::Definition::Base) do
+        management_charge Framework::ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('5'))
+      end
+    end
+
+    it 'acts as setter and getter for the calculator' do
+      expect(definition_class.management_charge).to be_a(Framework::ManagementChargeCalculator::FlatRate)
+      expect(definition_class.management_charge.percentage).to eq(BigDecimal('5'))
+    end
+  end
+
   describe 'Base.calculate_management_charge' do
     let(:definition_class) do
       Class.new(Framework::Definition::Base) do
-        management_charge_rate BigDecimal('1.5')
+        management_charge Framework::ManagementChargeCalculator::FlatRate.new(percentage: BigDecimal('1.5'))
       end
     end
 

--- a/spec/models/framework/definition_spec.rb
+++ b/spec/models/framework/definition_spec.rb
@@ -45,12 +45,16 @@ RSpec.describe Framework::Definition do
   end
 
   describe 'Base.calculate_management_charge' do
-    it 'returns the management charge based on the framework’s management charge rate, rounded to 4 decimal places' do
+    let(:definition_class) do
+      Class.new(Framework::Definition::Base) do
+        management_charge_rate BigDecimal('1.5')
+      end
+    end
+
+    it 'returns the management charge calculation, rounded to 4 decimal places' do
       entry = double('entry', total_value: BigDecimal('102123.23'))
 
-      expect(Framework::Definition::RM3756.calculate_management_charge(entry)).to eq BigDecimal('1531.8484')
-      expect(Framework::Definition::RM1070.calculate_management_charge(entry)).to eq BigDecimal('510.6161')
-      expect(Framework::Definition::CM_OSG_05_3565.calculate_management_charge(entry)).to eq BigDecimal('0')
+      expect(definition_class.calculate_management_charge(entry)).to eq BigDecimal('1531.8484')
     end
   end
 

--- a/spec/models/framework/definition_spec.rb
+++ b/spec/models/framework/definition_spec.rb
@@ -10,20 +10,12 @@ RSpec.describe Framework::Definition do
         it 'returns that framework' do
           expect(definition.framework_short_name).to eql(framework_short_name)
         end
-
-        it 'reports the management charge' do
-          expect(definition.management_charge_rate.percentage).to eq(BigDecimal('1.5'))
-        end
       end
 
       context 'and it has slashes in it' do
         let(:framework_short_name) { 'CM/OSG/05/3565' }
         it 'returns that framework' do
           expect(definition.framework_short_name).to eql(framework_short_name)
-        end
-
-        it 'reports the management charge' do
-          expect(definition.management_charge_rate.percentage).to eq(BigDecimal('0'))
         end
       end
 
@@ -32,10 +24,6 @@ RSpec.describe Framework::Definition do
 
         it 'returns that framework' do
           expect(definition.framework_short_name).to eql(framework_short_name)
-        end
-
-        it 'reports the management charge' do
-          expect(definition.management_charge_rate.percentage).to eq(BigDecimal('1'))
         end
       end
     end

--- a/spec/models/framework/management_charge_calculator/flat_rate_spec.rb
+++ b/spec/models/framework/management_charge_calculator/flat_rate_spec.rb
@@ -1,10 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe Framework::ManagementChargeCalculator::FlatRate do
-  it 'calculates the management charge for an entry, using a flat rate' do
-    entry = FactoryBot.create(:submission_entry, total_value: 180)
-    calculator = Framework::ManagementChargeCalculator::FlatRate.new(percentage: 5)
+  let(:calculator) { Framework::ManagementChargeCalculator::FlatRate.new(calculator_arguments) }
 
-    expect(calculator.calculate_for(entry)).to eql(9) # 5% of 180 = 9
+  describe '#calculate_for' do
+    let(:calculator_arguments) { { percentage: BigDecimal('1.5') } }
+    let(:entry) { FactoryBot.build(:submission_entry, total_value: 102123.23) }
+
+    it 'calculates the management charge as a percentage of the total value to 4 decimal places' do
+      expect(calculator.calculate_for(entry)).to eql(BigDecimal('1531.8484'))
+    end
+
+    context 'with the calculation field overriden' do
+      let(:calculator_arguments) { { percentage: BigDecimal('0.5'), column: 'Some field' } }
+
+      context 'and a Float value' do
+        let(:entry) { FactoryBot.build(:submission_entry, total_value: 1234, data: { 'Some field' => 548.68 }) }
+
+        it 'correctly calculates and truncates the management charge' do
+          expect(calculator.calculate_for(entry)).to eql(BigDecimal('2.7434'))
+        end
+      end
+
+      context 'and a String value' do
+        let(:entry) { FactoryBot.build(:submission_entry, total_value: 1234, data: { 'Some field' => '548.68' }) }
+
+        it 'correctly calculates and truncates the management charge' do
+          expect(calculator.calculate_for(entry)).to eql(BigDecimal('2.7434'))
+        end
+      end
+
+      context 'and an Integer value' do
+        let(:entry) { FactoryBot.build(:submission_entry, total_value: 1234, data: { 'Some field' => 200 }) }
+
+        it 'correctly calculates the management charge' do
+          expect(calculator.calculate_for(entry)).to eql(BigDecimal('1.0'))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds support for overriding the field on which the management charge is calculated for frameworks with a flat-rate calculation. This is so that we can correctly calculate the management charge for RM6060.