### PR TITLE
Refactor interface to ManagementChargeCalculator::ColumnBased

### DIFF
--- a/app/models/framework/definition/RM3710.rb
+++ b/app/models/framework/definition/RM3710.rb
@@ -5,7 +5,7 @@ class Framework
       framework_name       'Vehicle Lease and Fleet Management'
 
       management_charge ManagementChargeCalculator::ColumnBased.new(
-        column: 'Spend Code',
+        varies_by: 'Spend Code',
         value_to_percentage: {
           'Lease Rental': BigDecimal('0.5'),
           'Fleet Management Fee': BigDecimal('0.5'),

--- a/app/models/framework/definition/RM858.rb
+++ b/app/models/framework/definition/RM858.rb
@@ -5,7 +5,7 @@ class Framework
       framework_name       'Pan Govt Vehicle Leasing & Fleet Outsource Solutio'
 
       management_charge ManagementChargeCalculator::ColumnBased.new(
-        column: 'Spend Code',
+        varies_by: 'Spend Code',
         value_to_percentage: {
           'Lease Rental': BigDecimal('0.5'),
           'Fleet Management Fee': BigDecimal('0.5'),

--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -1,20 +1,20 @@
 class Framework
   module ManagementChargeCalculator
     class ColumnBased
-      attr_reader :column, :value_to_percentage
+      attr_reader :varies_by, :value_to_percentage
 
-      def initialize(column:, value_to_percentage:)
-        @column = column
+      def initialize(varies_by:, value_to_percentage:)
+        @varies_by = varies_by
         @value_to_percentage = prepare_hash(value_to_percentage)
       end
 
       def calculate_for(entry)
-        column_value_for_entry = entry.data.dig(column).to_s
-        percentage = value_to_percentage[column_value_for_entry.downcase]
+        column_name_for_entry = entry.data.dig(varies_by).to_s
+        percentage = value_to_percentage[column_name_for_entry.downcase]
 
         if percentage.nil?
           Rollbar.error(
-            "Got value '#{column_value_for_entry}' for '#{column}' on #{entry.framework.short_name}"\
+            "Got value '#{column_name_for_entry}' for '#{varies_by}' on #{entry.framework.short_name}"\
             "from entry #{entry.id}. Missing validation?"
           )
 

--- a/spec/models/framework/management_charge_calculator/column_based_spec.rb
+++ b/spec/models/framework/management_charge_calculator/column_based_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     entry = FactoryBot.create(:submission_entry, total_value: 123.45, data: { test_value: 'test' })
 
     calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
-      column: 'test_value',
+      varies_by: 'test_value',
       value_to_percentage: {
         'other': 0,
         'test': BigDecimal('10')
@@ -19,7 +19,7 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     entry = FactoryBot.create(:submission_entry, total_value: 123.45, data: { test_value: 'TeST' })
 
     calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
-      column: 'test_value',
+      varies_by: 'test_value',
       value_to_percentage: {
         'Test': BigDecimal('5')
       }
@@ -32,7 +32,7 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     entry = FactoryBot.create(:submission_entry, total_value: 42.424242, data: { test_value: 'test' })
 
     calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
-      column: 'test_value',
+      varies_by: 'test_value',
       value_to_percentage: {
         'test': BigDecimal('0.5')
       }
@@ -45,7 +45,7 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     entry = FactoryBot.create(:submission_entry, total_value: 42.424242, data: { test_value: 'invalid' })
 
     calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
-      column: 'test_value',
+      varies_by: 'test_value',
       value_to_percentage: {
         'test': BigDecimal('0.5')
       }


### PR DESCRIPTION
Rename `column:` parameter on ManagementChargeCalculator::ColumnBased to
`varies_by:`

When thinking about implementing ManagementCharge in FDL, we noticed that the
interfaces to `ManagementChargeCalculator::ColumnBased` and
`ManagementChargeCalculator::FlatRate` were confusingly similar.

In `ManagementChargeCalculator::ColumnBased`, the `column` parameter refers to
the column name which the charge _varies by_.

In `ManagementChargeCalculator::FlatRate`, the `column` parameter refers to the
column name which the charge itself is _taken from_.

In `ManagementChargeCalculator::ColumnBased`, the column name from which the
charge is taken from cannot be varied (it is always the `total_value` attribute
of the entry). So the identical naming of these two parameters between the two
classes was very confusing.

We have renamed `column:` in ManagementChargeCalculator::ColumnBased to make it
obvious this is the factor by which the charge _varies_, not the column the
value is taken from.