### PR TITLE
Add NULL constraint to submissions.task_id

### DIFF
--- a/db/migrate/20190312173622_add_null_constraint_to_submissions_task_id.rb
+++ b/db/migrate/20190312173622_add_null_constraint_to_submissions_task_id.rb
@@ -1,0 +1,5 @@
+class AddNullConstraintToSubmissionsTaskId < ActiveRecord::Migration[5.2]
+  def change
+    change_column :submissions, :task_id, :uuid, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_25_111223) do
+ActiveRecord::Schema.define(version: 2019_03_12_173622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -151,7 +151,7 @@ ActiveRecord::Schema.define(version: 2019_02_25_111223) do
     t.uuid "framework_id", null: false
     t.uuid "supplier_id", null: false
     t.string "aasm_state"
-    t.uuid "task_id"
+    t.uuid "task_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "purchase_order_number"


### PR DESCRIPTION
We never expect or want a submission to exist without an associated task so adding this constraint to prevent data getting accidentally corrupted.