### PR TITLE
Hotfix include hashdiff gem in production bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update overdue user notification CSV generation to match new GOV.UK Notify
   templates
+- Added first version of Framework Definition Language (FDL) for defining
+  frameworks, with CM/OSG/05/3565 fully defined
 
 ## [release-53] - 2019-03-07
 

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,9 @@ gem 'lolsoap', require: false
 gem 'akami', require: false
 gem 'http'
 
+# Used for FDL testing (see FDL::Validations::Test)
+gem 'hashdiff', require: false
+
 group :development, :test do
   gem 'brakeman', require: false
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
@@ -75,7 +78,6 @@ end
 
 group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'hashdiff'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'


### PR DESCRIPTION
I've snuck in the commit to correct the release notes whilst we're at it.