### PR TITLE
Implement single-level lookups on RM3754

### DIFF
--- a/app/models/framework/definition/RM3754.fdl
+++ b/app/models/framework/definition/RM3754.fdl
@@ -15,19 +15,10 @@ Framework RM3754 {
     String Additional1 from 'Vehicle Registration No'
     UnitQuantity from 'Total Number of Units'
     InvoiceValue from 'Total Charge (ex VAT)'
-    PaymentProfile Additional2 from 'Payment Profile'
+    String Additional2 from 'Payment Profile'
     VATCharged from 'VAT amount charged'
     optional String Additional3 from 'Subcontractor Supplier Name'
     optional String from 'Cost Centre'
     optional String from 'Contract Number'
-  }
-
-  Lookups {
-    PaymentProfile [
-      'Monthly'
-      'Quarterly'
-      'Annual'
-      'One-off'
-    ]
   }
 }

--- a/app/models/framework/definition/RM3754.fdl
+++ b/app/models/framework/definition/RM3754.fdl
@@ -1,0 +1,33 @@
+Framework RM3754 {
+  Name 'Vehicle Telematics'
+  ManagementCharge 0.5%
+
+  InvoiceFields {
+    CustomerURN from 'Customer URN'
+    optional CustomerPostCode from 'Customer PostCode'
+    CustomerName from 'Customer Organisation'
+    InvoiceDate from 'Customer Invoice Date'
+    InvoiceNumber from 'Customer Invoice Number'
+    ProductDescription from 'Product Description'
+    UNSPSC from 'UNSPSC'
+    UnitType from 'Unit of Purchase'
+    UnitPrice from 'Price per Unit'
+    String Additional1 from 'Vehicle Registration No'
+    UnitQuantity from 'Total Number of Units'
+    InvoiceValue from 'Total Charge (ex VAT)'
+    PaymentProfile Additional2 from 'Payment Profile'
+    VATCharged from 'VAT amount charged'
+    optional String Additional3 from 'Subcontractor Supplier Name'
+    optional String from 'Cost Centre'
+    optional String from 'Contract Number'
+  }
+
+  Lookups {
+    PaymentProfile [
+      'Monthly'
+      'Quarterly'
+      'Annual'
+      'One-off'
+    ]
+  }
+}

--- a/app/models/framework/definition/RM3754.fdl
+++ b/app/models/framework/definition/RM3754.fdl
@@ -21,4 +21,13 @@ Framework RM3754 {
     optional String from 'Cost Centre'
     optional String from 'Contract Number'
   }
+
+  Lookups {
+    PaymentProfile [
+      'Monthly'
+      'Quarterly'
+      'Annual'
+      'One-off'
+    ]
+  }
 }

--- a/app/models/framework/definition/RM3754.fdl
+++ b/app/models/framework/definition/RM3754.fdl
@@ -15,7 +15,7 @@ Framework RM3754 {
     String Additional1 from 'Vehicle Registration No'
     UnitQuantity from 'Total Number of Units'
     InvoiceValue from 'Total Charge (ex VAT)'
-    PaymentProfile Additional2 from 'Payment Profile'
+    optional PaymentProfile Additional2 from 'Payment Profile'
     VATCharged from 'VAT amount charged'
     optional String Additional3 from 'Subcontractor Supplier Name'
     optional String from 'Cost Centre'

--- a/app/models/framework/definition/RM3754.fdl
+++ b/app/models/framework/definition/RM3754.fdl
@@ -15,7 +15,7 @@ Framework RM3754 {
     String Additional1 from 'Vehicle Registration No'
     UnitQuantity from 'Total Number of Units'
     InvoiceValue from 'Total Charge (ex VAT)'
-    String Additional2 from 'Payment Profile'
+    PaymentProfile Additional2 from 'Payment Profile'
     VATCharged from 'VAT amount charged'
     optional String Additional3 from 'Subcontractor Supplier Name'
     optional String from 'Cost Centre'
@@ -31,3 +31,4 @@ Framework RM3754 {
     ]
   }
 }
+

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -29,8 +29,25 @@ class Framework
         end
 
         # Lookups
+        # {
+        #   lookup_name: 'UnitType',
+        #   list: [{ :string => 'Day' }, { :string => 'Each' }]
+        # } =>
+        #   { 'UnitType' => ['Day', 'Each'] }
         rule(lookup_name: simple(:lookup_name), list: sequence(:values)) do
           { lookup_name.to_s => values }
+        end
+
+        #
+        # Take a list of lookups like
+        # { lookups: [{ 'UnitType' => ['Day', 'Each'] }, { 'Other' => ['Value 1', 'Value2'] }] }
+        # and produce a simplified tree like
+        # { 'UnitType' => ['Day', 'Each'], 'Other' => ['Value 1', 'Value 2'] }
+        rule(lookups: subtree(:lookups)) do
+          lookups.each_with_object({}) do |single_key_value, result|
+            lookup_name, value_list = *single_key_value.first
+            result[lookup_name] = value_list
+          end
         end
       end
     end

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -6,26 +6,26 @@ class Framework
       class Creator < Parslet::Transform
         rule(string: simple(:s))  { String(s) }
         rule(decimal: simple(:d)) { BigDecimal(d) }
-        rule(field: simple(:field), from: simple(:from)) { { field: field.to_s, from: from.to_s } }
 
         # match known fields only
+        rule(field: simple(:field), from: simple(:from)) { { kind: :known, field: field.to_s, from: from.to_s } }
         rule(optional: simple(:optional), field: simple(:field), from: simple(:from)) do
-          { optional: true, field: field.to_s, from: from.to_s }
+          { kind: :known, optional: true, field: field.to_s, from: from.to_s }
         end
 
         # optional Additional field rule
         rule(optional: simple(:optional), type: simple(:type), field: simple(:field), from: subtree(:from)) do
-          { optional: true, type: type.to_s, field: field.to_s, from: from }
+          { kind: :additional, optional: true, type: type.to_s, field: field.to_s, from: from }
         end
 
         # Additional field rule
         rule(type: simple(:type), field: simple(:field), from: subtree(:from)) do
-          { type: type.to_s, field: field.to_s, from: from }
+          { kind: :additional, type: type.to_s, field: field.to_s, from: from }
         end
 
         # Unknown fields rule
         rule(optional: simple(:optional), type: simple(:type), from: simple(:from)) do
-          { optional: true, type: type.to_s, from: from }
+          { kind: :unknown, optional: true, type: type.to_s, from: from }
         end
 
         # Lookups

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -27,6 +27,11 @@ class Framework
         rule(optional: simple(:optional), type: simple(:type), from: simple(:from)) do
           { optional: true, type: type.to_s, from: from }
         end
+
+        # Lookups
+        rule(lookup_name: simple(:lookup_name), list: sequence(:values)) do
+          { lookup_name.to_s => values }
+        end
       end
     end
   end

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -13,7 +13,7 @@ class Framework
             options[:exports_to] = field.warehouse_name
 
             add_known_type_validations! if field.known?
-            options.delete(:presence) if field.type == :urn # The URN validator covers this
+            options.delete(:presence) if field.primitive_type == :urn # The URN validator covers this
             set_optional_modifiers! if field.optional?
 
             options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
@@ -29,7 +29,7 @@ class Framework
 
           def add_known_type_validations!
             field_type = DataWarehouse::KnownFields.type_for(field.warehouse_name)
-            options.merge!(TYPE_VALIDATIONS.fetch(field_type))
+            options.merge!(PRIMITIVE_TYPE_VALIDATIONS.fetch(field_type))
           end
         end
       end

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -1,0 +1,38 @@
+class Framework
+  module Definition
+    module AST
+      class Field
+        class Options
+          attr_reader :field, :options
+          def initialize(field)
+            @field = field
+            @options = { presence: true }
+          end
+
+          def build(lookup_values)
+            options[:exports_to] = field.warehouse_name
+
+            add_known_type_validations! if field.known?
+            options.delete(:presence) if field.type == :urn # The URN validator covers this
+            set_optional_modifiers! if field.optional?
+
+            options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
+            options
+          end
+
+          private
+
+          def set_optional_modifiers!
+            options.delete(:presence)
+            options[:allow_nil] = true if field.validators?
+          end
+
+          def add_known_type_validations!
+            field_type = DataWarehouse::KnownFields.type_for(field.warehouse_name)
+            options.merge!(TYPE_VALIDATIONS.fetch(field_type))
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/ast/field_presenter.rb
+++ b/app/models/framework/definition/ast/field_presenter.rb
@@ -45,7 +45,7 @@ class Framework
         ##
         # The implementation type. Usually :string
         def activemodel_type
-          type == :urn ? :integer : :string
+          %i[integer urn].include?(type) ? :integer : :string
         end
 
         def validators?

--- a/app/models/framework/definition/data_warehouse/known_fields.rb
+++ b/app/models/framework/definition/data_warehouse/known_fields.rb
@@ -16,7 +16,10 @@ class Framework
           'UnitPrice' => :decimal,
           'UnitType' => :string,
           'VATIncluded' => :yesno,
-          'UnitQuantity' => :decimal
+          'UnitQuantity' => :decimal,
+          'InvoiceNumber' => :string,
+          'UNSPSC' => :integer,
+          'VATCharged' => :decimal
         }.freeze
 
         def self.type_for(value)

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -19,10 +19,12 @@ class Framework
       rule(:fields_block)         { braced(spaced(field_defs)) }
 
       rule(:field_defs)           { field_def.repeat(1) }
-      rule(:field_def)            { (unknown_field | known_field | additional_field) }
+      rule(:field_def)            { unknown_field | known_field | additional_field }
       rule(:known_field)          { optional >> pascal_case_identifier.as(:field) >> from_specifier }
-      rule(:additional_field)     { optional >> str('String').as(:type) >> space >> additional_field_identifier.as(:field) >> from_specifier }
-      rule(:unknown_field)        { optional >> str('String').as(:type) >> space >> from_specifier }
+      rule(:additional_field)     { optional >> type >> space >> additional_field_identifier.as(:field) >> from_specifier }
+      rule(:unknown_field)        { optional >> primitive_type >> space >> from_specifier }
+      rule(:type)                 { pascal_case_identifier.as(:type) }
+      rule(:primitive_type)       { str('String').as(:type) }
       rule(:from_specifier)       { spaced(str('from')) >> string.as(:from) }
       rule(:optional)             { spaced(str('optional').as(:optional).maybe) }
 

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -12,7 +12,7 @@ class Framework
       rule(:additional_field_identifier) { str('Additional') >> match('[0-9]').repeat(1) }
 
       rule(:framework_identifier) { match(%r{[A-Z0-9/]}).repeat(1).as(:string) }
-      rule(:framework_block)      { braced(spaced(metadata) >> spaced(invoice_fields) >> spaced(lookups_block).maybe) }
+      rule(:framework_block)      { braced(spaced(metadata) >> spaced(invoice_fields) >> spaced(lookups_block.as(:lookups)).maybe) }
       rule(:framework_name)       { str('Name') >> spaced(string.as(:framework_name)) }
       rule(:management_charge)    { str('ManagementCharge') >> spaced(percentage).as(:management_charge) }
       rule(:invoice_fields)       { str('InvoiceFields') >> spaced(fields_block.as(:invoice_fields)) }

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -12,7 +12,7 @@ class Framework
       rule(:additional_field_identifier) { str('Additional') >> match('[0-9]').repeat(1) }
 
       rule(:framework_identifier) { match(%r{[A-Z0-9/]}).repeat(1).as(:string) }
-      rule(:framework_block)      { braced(spaced(metadata) >> spaced(invoice_fields)) }
+      rule(:framework_block)      { braced(spaced(metadata) >> spaced(invoice_fields) >> spaced(lookups_block).maybe) }
       rule(:framework_name)       { str('Name') >> spaced(string.as(:framework_name)) }
       rule(:management_charge)    { str('ManagementCharge') >> spaced(percentage).as(:management_charge) }
       rule(:invoice_fields)       { str('InvoiceFields') >> spaced(fields_block.as(:invoice_fields)) }
@@ -23,10 +23,12 @@ class Framework
       rule(:known_field)          { optional >> pascal_case_identifier.as(:field) >> from_specifier }
       rule(:additional_field)     { optional >> str('String').as(:type) >> space >> additional_field_identifier.as(:field) >> from_specifier }
       rule(:unknown_field)        { optional >> str('String').as(:type) >> space >> from_specifier }
-
-      rule(:percentage)           { (decimal | integer).as(:flat_rate) >> str('%') >> space? }
       rule(:from_specifier)       { spaced(str('from')) >> string.as(:from) }
       rule(:optional)             { spaced(str('optional').as(:optional).maybe) }
+
+      rule(:lookups_block)        { str('Lookups') >> space >> braced(lookup_key_values.repeat(1)).as(:lookups) }
+      rule(:lookup_key_values)    { pascal_case_identifier.as(:lookup_name) >> space >> string_array }
+      rule(:string_array)         { square_bracketed(string.repeat(1).as(:list)) }
 
       rule(:metadata)             { framework_name >> management_charge }
 
@@ -35,14 +37,18 @@ class Framework
           str("'").absent? >> any
         ).repeat.as(:string) >> str("'") >> space?
       end
-      rule(:integer) { match(/[0-9]/).repeat >> space? }
-      rule(:decimal) { (integer >> (str('.') >> integer >> space?)).as(:decimal) >> space? }
+
+      rule(:integer)    { match(/[0-9]/).repeat >> space? }
+      rule(:decimal)    { (integer >> (str('.') >> integer >> space?)).as(:decimal) >> space? }
+      rule(:percentage) { (decimal | integer).as(:flat_rate) >> str('%') >> space? }
 
       rule(:space)   { match(/\s/).repeat(1) }
       rule(:space?)  { space.maybe }
 
       rule(:lbrace)  { str('{') >> space? }
       rule(:rbrace)  { str('}') >> space? }
+      rule(:lsquare) { str('[') >> space? }
+      rule(:rsquare) { str(']') >> space? }
 
       ##
       # It is often the case that we need spaces before and after
@@ -53,9 +59,16 @@ class Framework
 
       ##
       # braced(atom1 >> atom 2) reads better than
-      # lbrace >> atom 1 >> atom2 >> brace in most situations.
+      # lbrace >> atom 1 >> atom2 >> rbrace in most situations.
       def braced(atom)
         lbrace >> atom >> rbrace
+      end
+
+      ##
+      # square_bracketed(atom1 >> atom 2) reads better than
+      # lsquare >> atom 1 >> atom2 >> rsquare in most situations.
+      def square_bracketed(atom)
+        lsquare >> atom >> rsquare
       end
     end
   end

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -49,6 +49,7 @@ class Framework
       TYPE_VALIDATIONS = {
         string:  {},
         decimal: { ingested_numericality: true },
+        integer: { ingested_numericality: { only_integer: true } },
         urn:     { urn: true },
         date:    { ingested_date: true },
         yesno:   { case_insensitive_inclusion: { in: %w[Y N], message: "must be 'Y' or 'N'" } }

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -35,6 +35,8 @@ class Framework
           )
           total_value_field _total_value_field.sheet_name
 
+          lookups ast[:lookups]
+
           ast[:invoice_fields].each do |field_def|
             field = AST::FieldPresenter.new(field_def)
             _options = transpiler.send(:options_for_field, field)

--- a/app/models/framework/entry_data.rb
+++ b/app/models/framework/entry_data.rb
@@ -32,6 +32,10 @@ class Framework
         @total_value_field ||= value
       end
 
+      def lookups(value = nil)
+        @lookups ||= value
+      end
+
       ##
       # Define a field using an ActiveModel-compatible syntax.
       # This is intended to pass through to ActiveModel::Attributes.attribute,

--- a/lib/fdl/validations/test.rb
+++ b/lib/fdl/validations/test.rb
@@ -36,7 +36,7 @@ module FDL
         bar = ProgressBar.new(sample_rows.count)
 
         sample_rows.each do |entry|
-          compare = Compare.new(entry, framework_short_name)
+          compare = Compare.new(entry, framework_short_name, fdl_definition)
           diff = compare.diff
           bar.increment!
           next if diff.empty?
@@ -47,6 +47,10 @@ module FDL
             entry_id: entry.id
           }
         end
+      end
+
+      def fdl_definition
+        @fdl_definition ||= Framework::Definition::Language[framework_short_name]
       end
 
       def formatted_report

--- a/lib/fdl/validations/test/compare.rb
+++ b/lib/fdl/validations/test/compare.rb
@@ -7,10 +7,11 @@ module FDL
       # Given a +entry+ and a +framework+, allow us to compute the +diff+ of
       # validation errors, if any exist.
       class Compare
-        attr_reader :entry, :framework_short_name
-        def initialize(entry, framework_short_name)
+        attr_reader :entry, :framework_short_name, :fdl_definition
+        def initialize(entry, framework_short_name, fdl_definition)
           @entry                = entry
           @framework_short_name = framework_short_name
+          @fdl_definition       = fdl_definition
         end
 
         def original_invoice
@@ -50,10 +51,6 @@ module FDL
 
         def fdl_invoice_class
           @fdl_invoice_class ||= fdl_definition::Invoice
-        end
-
-        def fdl_definition
-          Framework::Definition::Language[framework_short_name]
         end
 
         def original_invoice_class

--- a/lib/fdl/validations/test/compare.rb
+++ b/lib/fdl/validations/test/compare.rb
@@ -13,14 +13,21 @@ module FDL
           @framework_short_name = framework_short_name
         end
 
+        def original_invoice
+          @original_invoice ||= original_invoice_class.new(entry)
+        end
+
         def original_errors
-          invoice = original_invoice_class.new(entry)
-          invoice.validate
-          invoice.errors.to_h
+          original_invoice.validate
+          original_invoice.errors.to_h
+        end
+
+        def fdl_invoice
+          @fdl_invoice ||= fdl_invoice_class.new(entry)
         end
 
         def fdl_errors
-          invoice = fdl_invoice_class.new(entry)
+          invoice = fdl_invoice
           invoice.validate
           invoice.errors.to_h
         end

--- a/lib/tasks/fdl.rake
+++ b/lib/tasks/fdl.rake
@@ -13,4 +13,11 @@ namespace :fdl do
       puts test.formatted_report
     end
   end
+
+  desc 'Transpile a framework from source'
+  task :transpile, %i[framework_short_name] => [:environment] do |_task, args|
+    framework_short_name = args[:framework_short_name] or raise ArgumentError 'framework_short_name required'
+
+    Framework::Definition::Language[framework_short_name]
+  end
 end

--- a/spec/lib/fdl/validation/failing_cases_spec.rb
+++ b/spec/lib/fdl/validation/failing_cases_spec.rb
@@ -34,4 +34,13 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
     # and adding support for those optional fields
     it { is_expected.to be_empty }
   end
+
+  context 'Framework RM3754' do
+    let(:short_name) { 'RM3754' }
+    let(:data)       { { 'Total Charge (ex VAT)' => 13835 } }
+
+    # Fixed by: annotating field kinds properly
+    # so we can treat all lookups as if they have type :string
+    it { is_expected.to be_empty }
+  end
 end

--- a/spec/lib/fdl/validation/failing_cases_spec.rb
+++ b/spec/lib/fdl/validation/failing_cases_spec.rb
@@ -5,8 +5,9 @@ require 'fdl/validations/test'
 # Temporary spec to deal with classes of error found in output
 # of fdl:validation:test
 RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
-  let(:compare)  { FDL::Validations::Test::Compare.new(entry, short_name) }
-  let(:entry)    { build(:submission_entry, data: data) }
+  let(:compare)        { FDL::Validations::Test::Compare.new(entry, short_name, fdl_definition) }
+  let(:entry)          { build(:submission_entry, data: data) }
+  let(:fdl_definition) { Framework::Definition::Language[short_name] }
 
   subject(:diff) { compare.diff }
 

--- a/spec/models/framework/definition/ast/field_spec.rb
+++ b/spec/models/framework/definition/ast/field_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Framework::Definition::AST::Field do
+  describe '#primitive_type' do
+    subject(:primitive_type) { Framework::Definition::AST::Field.new(field_def).primitive_type }
+
+    context 'a known field' do
+      let(:field_def) do
+        { kind: :known, field: 'CustomerURN', from: 'Customer URN' }
+      end
+
+      it { is_expected.to eql(:urn) }
+    end
+
+    context 'an additional field' do
+      context 'with a primitive type' do
+        let(:field_def) do
+          {
+            kind: :additional,
+            optional: true,
+            type:  'String',
+            field: 'Additional3',
+            from:  'Subcontractor Supplier Name'
+          }
+        end
+
+        it { is_expected.to eql(:string) }
+      end
+
+      context 'with a lookup type' do
+        let(:field_def) do
+          {
+            kind: :additional,
+            optional: true,
+            type:  'PaymentProfile',
+            field: 'Additional2',
+            from:  'Payment Profile'
+          }
+        end
+
+        it 'always treats lookups types as :string' do
+          expect(primitive_type).to eql(:string)
+        end
+      end
+    end
+
+    context 'an unknown field' do
+      let(:field_def) do
+        { kind: :unknown, optional: true, type: 'String', from: 'Cost Centre' }
+      end
+
+      it { is_expected.to eql(:string) }
+    end
+  end
+end

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Framework::Definition::Language do
     let(:logger)         { spy('Logger') }
     subject(:definition) { Framework::Definition::Language.generate_framework_definition(source, logger) }
 
-    context 'we have some valid FDL' do
+    context 'Laundry framework language features (CM_OSG_05_3565)' do
       let(:source) do
         File.read('app/models/framework/definition/CM_OSG_05_3565.fdl')
       end
@@ -128,6 +128,22 @@ RSpec.describe Framework::Definition::Language do
           it { is_expected.to have_field('Cost Centre').not_validated_by(:presence) }
           it { is_expected.to have_field('Contract Number').not_validated_by(:presence) }
         end
+      end
+    end
+
+    context 'Vehicle Telematics framework features' do
+      let(:source) do
+        File.read('app/models/framework/definition/RM3754.fdl')
+      end
+
+      describe 'the Invoice fields class' do
+        subject(:invoice_class) { definition::Invoice }
+
+        it {
+          is_expected.to have_field('UNSPSC')
+            .with_activemodel_type(:integer)
+            .validated_by(ingested_numericality: { only_integer: true })
+        }
       end
     end
 

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -144,6 +144,16 @@ RSpec.describe Framework::Definition::Language do
             .with_activemodel_type(:integer)
             .validated_by(ingested_numericality: { only_integer: true })
         }
+
+        describe '.lookups' do
+          subject { invoice_class.lookups }
+
+          it {
+            is_expected.to eq(
+              ['PaymentProfile' => %w[Monthly Quarterly Annual One-off]]
+            )
+          }
+        end
       end
     end
 

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -138,6 +138,9 @@ RSpec.describe Framework::Definition::Language do
 
       describe 'the Invoice fields class' do
         subject(:invoice_class) { definition::Invoice }
+        let(:expected_lookups) do
+          { 'PaymentProfile' => %w[Monthly Quarterly Annual One-off] }
+        end
 
         it {
           is_expected.to have_field('UNSPSC')
@@ -147,13 +150,14 @@ RSpec.describe Framework::Definition::Language do
 
         describe '.lookups' do
           subject { invoice_class.lookups }
-
-          it {
-            is_expected.to eq(
-              ['PaymentProfile' => %w[Monthly Quarterly Annual One-off]]
-            )
-          }
+          it { is_expected.to eq(expected_lookups) }
         end
+
+        it {
+          is_expected.to have_field('Payment Profile')
+            .with_activemodel_type(:string)
+            .validated_by(case_insensitive_inclusion: { in: expected_lookups['PaymentProfile'] })
+        }
       end
     end
 

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -160,19 +160,19 @@ RSpec.describe Framework::Definition::Parser do
 
     it 'parses the lookup fields' do
       expect(rule).to parse(source).as(
-        [
+        lookups: [
           {
-            lookup_name: "PaymentProfile",
+            lookup_name: 'PaymentProfile',
             list: [
-              { string: "Monthly" },
-              { string: "Quarterly" }
+              { string: 'Monthly' },
+              { string: 'Quarterly' }
             ]
           },
           {
-            lookup_name: "ServiceType",
+            lookup_name: 'ServiceType',
             list: [
-              { string: "Type1" },
-              { string: "Type2" }
+              { string: 'Type1' },
+              { string: 'Type2' }
             ]
           }
         ]

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -138,4 +138,45 @@ RSpec.describe Framework::Definition::Parser do
       )
     end
   end
+
+  describe '#lookups_block' do
+    subject(:rule) { parser.lookups_block }
+
+    let(:source) do
+      <<~FDL.strip
+        Lookups {
+          PaymentProfile [
+            'Monthly'
+            'Quarterly'
+          ]
+
+          ServiceType [
+            'Type1'
+            'Type2'
+          ]
+        }
+      FDL
+    end
+
+    it 'parses the lookup fields' do
+      expect(rule).to parse(source).as(
+        [
+          {
+            lookup_name: "PaymentProfile",
+            list: [
+              { string: "Monthly" },
+              { string: "Quarterly" }
+            ]
+          },
+          {
+            lookup_name: "ServiceType",
+            list: [
+              { string: "Type1" },
+              { string: "Type2" }
+            ]
+          }
+        ]
+      )
+    end
+  end
 end

--- a/spec/support/introspector.rb
+++ b/spec/support/introspector.rb
@@ -43,6 +43,18 @@ module ActiveModel
       end
     end
 
+    def validator_summary(field)
+      validators_found = klass.validators_on(field).map do |validator|
+        validator_name = validator.class.to_s.underscore
+                                  .sub('active_model/validations/', '')
+                                  .sub('_validator', '')
+
+        "\t#{validator_name}: #{validator.options.any? ? validator.options : true}"
+      end.join("\n")
+
+      "Validators found:\n#{validators_found}"
+    end
+
     ##
     # An ActiveModel symbol type, e.g. +:string+
     def type_of(field)

--- a/spec/support/matchers/have_field.rb
+++ b/spec/support/matchers/have_field.rb
@@ -25,6 +25,22 @@ RSpec::Matchers.define :have_field do |field_name|
     field_exists && mandatory_validators_present && unwanted_validators_absent && activemodel_type_valid
   end
 
+  failure_message do |actual_class|
+    introspector = ActiveModel::Introspector.new(actual_class)
+
+    return "Expected '#{field_name}' to exist" unless introspector.field_exists?(field_name)
+
+    actual_type = introspector.type_of(field_name)
+    type_message = if actual_type == @expected_activemodel_type
+                     nil
+                   else
+                     "Type: expected field to be of type #{@expected_activemodel_type}, got #{actual_type}\n"
+                   end
+
+    actual_validators = introspector.validator_summary(field_name)
+    "#{super()}\n#{type_message}#{actual_validators}"
+  end
+
   chain :validated_by do |*validator_args|
     @validator_args = validator_args
   end


### PR DESCRIPTION
# [Single-level lookups](https://trello.com/c/MbI1tNyL/898-lookups-rm3754)

Add FDL for RM3754, which is the first framework to have a one-level lookup implemented by a `case_insensitive_inclusion` validator.

Define the lookup with a lookup block like this:

```
Lookups {
  PaymentProfile [
    'Monthly'
    'Quarterly'
    'Annual'
    'One-off'
  ]
}
```

Then reference this lookup as a user-defined lookup type like this:

```
optional PaymentProfile Additional2 from 'Payment Profile'
```

## Add support for an integer field

This framework has our first non-string type; implement it

## Prove that the validations from this FDL result in no errors compared to the existing class for our current submissions

```
➜  DataSubmissionServiceAPI git:(898-lookups-rm3754) ✗ be rake fdl:validations:test[RM3754,9000]
W, [2019-03-12T12:22:23.841419 #29661]  WARN -- Skylight: [SKYLIGHT] [4.0.0-alpha] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
[####################################################################################################] [8761/8761] [100.00%] [03:25] [00:00] [  42.56/s]
```

## Rake task `fdl:transpile[short_name]`

Add a rake task `fdl:transpile` that takes a framework short name and verifies that the FDL transpiles correctly. In the event that it doesn't, print a Parslet error tree showing what went wrong.