### PR TITLE
(846) Generate data warehouse exports incrementally

### DIFF
--- a/app/models/data_warehouse_export.rb
+++ b/app/models/data_warehouse_export.rb
@@ -4,10 +4,14 @@ class DataWarehouseExport < ApplicationRecord
   before_create :set_date_range
 
   def run
-    Export::Anything.new(Export::Tasks::Extract.all_relevant).run
-    Export::Anything.new(Export::Submissions::Extract.all_relevant).run
-    Export::Anything.new(Export::Invoices::Extract.all_relevant).run
-    Export::Anything.new(Export::Contracts::Extract.all_relevant).run
+    Export::Anything.new(Export::Tasks::Extract.all_relevant(date_range)).run
+    Export::Anything.new(Export::Submissions::Extract.all_relevant(date_range)).run
+    Export::Anything.new(Export::Invoices::Extract.all_relevant(date_range)).run
+    Export::Anything.new(Export::Contracts::Extract.all_relevant(date_range)).run
+  end
+
+  def date_range
+    (range_from..range_to)
   end
 
   private

--- a/app/models/data_warehouse_export.rb
+++ b/app/models/data_warehouse_export.rb
@@ -1,0 +1,16 @@
+class DataWarehouseExport < ApplicationRecord
+  EARLIEST_RANGE_FROM = Time.new(2000, 1, 1).utc.freeze
+
+  before_create :set_date_range
+
+  private
+
+  def set_date_range
+    self.range_from ||= last_export_date || EARLIEST_RANGE_FROM
+    self.range_to   ||= Time.zone.now
+  end
+
+  def last_export_date
+    DataWarehouseExport.maximum(:range_to)
+  end
+end

--- a/app/models/data_warehouse_export.rb
+++ b/app/models/data_warehouse_export.rb
@@ -3,6 +3,13 @@ class DataWarehouseExport < ApplicationRecord
 
   before_create :set_date_range
 
+  def run
+    Export::Anything.new(Export::Tasks::Extract.all_relevant).run
+    Export::Anything.new(Export::Submissions::Extract.all_relevant).run
+    Export::Anything.new(Export::Invoices::Extract.all_relevant).run
+    Export::Anything.new(Export::Contracts::Extract.all_relevant).run
+  end
+
   private
 
   def set_date_range

--- a/app/models/export/anything.rb
+++ b/app/models/export/anything.rb
@@ -25,10 +25,11 @@ module Export
 
     def model_classname
       if @relation.klass == SubmissionEntry
-        {
-          'invoice' => 'Invoice',
-          'order' => 'Contract'
-        }.fetch(@relation.first.entry_type)
+        if @relation.where_values_hash['entry_type'] == 'invoice'
+          'Invoice'
+        else
+          'Contract'
+        end
       else
         @relation.klass.to_s
       end

--- a/app/models/export/contracts/extract.rb
+++ b/app/models/export/contracts/extract.rb
@@ -1,11 +1,14 @@
 module Export
   class Contracts
     module Extract
-      def self.all_relevant
+      def self.all_relevant(date_range = nil)
+        submission_scope = Submission.completed
+        submission_scope = submission_scope.where(updated_at: date_range) if date_range.present?
+
         SubmissionEntry.orders
                        .select('submission_entries.*, frameworks.short_name AS _framework_short_name')
                        .joins(submission: :framework)
-                       .merge(Submission.completed)
+                       .merge(submission_scope)
       end
     end
   end

--- a/app/models/export/invoices/extract.rb
+++ b/app/models/export/invoices/extract.rb
@@ -1,11 +1,14 @@
 module Export
   class Invoices
     module Extract
-      def self.all_relevant
+      def self.all_relevant(date_range = nil)
+        submission_scope = Submission.completed
+        submission_scope = submission_scope.where(updated_at: date_range) if date_range.present?
+
         SubmissionEntry.invoices
                        .select('submission_entries.*, frameworks.short_name AS _framework_short_name')
                        .joins(submission: :framework)
-                       .merge(Submission.completed)
+                       .merge(submission_scope)
       end
     end
   end

--- a/app/models/export/submissions/extract.rb
+++ b/app/models/export/submissions/extract.rb
@@ -3,7 +3,10 @@ module Export
     module Extract
       RELEVANT_STATUSES = %w[completed validation_failed].freeze
 
-      def self.all_relevant
+      def self.all_relevant(date_range = nil)
+        filters = { aasm_state: RELEVANT_STATUSES }
+        filters = filters.merge(updated_at: date_range) if date_range.present?
+
         Submission.select(
           <<~POSTGRESQL
             submissions.*,
@@ -39,7 +42,7 @@ module Export
             LEFT JOIN active_storage_blobs blobs ON blobs.id = att.blob_id
         POSTGRESQL
         ).where(
-          aasm_state: RELEVANT_STATUSES
+          filters
         ).group(
           'submissions.id, frameworks.short_name, orders.total_value, invoices.total_value,'\
           'invoices.total_management_charge, orders.entry_count, invoices.entry_count'

--- a/app/models/export/tasks/extract.rb
+++ b/app/models/export/tasks/extract.rb
@@ -1,8 +1,10 @@
 module Export
   class Tasks
     module Extract
-      def self.all_relevant
-        Task.includes(:framework, :supplier)
+      def self.all_relevant(date_range = nil)
+        tasks = Task.includes(:framework, :supplier)
+        tasks = tasks.where(updated_at: date_range) if date_range.present?
+        tasks
       end
     end
   end

--- a/app/models/export/tasks/extract.rb
+++ b/app/models/export/tasks/extract.rb
@@ -1,0 +1,9 @@
+module Export
+  class Tasks
+    module Extract
+      def self.all_relevant
+        Task.includes(:framework, :supplier)
+      end
+    end
+  end
+end

--- a/db/migrate/20190305081528_create_data_warehouse_export.rb
+++ b/db/migrate/20190305081528_create_data_warehouse_export.rb
@@ -1,0 +1,8 @@
+class CreateDataWarehouseExport < ActiveRecord::Migration[5.2]
+  def change
+    create_table :data_warehouse_exports do |t|
+      t.datetime :range_from, null: false
+      t.datetime :range_to, null: false, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,6 +67,12 @@ ActiveRecord::Schema.define(version: 2019_03_12_173622) do
     t.index ["urn"], name: "index_customers_on_urn", unique: true
   end
 
+  create_table "data_warehouse_exports", force: :cascade do |t|
+    t.datetime "range_from", null: false
+    t.datetime "range_to", null: false
+    t.index ["range_to"], name: "index_data_warehouse_exports_on_range_to"
+  end
+
   create_table "event_store_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "event_type", null: false
     t.text "metadata"

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -5,7 +5,7 @@ namespace :export do
 
   desc 'Export task entities to CSV'
   task :tasks, [:output] => [:environment] do |_task, args|
-    Export::Anything.new(Task.includes(:framework, :supplier), args[:output]).run
+    Export::Anything.new(Export::Tasks::Extract.all_relevant, args[:output]).run
   end
 
   desc 'Export submission entities to CSV'

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -3,6 +3,15 @@ namespace :export do
   desc 'Export everything to CSV'
   task all: %i[environment tasks submissions invoices contracts]
 
+  namespace :all do
+    desc 'Export everything that has updated since the last export to CSV'
+    task incremental: :environment do
+      export = DataWarehouseExport.new
+      puts "Generating incremental export for #{export.date_range}"
+      export.run
+    end
+  end
+
   desc 'Export task entities to CSV'
   task :tasks, [:output] => [:environment] do |_task, args|
     Export::Anything.new(Export::Tasks::Extract.all_relevant, args[:output]).run

--- a/spec/models/data_warehouse_export_spec.rb
+++ b/spec/models/data_warehouse_export_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe DataWarehouseExport do
+  describe 'on creation' do
+    context 'with no previous exports' do
+      it "sets the new export's range_from to a date before the project started" do
+        first_export = DataWarehouseExport.create!
+
+        expect(first_export.range_from).to eql DataWarehouseExport::EARLIEST_RANGE_FROM
+      end
+    end
+
+    context 'with previous exports' do
+      let!(:previous_export) { DataWarehouseExport.create!(range_to: '2018-12-25 12:34:56') }
+
+      it "sets the new export's range_from to the range_to of the most recent export" do
+        new_export = DataWarehouseExport.create!
+
+        expect(new_export.range_from).to eql previous_export.range_to
+      end
+    end
+
+    it "sets the new export's range_to to the current time" do
+      freeze_time do
+        new_export = DataWarehouseExport.create!
+        expect(new_export.range_to).to eql Time.zone.now
+      end
+    end
+  end
+end

--- a/spec/models/export/invoices/extract_spec.rb
+++ b/spec/models/export/invoices/extract_spec.rb
@@ -21,5 +21,26 @@ RSpec.describe Export::Invoices::Extract do
         expect(all_relevant.map(&:_framework_short_name)).to all(eql(complete_submission.framework.short_name))
       end
     end
+
+    context 'with a date range provided' do
+      let!(:submission) do
+        create(:submission, aasm_state: 'completed', updated_at: 2.days.ago) do |submission|
+          submission.entries << create(:invoice_entry)
+        end
+      end
+      let(:date_range) { 1.day.ago..1.minute.from_now }
+
+      it 'only includes invoices whose submissions were updated during the range' do
+        all_relevant = Export::Invoices::Extract.all_relevant(date_range)
+        expect(all_relevant).not_to match_array submission.entries
+
+        # rubocop:disable Rails/SkipsModelValidations
+        submission.touch
+        # rubocop:enable Rails/SkipsModelValidations
+
+        all_relevant = Export::Invoices::Extract.all_relevant(date_range)
+        expect(all_relevant).to match_array submission.entries
+      end
+    end
   end
 end

--- a/spec/models/export/submissions/extract_spec.rb
+++ b/spec/models/export/submissions/extract_spec.rb
@@ -84,5 +84,22 @@ RSpec.describe Export::Submissions::Extract do
         end
       end
     end
+
+    context 'with a date range provided' do
+      let!(:submission) { create(:completed_submission, updated_at: 1.week.ago) }
+      let(:date_range) { 4.days.ago..1.minute.from_now }
+
+      it 'only includes submissions that were updated during the range' do
+        all_relevant = Export::Submissions::Extract.all_relevant(date_range)
+        expect(all_relevant).not_to match_array submission
+
+        # rubocop:disable Rails/SkipsModelValidations
+        submission.touch
+        # rubocop:enable Rails/SkipsModelValidations
+
+        all_relevant = Export::Submissions::Extract.all_relevant(date_range)
+        expect(all_relevant).to match_array submission
+      end
+    end
   end
 end

--- a/spec/models/export/tasks/extract_spec.rb
+++ b/spec/models/export/tasks/extract_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Export::Tasks::Extract do
+  describe '#all_relevant' do
+    let(:all_relevant) { Export::Tasks::Extract.all_relevant(date_range) }
+
+    context 'with no date range provided' do
+      let(:date_range) { nil }
+
+      it 'includes all tasks' do
+        tasks = create_list(:task, 3)
+
+        expect(all_relevant).to eq tasks
+      end
+    end
+
+    context 'with a date range provided' do
+      let!(:task) { create(:task, updated_at: 1.week.ago) }
+      let(:date_range) { 4.days.ago..1.minute.from_now }
+
+      it 'only includes tasks that were updated during the range' do
+        all_relevant = Export::Tasks::Extract.all_relevant(date_range)
+        expect(all_relevant).not_to match_array task
+
+        # rubocop:disable Rails/SkipsModelValidations
+        task.touch
+        # rubocop:enable Rails/SkipsModelValidations
+
+        all_relevant = Export::Tasks::Extract.all_relevant(date_range)
+        expect(all_relevant).to match_array task
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -13,6 +13,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
+  config.before(:each, truncation: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
   config.before(:each, type: :feature) do
     # :rack_test driver's Rack app under test shares database connection
     # with the specs, so continue to use transaction strategy for speed.

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,7 +1,10 @@
+require 'capybara/rspec'
+
 RSpec.configure do |config|
   DatabaseCleaner.allow_remote_database_url = true
 
   config.use_transactional_fixtures = false
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end
@@ -10,11 +13,24 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
+  config.before(:each, type: :feature) do
+    # :rack_test driver's Rack app under test shares database connection
+    # with the specs, so continue to use transaction strategy for speed.
+    driver_shares_db_connection_with_specs = Capybara.current_driver == :rack_test
+
+    unless driver_shares_db_connection_with_specs
+      # Driver is probably for an external browser with an app
+      # under test that does *not* share a database connection with the
+      # specs, so use truncation strategy.
+      DatabaseCleaner.strategy = :truncation
+    end
+  end
+
   config.before(:each) do
     DatabaseCleaner.start
   end
 
-  config.after(:each) do
+  config.append_after(:each) do
     DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
We need to provide exports to the data warehouse on a daily basis, so
need to return only data that has been added or updated since the last
export.

The new `DataWarehouseExport` model stores the range of dates that will
be used to extract the relevant data, and its `run` method calls the
existing exports to extract the tasks, submissions, invoices and
contracts.

When the first export is run, it'll include everything (with the start
of the included date range set to 1/1/2000). If an export fails for some
reason, the last `DataWarehouseExport` entry can be removed, and the
export re-run.

NB: This doesn't change the existing rake tasks, which will continue to
return extracts for all time. These will likely get removed once exports
are performed automatically.