### PR TITLE
Ensure completed submissions are always the active one.

### DIFF
--- a/app/serializable/serializable_task.rb
+++ b/app/serializable/serializable_task.rb
@@ -2,6 +2,7 @@ class SerializableTask < JSONAPI::Serializable::Resource
   type 'tasks'
 
   has_one :latest_submission
+  has_one :active_submission
   has_many :submissions
   belongs_to :framework
 


### PR DESCRIPTION
When we add correction returns, we will enable Tasks to have a completed submission that is not the latest. Currently, the code assumes that if there is a completed submission, it would be the latest.

Instead, we want to always return the completed submission if one exists *even if* it's not the latest.

This commit is also the first commit to begin renaming the `latest_submission` relationship to `active_submission`.

It was decided that we want to keep this method as a relationship, for compatibility to JSONAPI API and reducing DB queries. This has resulted in a slightly convoluted SQL scope, due to how SQL's OR works.