### PR TITLE
Update "late" CSV for new GOV.UK Notify templates

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -40,4 +40,9 @@ class Task < ApplicationRecord
   def period_date
     Date.new(period_year, period_month)
   end
+
+  # Returns true when the task is yet to be completed by the Supplier
+  def incomplete?
+    !completed?
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -76,4 +76,19 @@ RSpec.describe Task do
       expect(task.period_date).to eq Date.new(2020, 5, 1)
     end
   end
+
+  describe '#incomplete?' do
+    let(:known_incomplete_states) { %i[unstarted in_progress] }
+    let(:all_states) { Task.aasm.states.map(&:name) }
+
+    it 'returns true for the known "incomplete" states' do
+      all_states.each do |state|
+        if known_incomplete_states.include?(state)
+          expect(Task.new(status: state)).to be_incomplete
+        else
+          expect(Task.new(status: state)).not_to be_incomplete
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
The GOV.UK Notify templates for late submissions has changed to a new format. This updates the CSV we generate to match the new templates.