### PR TITLE
Admin user can download CSV files for Notify templates

### DIFF
--- a/app/controllers/admin/notify_downloads_controller.rb
+++ b/app/controllers/admin/notify_downloads_controller.rb
@@ -19,10 +19,19 @@ class Admin::NotifyDownloadsController < AdminController
   end
 
   def task_notification_list(file)
-    Task::OverdueUserNotificationList.new(month: latest_period.month, year: latest_period.year, output: file)
+    case params[:id]
+    when 'late', 'overdue'
+      Task::OverdueUserNotificationList.new(month: latest_period.month, year: latest_period.year, output: file)
+    when 'due'
+      Task::AnticipatedUserNotificationList.new(month: current_date.month, year: current_date.year, output: file)
+    end
   end
 
   def latest_period
-    Time.zone.today.beginning_of_month - 1.month
+    current_date.beginning_of_month - 1.month
+  end
+
+  def current_date
+    Time.zone.today
   end
 end

--- a/app/controllers/admin/notify_downloads_controller.rb
+++ b/app/controllers/admin/notify_downloads_controller.rb
@@ -1,4 +1,6 @@
 class Admin::NotifyDownloadsController < AdminController
+  before_action :catch_unrecognised_download, only: :show
+
   def index; end
 
   def show
@@ -33,5 +35,9 @@ class Admin::NotifyDownloadsController < AdminController
 
   def current_date
     Time.zone.today
+  end
+
+  def catch_unrecognised_download
+    head(:not_found) unless %w[due late overdue].include?(params[:id])
   end
 end

--- a/app/controllers/admin/notify_downloads_controller.rb
+++ b/app/controllers/admin/notify_downloads_controller.rb
@@ -15,7 +15,7 @@ class Admin::NotifyDownloadsController < AdminController
   end
 
   def csv_filename
-    "late_notifications-#{Time.zone.today}.csv"
+    "#{params[:id]}_notifications-#{Time.zone.today}.csv"
   end
 
   def task_notification_list(file)

--- a/app/controllers/admin/notify_downloads_controller.rb
+++ b/app/controllers/admin/notify_downloads_controller.rb
@@ -1,0 +1,28 @@
+class Admin::NotifyDownloadsController < AdminController
+  def index; end
+
+  def show
+    send_file csv_file, type: 'text/csv', filename: csv_filename
+  end
+
+  private
+
+  def csv_file
+    Tempfile.new.tap do |file|
+      task_notification_list(file).generate
+      file.rewind
+    end
+  end
+
+  def csv_filename
+    "late_notifications-#{Time.zone.today}.csv"
+  end
+
+  def task_notification_list(file)
+    Task::OverdueUserNotificationList.new(month: latest_period.month, year: latest_period.year, output: file)
+  end
+
+  def latest_period
+    Time.zone.today.beginning_of_month - 1.month
+  end
+end

--- a/app/views/admin/notify_downloads/index.html.haml
+++ b/app/views/admin/notify_downloads/index.html.haml
@@ -17,6 +17,10 @@
           %th.govuk-table__header Notify template
           %th.govuk-table__header Actions
       %tbody.govuk-table__body
+        %tr.govuk-table__row#notify-download-due
+          %td.govuk-table__cell
+            Management information is due
+          %td.govuk-table__cell= link_to 'Download CSV', admin_notify_download_path(:due)
         %tr.govuk-table__row#notify-download-overdue
           %td.govuk-table__cell
             Management information is overdue

--- a/app/views/admin/notify_downloads/index.html.haml
+++ b/app/views/admin/notify_downloads/index.html.haml
@@ -1,0 +1,24 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      Notify downloads
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %p
+      These CSV files can be used with the CCS GOV.UK Notify templates for
+      sending due, overdue, and late notifications to suppliers.
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %table.govuk-table{:class => 'govuk-!-margin-top-7'}
+      %thead.govuk-table__head
+        %tr.govuk-table__row
+          %th.govuk-table__header Notify template
+          %th.govuk-table__header Actions
+      %tbody.govuk-table__body
+        %tr.govuk-table__row#notify-download-late
+          %td.govuk-table__cell
+            Management information is late
+          %td.govuk-table__cell= link_to 'Download CSV', admin_notify_download_path(:late)
+

--- a/app/views/admin/notify_downloads/index.html.haml
+++ b/app/views/admin/notify_downloads/index.html.haml
@@ -17,8 +17,11 @@
           %th.govuk-table__header Notify template
           %th.govuk-table__header Actions
       %tbody.govuk-table__body
+        %tr.govuk-table__row#notify-download-overdue
+          %td.govuk-table__cell
+            Management information is overdue
+          %td.govuk-table__cell= link_to 'Download CSV', admin_notify_download_path(:overdue)
         %tr.govuk-table__row#notify-download-late
           %td.govuk-table__cell
             Management information is late
           %td.govuk-table__cell= link_to 'Download CSV', admin_notify_download_path(:late)
-

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -21,4 +21,6 @@
               %li.govuk-header__navigation-item
                 = link_to 'Suppliers', admin_suppliers_path, {:class=>"govuk-header__link"}
               %li.govuk-header__navigation-item
+                = link_to 'Notify downloads', admin_notify_downloads_path, {:class=>"govuk-header__link"}
+              %li.govuk-header__navigation-item
                 = link_to 'Sign out', admin_sign_out_path, {:class=>"govuk-header__link"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :notify_downloads, only: %i[index show]
+
     get '/sign_in', to: 'sessions#new', as: :sign_in
     get '/sign_out', to: 'sessions#destroy', as: :sign_out
   end

--- a/spec/features/admin_notify_downloads_spec.rb
+++ b/spec/features/admin_notify_downloads_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin Notify downloads section' do
+  around do |example|
+    travel_to Date.new(2018, 12, 9) do
+      example.run
+    end
+  end
+
+  before do
+    sign_in_as_admin
+  end
+
+  scenario 'admin user downloads Notify CSV' do
+    click_on 'Notify downloads'
+
+    within '#notify-download-late' do
+      click_on 'Download CSV'
+
+      expect(page.response_headers['Content-Disposition']).to match(/^attachment/)
+      expect(page.response_headers['Content-Disposition']).to match(/filename="late_notifications-2018-12-09.csv"$/)
+      expect(page.body).to include 'email address,due_date,person_name'
+    end
+  end
+end

--- a/spec/requests/admin/notify_downloads_spec.rb
+++ b/spec/requests/admin/notify_downloads_spec.rb
@@ -72,4 +72,35 @@ RSpec.describe 'Admin Notify Downloads', type: :request do
       end
     end
   end
+
+  describe '#show for :due tasks' do
+    let(:current_date) { Date.new(2018, 2, 27) }
+    let(:next_period) { Date.new(2018, 3, 1) }
+
+    around do |example|
+      travel_to current_date do
+        example.run
+      end
+    end
+
+    before do
+      user = FactoryBot.create(:user, name: 'User A')
+      supplier = FactoryBot.create(:supplier, name: 'Supplier A')
+      framework = FactoryBot.create(:framework, short_name: 'RX123')
+      FactoryBot.create :membership, user: user, supplier: supplier
+      supplier.agreements.create!(framework: framework)
+    end
+
+    it 'returns the "due" notifications CSV file, with today’s date in the filename' do
+      get admin_notify_download_path(:due)
+
+      expect(response).to be_successful
+      expect(response.header['Content-Type']).to include 'text/csv'
+      expect(response.header['Content-Disposition']).to eq 'attachment; filename="due_notifications-2018-02-27.csv"'
+      expect(response.body).to include 'email address,due_date,person_name'
+      expect(response.body).to include 'User A'
+      expect(response.body).to include ',February 2018,'
+      expect(response.body).to include ',7 March 2018,'
+    end
+  end
 end

--- a/spec/requests/admin/notify_downloads_spec.rb
+++ b/spec/requests/admin/notify_downloads_spec.rb
@@ -103,4 +103,11 @@ RSpec.describe 'Admin Notify Downloads', type: :request do
       expect(response.body).to include ',7 March 2018,'
     end
   end
+
+  describe '#show for a non-existent download' do
+    it 'returns a 404' do
+      get admin_notify_download_path(:random)
+      expect(response).to be_not_found
+    end
+  end
 end

--- a/spec/requests/admin/notify_downloads_spec.rb
+++ b/spec/requests/admin/notify_downloads_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'Admin Notify Downloads', type: :request do
 
       expect(response).to be_successful
       expect(response.body).to include('Notify downloads')
+      expect(response.body).to include('Management information is overdue')
+      expect(response.body).to include(admin_notify_download_path(:overdue))
       expect(response.body).to include('Management information is late')
       expect(response.body).to include(admin_notify_download_path(:late))
     end
@@ -45,14 +47,29 @@ RSpec.describe 'Admin Notify Downloads', type: :request do
       )
     end
 
-    it 'returns a "late" notifications CSV file, with today’s date in the filename' do
-      get admin_notify_download_path(:late)
+    context 'when requesting the "overdue" notifications' do
+      it 'returns a "overdue" notifications CSV file, with today’s date in the filename' do
+        get admin_notify_download_path(:overdue)
 
-      expect(response).to be_successful
-      expect(response.header['Content-Type']).to include 'text/csv'
-      expect(response.header['Content-Disposition']).to eq 'attachment; filename="late_notifications-2019-03-09.csv"'
-      expect(response.body).to include 'email address,due_date,person_name'
-      expect(response.body).to include 'User A'
+        expect(response).to be_successful
+        expect(response.header['Content-Type']).to include 'text/csv'
+        expect(response.header['Content-Disposition'])
+          .to eq 'attachment; filename="overdue_notifications-2019-03-09.csv"'
+        expect(response.body).to include 'email address,due_date,person_name'
+        expect(response.body).to include 'User A'
+      end
+    end
+
+    context 'when requesting the "late" notifications' do
+      it 'returns a "late" notifications CSV file, with today’s date in the filename' do
+        get admin_notify_download_path(:late)
+
+        expect(response).to be_successful
+        expect(response.header['Content-Type']).to include 'text/csv'
+        expect(response.header['Content-Disposition']).to eq 'attachment; filename="late_notifications-2019-03-09.csv"'
+        expect(response.body).to include 'email address,due_date,person_name'
+        expect(response.body).to include 'User A'
+      end
     end
   end
 end

--- a/spec/requests/admin/notify_downloads_spec.rb
+++ b/spec/requests/admin/notify_downloads_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Notify Downloads', type: :request do
+  include SingleSignOnHelpers
+
+  before do
+    stub_govuk_bank_holidays_request
+    mock_sso_with(email: 'admin@example.com')
+    get '/auth/google_oauth2/callback'
+  end
+
+  describe '#index' do
+    it 'lists the available Notify downloads' do
+      get admin_notify_downloads_path
+
+      expect(response).to be_successful
+      expect(response.body).to include('Notify downloads')
+      expect(response.body).to include('Management information is late')
+      expect(response.body).to include(admin_notify_download_path(:late))
+    end
+  end
+
+  describe '#show when there are incomplete tasks' do
+    let(:reporting_period) { Date.new(2019, 2, 1) }
+    let(:due_date) { reporting_period + 1.month + 7.days }
+    let(:after_due_date) { due_date + 1.day }
+
+    around do |example|
+      travel_to after_due_date do
+        example.run
+      end
+    end
+
+    before do
+      user = FactoryBot.create(:user, name: 'User A')
+      supplier = FactoryBot.create(:supplier, name: 'Supplier A')
+
+      FactoryBot.create :membership, user: user, supplier: supplier
+      FactoryBot.create(
+        :task,
+        supplier: supplier,
+        period_month: reporting_period.month,
+        period_year: reporting_period.year,
+        due_on: due_date
+      )
+    end
+
+    it 'returns a "late" notifications CSV file, with today’s date in the filename' do
+      get admin_notify_download_path(:late)
+
+      expect(response).to be_successful
+      expect(response.header['Content-Type']).to include 'text/csv'
+      expect(response.header['Content-Disposition']).to eq 'attachment; filename="late_notifications-2019-03-09.csv"'
+      expect(response.body).to include 'email address,due_date,person_name'
+      expect(response.body).to include 'User A'
+    end
+  end
+end


### PR DESCRIPTION
This implements two the two cards related to downloading Notify CSV files. Admin users get links to download CSV for "due", "overdue" and "late" tasks.

<img width="880" alt="Screenshot 2019-03-12 at 16 02 16" src="https://user-images.githubusercontent.com/3687/54215671-3ab7d500-44e0-11e9-9d0b-2d642e2d9058.png">

Delivers https://trello.com/c/3aHbs0za/893-enable-admin-users-to-download-the-csv-data-for-the-management-information-is-overdue-late-notify-templates and https://trello.com/c/tGj6W3mN/894-enable-admin-users-to-download-the-csv-data-for-the-management-information-is-due-notify-template