### PR TITLE
Simply Task#completed_or_latest_scope

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,19 +23,7 @@ class Task < ApplicationRecord
   delegate :name, to: :supplier, prefix: true
 
   completed_or_latest_scope = lambda do
-    where("
-        CASE WHEN
-          EXISTS(
-            SELECT 1
-              FROM submissions
-              WHERE aasm_state = 'completed' AND task_id = $1
-          )
-        THEN
-          aasm_state = 'completed'
-        ELSE
-          1=1
-        END
-    ").order(created_at: :desc)
+    order(Arel.sql("CASE aasm_state WHEN 'completed' THEN 1 ELSE 2 END"), created_at: :desc)
   end
   has_one :active_submission, completed_or_latest_scope, class_name: 'Submission', inverse_of: :task
   has_one :latest_submission, completed_or_latest_scope, class_name: 'Submission', inverse_of: :task

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Task do
         expect(task.active_submission).to eq(completed_submission)
       end
     end
+
+    it 'can be preloaded as part of another association query' do
+      expect(Task.where(id: task.id, period_year: task.period_year).includes(:active_submission)).to eq [task]
+    end
   end
 
   describe '#latest_submission' do


### PR DESCRIPTION
The previous query, whilst it worked, relied on binding to the `task_id` using the `$1` substitution parameter. Although this worked fine in most scenarios, it broke when the association was preloaded as part of a larger query that also had additional substitution parameters (for example, the query in the `TotalsReporter`). Instead of a sub-query, we can get the same result (i.e. either the most recent "completed" submission, or failing that, the most recent submission) with a `CASE` in the `ORDER` clause.

Resolves the issue found during review of https://github.com/dxw/DataSubmissionServiceAPI/pull/305.