### PR TITLE
Configure `null_store` for caching in the test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Disable caching
+  config.cache_store = :null_store
 end

--- a/spec/models/task/overdue_user_notification_list_spec.rb
+++ b/spec/models/task/overdue_user_notification_list_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Task::OverdueUserNotificationList do
   describe '#generate' do
     let(:output) { StringIO.new }
 
+    before { stub_govuk_bank_holidays_request }
+
     context 'there are incomplete submissions for the month in question' do
       let(:year)  { 2019 }
       let(:month) { 1 }


### PR DESCRIPTION
The configuration of the cache store was missing, which caused the cache
to persist between tests.

Removing this revealed a persistent test failure, due to a missing stub
in the `Task::OverdueUserNotificationList` specs.

Co-authored-by: Cristina <cristina@dxw.com>
Co-authored-by: James Darling <james@abscond.org>