### PR TITLE
896 FDL'ing the management charge

### DIFF
--- a/app/models/framework/definition/RM858.fdl
+++ b/app/models/framework/definition/RM858.fdl
@@ -1,0 +1,66 @@
+Framework RM858 {
+  Name 'Pan Govt Vehicle Leasing & Fleet Outsource Solutio'
+
+  ManagementCharge varies_by 'Spend Code' {
+    'Lease Rental'         -> 0.5%
+    'Fleet Management Fee' -> 0.5%
+    'Damage'               -> 0%
+    'Other Re-charges'     -> 0%
+  }
+
+  InvoiceFields {
+    LotNumber from 'Lot Number'
+    optional CustomerPostCode from 'Customer PostCode'
+    CustomerName from 'Customer Organisation'
+    CustomerURN from 'Customer URN'
+    optional InvoiceDate from 'Customer Invoice Date'
+    InvoiceNumber from 'Customer Invoice Number'
+    optional String from 'Customer Invoice Line Number'
+    optional ProductDescription from 'Invoice Line Product / Service Description'
+    UnitType from 'Unit of Purchase'
+    optional UnitPrice from 'Price per Unit ex VAT'
+    optional UnitQuantity from 'Invoice Line Quantity'
+    InvoiceValue from 'Invoice Line Total Value ex VAT'
+    VATIncluded from 'VAT Applicable'
+    optional VATCharged from 'VAT Amount Charged'
+    PromotionCode from 'Spend Code'
+    ProductGroup from 'Invoice Line Product / Service Grouping'
+    optional ProductCode from 'CAP Code'
+    optional ProductClass from 'Vehicle Make'
+    optional ProductSubClass from 'Vehicle Model'
+    optional String Additional1 from 'Vehicle Derivative'
+    optional String Additional2 from 'Product Classification'
+    optional String Additional3 from 'Vehicle Registration'
+    optional String Additional4 from 'Vehicle Convertors Name'
+    optional String Additional5 from 'Vehicle Conversion Type'
+    optional String Additional6 from 'Vehicle Type'
+    optional String Additional7 from 'Fuel Type'
+    optional String Additional8 from 'CO2 Emission Levels'
+    optional String Additional9 from 'Lease Period'
+    Date Additional10 from 'Lease Start Date'
+    Date Additional11 from 'Lease End Date'
+    optional String Additional12 from 'Payment Profile'
+    optional Decimal Additional13 from 'Annual Lease Mileage'
+    optional Decimal Additional14 from 'Base Vehicle Price ex VAT'
+    optional Decimal Additional15 from 'Lease Cost excluding Optional Extras and Conversion ex VAT'
+    optional Decimal Additional16 from 'Lease Finance Charge ex VAT'
+    optional Decimal Additional17 from 'Lease Finance Margin ex VAT'
+    optional String Additional18 from 'Vehicle Purchase Terms'
+    optional Decimal Additional19 from 'Standard Vehicle Discount (%)'
+    optional Decimal Additional20 from 'Enhanced Vehicle Discount (%)'
+    optional Decimal Additional21 from 'Annual Service Maintenance & Repair Costs ex VAT'
+    optional Decimal Additional22 from 'Annual Breakdown & Recovery Costs ex VAT'
+    optional Decimal Additional23 from 'Residual Value'
+    optional String from 'Cost Centre'
+    optional String from 'Contract Number'
+  }
+
+  Lookups {
+    PromotionCode [
+      'Lease Rental'
+      'Fleet Management Fee'
+      'Damage'
+      'Other Re-charges'
+    ]
+  }
+}

--- a/app/models/framework/definition/RM858.fdl
+++ b/app/models/framework/definition/RM858.fdl
@@ -13,7 +13,7 @@ Framework RM858 {
     optional CustomerPostCode from 'Customer PostCode'
     CustomerName from 'Customer Organisation'
     CustomerURN from 'Customer URN'
-    optional InvoiceDate from 'Customer Invoice Date'
+    InvoiceDate from 'Customer Invoice Date'
     InvoiceNumber from 'Customer Invoice Number'
     optional String from 'Customer Invoice Line Number'
     optional ProductDescription from 'Invoice Line Product / Service Description'

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -6,6 +6,7 @@ class Framework
       class Creator < Parslet::Transform
         rule(string: simple(:s))  { String(s) }
         rule(decimal: simple(:d)) { BigDecimal(d) }
+        rule(integer: simple(:i)) { Integer(i) }
 
         # match known fields only
         rule(field: simple(:field), from: simple(:from)) { { kind: :known, field: field.to_s, from: from.to_s } }
@@ -47,6 +48,17 @@ class Framework
           lookups.each_with_object({}) do |single_key_value, result|
             lookup_name, value_list = *single_key_value.first
             result[lookup_name] = value_list
+          end
+        end
+
+        # dictionary key/value pairs
+        rule(key: simple(:key), value: simple(:value)) { { key => value } }
+
+        # Transform a CST sequence like [{ key1 => value1}, { key2 => value2}] to a
+        # real hash                      { key1 => value1, key2 => value2 }
+        rule(dictionary: subtree(:dictionary)) do
+          dictionary.each_with_object({}) do |kv, result|
+            result[kv.keys.first] = kv.values.first
           end
         end
       end

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -8,6 +8,9 @@ class Framework
         rule(decimal: simple(:d)) { BigDecimal(d) }
         rule(integer: simple(:i)) { Integer(i) }
 
+        rule(primitive: simple(:primitive)) { primitive }
+        rule(lookup: simple(:lookup))       { lookup }
+
         # match known fields only
         rule(field: simple(:field), from: simple(:from)) { { kind: :known, field: field.to_s, from: from.to_s } }
         rule(optional: simple(:optional), field: simple(:field), from: simple(:from)) do

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -18,17 +18,17 @@ class Framework
         end
 
         # optional Additional field rule
-        rule(optional: simple(:optional), type: simple(:type), field: simple(:field), from: subtree(:from)) do
+        rule(optional: simple(:optional), type_def: simple(:type), field: simple(:field), from: subtree(:from)) do
           { kind: :additional, optional: true, type: type.to_s, field: field.to_s, from: from }
         end
 
         # Additional field rule
-        rule(type: simple(:type), field: simple(:field), from: subtree(:from)) do
+        rule(type_def: simple(:type), field: simple(:field), from: subtree(:from)) do
           { kind: :additional, type: type.to_s, field: field.to_s, from: from }
         end
 
         # Unknown fields rule
-        rule(optional: simple(:optional), type: simple(:type), from: simple(:from)) do
+        rule(optional: simple(:optional), type_def: simple(:type), from: simple(:from)) do
           { kind: :unknown, optional: true, type: type.to_s, from: from }
         end
 

--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -16,6 +16,14 @@ class Framework
           yesno:   { case_insensitive_inclusion: { in: %w[Y N], message: "must be 'Y' or 'N'" } }
         }.freeze
 
+        PRIMITIVE_TYPES = {
+          'Integer' => :integer,
+          'String' => :string,
+          'Decimal' => :decimal,
+          'Date' => :date,
+          'YesNo' => :yesno
+        }.freeze
+
         extend Forwardable
 
         def_delegators :field_def, :[]
@@ -59,15 +67,17 @@ class Framework
           case kind
           when :known
             DataWarehouse::KnownFields.type_for(warehouse_name)
-          when :additional
-            :string # Everything's a string right now
           else
-            field_def[:type].underscore.to_sym
+            PRIMITIVE_TYPES[field_def[:type]] || :string
           end
         end
 
+        def lookup?
+          field_def[:type] && PRIMITIVE_TYPES[field_def[:type]].nil?
+        end
+
         def lookup_name
-          field_def[:type] unless field_def[:type] == 'String'
+          field_def[:type] if lookup?
         end
 
         ##

--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -29,9 +29,10 @@ class Framework
 
         def_delegators :field_def, :[]
 
-        attr_reader :field_def
-        def initialize(field_def)
+        attr_reader :field_def, :lookups
+        def initialize(field_def, lookups = {})
           @field_def = field_def
+          @lookups = lookups
         end
 
         def sheet_name
@@ -74,11 +75,17 @@ class Framework
         end
 
         def lookup?
-          field_def[:type] && PRIMITIVE_TYPES[field_def[:type]].nil?
+          if known?
+            lookups.key?(warehouse_name)
+          else
+            field_def[:type] && PRIMITIVE_TYPES[field_def[:type]].nil?
+          end
         end
 
         def lookup_name
-          field_def[:type] if lookup?
+          return nil unless lookup?
+
+          known? ? warehouse_name : field_def[:type]
         end
 
         ##

--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -8,12 +8,13 @@ class Framework
       # some helper methods# on it to make the +Transpiler+ readable
       class Field
         PRIMITIVE_TYPE_VALIDATIONS = {
-          string:  {},
-          decimal: { ingested_numericality: true },
-          integer: { ingested_numericality: { only_integer: true } },
-          urn:     { urn: true },
-          date:    { ingested_date: true },
-          yesno:   { case_insensitive_inclusion: { in: %w[Y N], message: "must be 'Y' or 'N'" } }
+          string:     {},
+          decimal:    { ingested_numericality: true },
+          integer:    { ingested_numericality: { only_integer: true } },
+          urn:        { urn: true },
+          lot_number: { lot_in_agreement: true },
+          date:       { ingested_date: true },
+          yesno:      { case_insensitive_inclusion: { in: %w[Y N], message: "must be 'Y' or 'N'" } }
         }.freeze
 
         PRIMITIVE_TYPES = {

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -12,7 +12,8 @@ class Framework
           def build(lookup_values)
             options[:exports_to] = field.warehouse_name
 
-            add_known_type_validations! if field.known?
+            options.merge!(PRIMITIVE_TYPE_VALIDATIONS.fetch(field.primitive_type))
+
             options.delete(:presence) if field.primitive_type == :urn # The URN validator covers this
             set_optional_modifiers! if field.optional?
 
@@ -25,11 +26,6 @@ class Framework
           def set_optional_modifiers!
             options.delete(:presence)
             options[:allow_nil] = true if field.validators?
-          end
-
-          def add_known_type_validations!
-            field_type = DataWarehouse::KnownFields.type_for(field.warehouse_name)
-            options.merge!(PRIMITIVE_TYPE_VALIDATIONS.fetch(field_type))
           end
         end
       end

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -14,7 +14,7 @@ class Framework
 
             options.merge!(PRIMITIVE_TYPE_VALIDATIONS.fetch(field.primitive_type))
 
-            options.delete(:presence) if field.primitive_type == :urn # The URN validator covers this
+            options.delete(:presence) if no_presence_required? # The URN validator covers this
             set_optional_modifiers! if field.optional?
 
             options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
@@ -22,6 +22,10 @@ class Framework
           end
 
           private
+
+          def no_presence_required?
+            field.primitive_type == :urn || field.lookup?
+          end
 
           def set_optional_modifiers!
             options.delete(:presence)

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -14,7 +14,7 @@ class Framework
 
             options.merge!(PRIMITIVE_TYPE_VALIDATIONS.fetch(field.primitive_type))
 
-            options.delete(:presence) if no_presence_required? # The URN validator covers this
+            options.delete(:presence) if no_presence_required?
             set_optional_modifiers! if field.optional?
 
             options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
@@ -24,7 +24,9 @@ class Framework
           private
 
           def no_presence_required?
-            field.primitive_type == :urn || field.lookup?
+            # Validators like UrnValidator and the case_insensitive_inclusion used for
+            # YesNo fields don't require an accompanying +presence: true+
+            %i[urn yesno].include?(field.primitive_type) || field.lookup?
           end
 
           def set_optional_modifiers!

--- a/app/models/framework/definition/data_warehouse/known_fields.rb
+++ b/app/models/framework/definition/data_warehouse/known_fields.rb
@@ -20,7 +20,7 @@ class Framework
           'InvoiceNumber' => :string,
           'UNSPSC' => :integer,
           'VATCharged' => :decimal,
-          'LotNumber' => :string,
+          'LotNumber' => :lot_number,
           'PromotionCode' => :string
         }.freeze
 

--- a/app/models/framework/definition/data_warehouse/known_fields.rb
+++ b/app/models/framework/definition/data_warehouse/known_fields.rb
@@ -19,7 +19,9 @@ class Framework
           'UnitQuantity' => :decimal,
           'InvoiceNumber' => :string,
           'UNSPSC' => :integer,
-          'VATCharged' => :decimal
+          'VATCharged' => :decimal,
+          'LotNumber' => :string,
+          'PromotionCode' => :string
         }.freeze
 
         def self.type_for(value)

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -14,10 +14,10 @@ class Framework
       rule(:framework_identifier) { match(%r{[A-Z0-9/]}).repeat(1).as(:string) }
       rule(:framework_block)      { braced(spaced(metadata) >> spaced(invoice_fields) >> spaced(lookups_block.as(:lookups)).maybe) }
       rule(:framework_name)       { str('Name') >> spaced(string.as(:framework_name)) }
-      rule(:management_charge)    { str('ManagementCharge') >> (column_based.as(:column_based) | flat_rate).as(:management_charge) }
-      rule(:flat_rate)            { spaced(percentage).as(:flat_rate) >> flat_rate_column.maybe }
+      rule(:management_charge)    { str('ManagementCharge') >> (column_based | flat_rate).as(:management_charge) }
+      rule(:flat_rate)            { (spaced(percentage).as(:value) >> flat_rate_column.maybe).as(:flat_rate) }
       rule(:flat_rate_column)     { spaced(str('of')) >> string.as(:column) }
-      rule(:column_based)         { spaced(str('varies_by')) >> spaced(string).as(:column_name) >> spaced(dictionary).as(:value_to_percentage) }
+      rule(:column_based)         { spaced(str('varies_by')) >> (spaced(string).as(:column_name) >> spaced(dictionary).as(:value_to_percentage)).as(:column_based) }
       rule(:invoice_fields)       { str('InvoiceFields') >> spaced(fields_block.as(:invoice_fields)) }
       rule(:fields_block)         { braced(spaced(field_defs)) }
 

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -20,7 +20,7 @@ class Framework
 
       rule(:field_defs)           { field_def.repeat(1) }
       rule(:field_def)            { unknown_field | known_field | additional_field }
-      rule(:known_field)          { optional >> pascal_case_identifier.as(:field) >> from_specifier }
+      rule(:known_field)          { optional >> additional_field_identifier.absent? >> pascal_case_identifier.as(:field) >> from_specifier }
       rule(:additional_field)     { optional >> type >> space >> additional_field_identifier.as(:field) >> from_specifier }
       rule(:unknown_field)        { optional >> primitive_type >> space >> from_specifier }
       rule(:type)                 { pascal_case_identifier.as(:type) }

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -14,7 +14,9 @@ class Framework
       rule(:framework_identifier) { match(%r{[A-Z0-9/]}).repeat(1).as(:string) }
       rule(:framework_block)      { braced(spaced(metadata) >> spaced(invoice_fields) >> spaced(lookups_block.as(:lookups)).maybe) }
       rule(:framework_name)       { str('Name') >> spaced(string.as(:framework_name)) }
-      rule(:management_charge)    { str('ManagementCharge') >> spaced(percentage).as(:management_charge) }
+      rule(:management_charge)    { str('ManagementCharge') >> (column_based.as(:column_based) | flat_rate.as(:flat_rate)).as(:management_charge) }
+      rule(:flat_rate)            { spaced(percentage) }
+      rule(:column_based)         { spaced(str('varies_by')) >> spaced(string).as(:column_name) >> spaced(dictionary).as(:value_to_percentage) }
       rule(:invoice_fields)       { str('InvoiceFields') >> spaced(fields_block.as(:invoice_fields)) }
       rule(:fields_block)         { braced(spaced(field_defs)) }
 
@@ -34,15 +36,18 @@ class Framework
 
       rule(:metadata)             { framework_name >> management_charge }
 
+      rule(:map)                  { string.as(:key) >> spaced(str('->')) >> percentage.as(:value) >> space? }
+      rule(:dictionary)           { braced(map.repeat(1).as(:dictionary)) }
+
       rule(:string) do
         str("'") >> (
           str("'").absent? >> any
         ).repeat.as(:string) >> str("'") >> space?
       end
 
-      rule(:integer)    { match(/[0-9]/).repeat >> space? }
-      rule(:decimal)    { (integer >> (str('.') >> integer >> space?)).as(:decimal) >> space? }
-      rule(:percentage) { (decimal | integer).as(:flat_rate) >> str('%') >> space? }
+      rule(:integer)    { match(/[0-9]/).repeat.as(:integer) >> space? }
+      rule(:decimal)    { (match(/[0-9]/).repeat >> (str('.') >> match(/[0-9]/).repeat >> space?)).as(:decimal) >> space? }
+      rule(:percentage) { (decimal | integer) >> str('%') }
 
       rule(:space)   { match(/\s/).repeat(1) }
       rule(:space?)  { space.maybe }

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -24,9 +24,9 @@ class Framework
       rule(:field_def)            { unknown_field | known_field | additional_field }
       rule(:known_field)          { optional >> additional_field_identifier.absent? >> pascal_case_identifier.as(:field) >> from_specifier }
       rule(:additional_field)     { optional >> type >> space >> additional_field_identifier.as(:field) >> from_specifier }
-      rule(:unknown_field)        { optional >> primitive_type >> space >> from_specifier }
-      rule(:type)                 { pascal_case_identifier.as(:type) }
-      rule(:primitive_type)       { str('String').as(:type) }
+      rule(:unknown_field)        { optional >> primitive_type.as(:type) >> space >> from_specifier }
+      rule(:type)                 { (primitive_type | pascal_case_identifier.as(:lookup)).as(:type) }
+      rule(:primitive_type)       { (str('String') | str('Date') | str('Integer') | str('Decimal') | str('YesNo')).as(:primitive) }
       rule(:from_specifier)       { spaced(str('from')) >> string.as(:from) }
       rule(:optional)             { spaced(str('optional').as(:optional).maybe) }
 

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -24,10 +24,10 @@ class Framework
       rule(:field_defs)           { field_def.repeat(1) }
       rule(:field_def)            { unknown_field | known_field | additional_field }
       rule(:known_field)          { optional >> additional_field_identifier.absent? >> pascal_case_identifier.as(:field) >> from_specifier }
-      rule(:additional_field)     { optional >> type >> space >> additional_field_identifier.as(:field) >> from_specifier }
-      rule(:unknown_field)        { optional >> primitive_type.as(:type) >> space >> from_specifier }
-      rule(:type)                 { (primitive_type | pascal_case_identifier.as(:lookup)).as(:type) }
-      rule(:primitive_type)       { (str('String') | str('Date') | str('Integer') | str('Decimal') | str('YesNo')).as(:primitive) }
+      rule(:additional_field)     { optional >> type_def >> space >> additional_field_identifier.as(:field) >> from_specifier }
+      rule(:unknown_field)        { optional >> primitive_type_def.as(:type_def) >> space >> from_specifier }
+      rule(:type_def)             { (primitive_type_def | pascal_case_identifier.as(:lookup)).as(:type_def) }
+      rule(:primitive_type_def)   { (str('String') | str('Date') | str('Integer') | str('Decimal') | str('YesNo')).as(:primitive) }
       rule(:from_specifier)       { spaced(str('from')) >> string.as(:from) }
       rule(:optional)             { spaced(str('optional').as(:optional).maybe) }
 

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -14,8 +14,9 @@ class Framework
       rule(:framework_identifier) { match(%r{[A-Z0-9/]}).repeat(1).as(:string) }
       rule(:framework_block)      { braced(spaced(metadata) >> spaced(invoice_fields) >> spaced(lookups_block.as(:lookups)).maybe) }
       rule(:framework_name)       { str('Name') >> spaced(string.as(:framework_name)) }
-      rule(:management_charge)    { str('ManagementCharge') >> (column_based.as(:column_based) | flat_rate.as(:flat_rate)).as(:management_charge) }
-      rule(:flat_rate)            { spaced(percentage) }
+      rule(:management_charge)    { str('ManagementCharge') >> (column_based.as(:column_based) | flat_rate).as(:management_charge) }
+      rule(:flat_rate)            { spaced(percentage).as(:flat_rate) >> flat_rate_column.maybe }
+      rule(:flat_rate_column)     { spaced(str('of')) >> string.as(:column) }
       rule(:column_based)         { spaced(str('varies_by')) >> spaced(string).as(:column_name) >> spaced(dictionary).as(:value_to_percentage) }
       rule(:invoice_fields)       { str('InvoiceFields') >> spaced(fields_block.as(:invoice_fields)) }
       rule(:fields_block)         { braced(spaced(field_defs)) }

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -57,8 +57,8 @@ class Framework
           )
         elsif info[:flat_rate]
           ManagementChargeCalculator::FlatRate.new(
-            percentage: info[:flat_rate],
-            column: info[:column]
+            percentage: info.dig(:flat_rate, :value),
+            column: info.dig(:flat_rate, :column)
           )
         end
       end

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -40,7 +40,7 @@ class Framework
           lookups ast[:lookups]
 
           ast[:invoice_fields].each do |field_def|
-            field = AST::Field.new(field_def)
+            field = AST::Field.new(field_def, ast.fetch(:lookups, {}))
             # Always use a case_insensitive_inclusion validator if
             # there's a lookup with the same name as the field
             lookup_values = ast.dig(:lookups, field.lookup_name)

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -56,7 +56,10 @@ class Framework
             value_to_percentage: info.dig(:column_based, :value_to_percentage)
           )
         elsif info[:flat_rate]
-          ManagementChargeCalculator::FlatRate.new(percentage: info[:flat_rate])
+          ManagementChargeCalculator::FlatRate.new(
+            percentage: info[:flat_rate],
+            column: info[:column]
+          )
         end
       end
     end

--- a/app/models/framework/management_charge_calculator/flat_rate.rb
+++ b/app/models/framework/management_charge_calculator/flat_rate.rb
@@ -7,7 +7,7 @@ class Framework
     # calculated against another column, that can be specified with the `column`
     # attribute.
     class FlatRate
-      attr_reader :percentage
+      attr_reader :percentage, :column
 
       def initialize(percentage:, column: nil)
         @percentage = BigDecimal(percentage)

--- a/lib/fdl/validations/test/compare.rb
+++ b/lib/fdl/validations/test/compare.rb
@@ -47,8 +47,6 @@ module FDL
           HashDiff.diff(original_errors, fdl_errors)
         end
 
-        private
-
         def fdl_invoice_class
           @fdl_invoice_class ||= fdl_definition::Invoice
         end

--- a/spec/lib/fdl/validation/failing_cases_spec.rb
+++ b/spec/lib/fdl/validation/failing_cases_spec.rb
@@ -54,68 +54,127 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
     let(:framework)  { create :framework, short_name: short_name }
     let!(:lot)       { create :framework_lot, framework: framework }
 
-    let(:data) do
-      {
-        'UNSPSC' => nil,
-        'CAP Code' => 'PEXXXXXXXXXXXX',
-        'Fuel Type' => 'Diesel',
-        'Lot Number' => 1,
-        'Spend Code' => 'Lease Rental',
-        'Cost Centre' => 'HEAD OFFICE',
-        'Customer URN' => 10004186,
-        'Lease Period' => 70,
-        'Product Code' => nil,
-        'Vehicle Make' => 'Peugeot',
-        'Vehicle Type' => nil,
-        'Vehicle Model' => 508,
-        'Lease End Date' => '3/26/17',
-        'Residual Value' => 6200,
-        'VAT Applicable' => 'Y',
-        'Contract Number' => 314021,
-        'Payment Profile' => 'Annual in advance',
-        'Lease Start Date' => '3/27/13',
-        'Unit of Purchase' => 'per vehicle',
-        'Customer PostCode' => 'BS32 4UD',
-        'VAT Amount Charged' => 68.51,
-        'Vehicle Derivative' => '508 SW Diesel Estate 2.0 HDi 163 Allure 5Dr',
-        'CO2 Emission Levels' => 130,
-        'Annual Lease Mileage' => 15000,
-        'Vehicle Registration' => 'XXXXXXX',
-        'Customer Invoice Date' => '12/31/18',
-        'Customer Organisation' => 'Agent’s Agency',
-        'Invoice Line Quantity' => 1,
-        'Price per Unit ex VAT' => 342.56,
-        'Supplier Order Number' => nil,
-        'Expenses/Disbursements' => nil,
-        'Product Classification' => 'Lower Medium',
-        'Vehicle Purchase Terms' => 'RM858',
-        'Customer Invoice Number' => 199999,
-        'Vehicle Conversion Type' => nil,
-        'Vehicle Convertors Name' => nil,
-        'Base Vehicle Price ex VAT' => 14687.52,
-        'Lease Finance Charge ex VAT' => 267.67,
-        'Lease Finance Margin ex VAT' => 4.5,
-        'Customer Invoice Line Number' => 1,
-        'Enhanced Vehicle Discount (%)' => 0,
-        'Standard Vehicle Discount (%)' => 29.75,
-        'Invoice Line Total Value ex VAT' => 342.56,
-        'Customer Order Number / Reference' => nil,
-        'Invoice Line Product / Service Grouping' => 'MadeUp Capital',
-        'Annual Breakdown & Recovery Costs ex VAT' => 0,
-        'Invoice Line Product / Service Description' => 'Car - Lease sourcing',
-        'Annual Service Maintenance & Repair Costs ex VAT' => 74.89,
-        'Lease Cost excluding Optional Extras and Conversion ex VAT' => 340.29
-      }
+    context 'Lot number problem' do
+      let(:data) do
+        {
+          'UNSPSC' => nil,
+          'CAP Code' => 'PEXXXXXXXXXXXX',
+          'Fuel Type' => 'Diesel',
+          'Lot Number' => 1,
+          'Spend Code' => 'Lease Rental',
+          'Cost Centre' => 'HEAD OFFICE',
+          'Customer URN' => 10004186,
+          'Lease Period' => 70,
+          'Product Code' => nil,
+          'Vehicle Make' => 'Peugeot',
+          'Vehicle Type' => nil,
+          'Vehicle Model' => 508,
+          'Lease End Date' => '3/26/17',
+          'Residual Value' => 6200,
+          'VAT Applicable' => 'Y',
+          'Contract Number' => 314021,
+          'Payment Profile' => 'Annual in advance',
+          'Lease Start Date' => '3/27/13',
+          'Unit of Purchase' => 'per vehicle',
+          'Customer PostCode' => 'BS32 4UD',
+          'VAT Amount Charged' => 68.51,
+          'Vehicle Derivative' => '508 SW Diesel Estate 2.0 HDi 163 Allure 5Dr',
+          'CO2 Emission Levels' => 130,
+          'Annual Lease Mileage' => 15000,
+          'Vehicle Registration' => 'XXXXXXX',
+          'Customer Invoice Date' => '12/31/18',
+          'Customer Organisation' => 'Agent’s Agency',
+          'Invoice Line Quantity' => 1,
+          'Price per Unit ex VAT' => 342.56,
+          'Supplier Order Number' => nil,
+          'Expenses/Disbursements' => nil,
+          'Product Classification' => 'Lower Medium',
+          'Vehicle Purchase Terms' => 'RM858',
+          'Customer Invoice Number' => 199999,
+          'Vehicle Conversion Type' => nil,
+          'Vehicle Convertors Name' => nil,
+          'Base Vehicle Price ex VAT' => 14687.52,
+          'Lease Finance Charge ex VAT' => 267.67,
+          'Lease Finance Margin ex VAT' => 4.5,
+          'Customer Invoice Line Number' => 1,
+          'Enhanced Vehicle Discount (%)' => 0,
+          'Standard Vehicle Discount (%)' => 29.75,
+          'Invoice Line Total Value ex VAT' => 342.56,
+          'Customer Order Number / Reference' => nil,
+          'Invoice Line Product / Service Grouping' => 'MadeUp Capital',
+          'Annual Breakdown & Recovery Costs ex VAT' => 0,
+          'Invoice Line Product / Service Description' => 'Car - Lease sourcing',
+          'Annual Service Maintenance & Repair Costs ex VAT' => 74.89,
+          'Lease Cost excluding Optional Extras and Conversion ex VAT' => 340.29
+        }
+      end
+
+      ##
+      # Error was:
+      #   [["-", "Lot Number", "is not included in the supplier framework agreement"]]
+      #
+      # Fixed by: changing the KnownFields type of LotNumber from :string to :lot_number
+      # and adding the LotInAgreementValidator when necessary.
+      it { is_expected.to be_empty }
     end
 
-    ##
-    # Error was:
-    #   [["-", "Lot Number", "is not included in the supplier framework agreement"]]
-    #
-    # Fixed by: changing the KnownFields type of LotNumber from :string to :lot_number
-    # and adding the LotInAgreementValidator when necessary.
-    it { is_expected.to be_empty }
+    context 'Spend code problem' do
+      let(:data) do
+        {
+          'Lot Number' => '2',
+          'Customer PostCode' => 'BX99 4XX',
+          'Customer Organisation' => 'MINISTRY OF TRUTH',
+          'Customer URN' => 1999994,
+          'Customer Invoice Date' => '12/31/18',
+          'Customer Invoice Number' => '59999999',
+          'Customer Invoice Line Number' => '1',
+          'Invoice Line Product / Service Description' => 'LCV',
+          'Unit of Purchase' => 'Each',
+          'Price per Unit ex VAT' => nil,
+          'Invoice Line Quantity' => '1',
+          'Invoice Line Total Value ex VAT' => nil,
+          'VAT Applicable' => 'Y',
+          'VAT Amount Charged' => nil,
+          'Spend Code' => nil,
+          'Invoice Line Product / Service Grouping' => 'Automotive Leasing',
+          'CAP Code' => 'XXXXXXXXX',
+          'Vehicle Make' => 'Fiat',
+          'Vehicle Model' => 'Panda',
+          'Vehicle Derivative' => 'Cross 0.87',
+          'Product Classification' => 'LCV',
+          'Vehicle Registration' => 'XXXXXXXX',
+          'Vehicle Convertors Name' => 'N/A',
+          'Vehicle Conversion Type' => '2-Way Radio/Air conditioning/Bright Orange',
+          'Vehicle Type' => 'N/A',
+          'Fuel Type' => 'Diesel',
+          'CO2 Emission Levels' => '206',
+          'Lease Period' => '60',
+          'Lease Start Date' => '1/20/16',
+          'Lease End Date' => '1/19/21',
+          'Payment Profile' => 'Monthly',
+          'Annual Lease Mileage' => '20000',
+          'Base Vehicle Price ex VAT' => '18276.52',
+          'Lease Cost excluding Optional Extras and Conversion ex VAT' => '3732.12',
+          'Lease Finance Charge ex VAT' => '3111',
+          'Lease Finance Margin ex VAT' => '3.06%',
+          'Vehicle Purchase Terms' => 'Buying Solutions Vehicle Purchase Framework RM859',
+          'Standard Vehicle Discount (%)' => '28',
+          'Enhanced Vehicle Discount (%)' => '0',
+          'Annual Service Maintenance & Repair Costs ex VAT' => '646.12',
+          'Annual Breakdown & Recovery Costs ex VAT' => '46.2',
+          'Residual Value' => '5248.5',
+          'Cost Centre' => '2',
+          'Contract Number' => '99999'
+        }
+      end
+
+      it 'behaves slightly differently to the Ruby' do
+        # The Ruby has an +InclusionValidator+ which behaves slightly
+        # differently to the +CaseInsensitiveInclusionValidator+ we use. This is the diff:
+        expect(diff).to eql([['-', 'Spend Code', 'is not included in the list']])
+        # ... and this is the question it raised:
+        # https://trello.com/c/CsjBwtkd/929-case-sensitive-vs-case-insensitive-inclusion-validators-what-should-we-do
+      end
+    end
   end
-
-
 end

--- a/spec/lib/fdl/validation/failing_cases_spec.rb
+++ b/spec/lib/fdl/validation/failing_cases_spec.rb
@@ -176,5 +176,11 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
         # https://trello.com/c/CsjBwtkd/929-case-sensitive-vs-case-insensitive-inclusion-validators-what-should-we-do
       end
     end
+
+    context 'All the problems' do
+      let(:data) { { 'Contract Number' => 'N/A' } }
+
+      it { is_expected.to eql([['-', 'Spend Code', 'is not included in the list']]) }
+    end
   end
 end

--- a/spec/lib/fdl/validation/failing_cases_spec.rb
+++ b/spec/lib/fdl/validation/failing_cases_spec.rb
@@ -44,4 +44,78 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
     # so we can treat all lookups as if they have type :string
     it { is_expected.to be_empty }
   end
+
+  context 'Framework RM858' do
+    let(:short_name) { 'RM858' }
+    let(:supplier)   { create :supplier }
+    let(:entry)      { build(:submission_entry, submission: submission, data: data) }
+    let!(:agreement) { create :agreement, supplier: supplier, framework: framework }
+    let(:submission) { create :submission, supplier: supplier, framework: framework }
+    let(:framework)  { create :framework, short_name: short_name }
+    let!(:lot)       { create :framework_lot, framework: framework }
+
+    let(:data) do
+      {
+        'UNSPSC' => nil,
+        'CAP Code' => 'PEXXXXXXXXXXXX',
+        'Fuel Type' => 'Diesel',
+        'Lot Number' => 1,
+        'Spend Code' => 'Lease Rental',
+        'Cost Centre' => 'HEAD OFFICE',
+        'Customer URN' => 10004186,
+        'Lease Period' => 70,
+        'Product Code' => nil,
+        'Vehicle Make' => 'Peugeot',
+        'Vehicle Type' => nil,
+        'Vehicle Model' => 508,
+        'Lease End Date' => '3/26/17',
+        'Residual Value' => 6200,
+        'VAT Applicable' => 'Y',
+        'Contract Number' => 314021,
+        'Payment Profile' => 'Annual in advance',
+        'Lease Start Date' => '3/27/13',
+        'Unit of Purchase' => 'per vehicle',
+        'Customer PostCode' => 'BS32 4UD',
+        'VAT Amount Charged' => 68.51,
+        'Vehicle Derivative' => '508 SW Diesel Estate 2.0 HDi 163 Allure 5Dr',
+        'CO2 Emission Levels' => 130,
+        'Annual Lease Mileage' => 15000,
+        'Vehicle Registration' => 'XXXXXXX',
+        'Customer Invoice Date' => '12/31/18',
+        'Customer Organisation' => 'Agent’s Agency',
+        'Invoice Line Quantity' => 1,
+        'Price per Unit ex VAT' => 342.56,
+        'Supplier Order Number' => nil,
+        'Expenses/Disbursements' => nil,
+        'Product Classification' => 'Lower Medium',
+        'Vehicle Purchase Terms' => 'RM858',
+        'Customer Invoice Number' => 199999,
+        'Vehicle Conversion Type' => nil,
+        'Vehicle Convertors Name' => nil,
+        'Base Vehicle Price ex VAT' => 14687.52,
+        'Lease Finance Charge ex VAT' => 267.67,
+        'Lease Finance Margin ex VAT' => 4.5,
+        'Customer Invoice Line Number' => 1,
+        'Enhanced Vehicle Discount (%)' => 0,
+        'Standard Vehicle Discount (%)' => 29.75,
+        'Invoice Line Total Value ex VAT' => 342.56,
+        'Customer Order Number / Reference' => nil,
+        'Invoice Line Product / Service Grouping' => 'MadeUp Capital',
+        'Annual Breakdown & Recovery Costs ex VAT' => 0,
+        'Invoice Line Product / Service Description' => 'Car - Lease sourcing',
+        'Annual Service Maintenance & Repair Costs ex VAT' => 74.89,
+        'Lease Cost excluding Optional Extras and Conversion ex VAT' => 340.29
+      }
+    end
+
+    ##
+    # Error was:
+    #   [["-", "Lot Number", "is not included in the supplier framework agreement"]]
+    #
+    # Fixed by: changing the KnownFields type of LotNumber from :string to :lot_number
+    # and adding the LotInAgreementValidator when necessary.
+    it { is_expected.to be_empty }
+  end
+
+
 end

--- a/spec/models/framework/definition/ast/field_spec.rb
+++ b/spec/models/framework/definition/ast/field_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Framework::Definition::AST::Field do
-  subject(:field) { Framework::Definition::AST::Field.new(field_def) }
+  let(:lookups)   { {} }
+  subject(:field) { Framework::Definition::AST::Field.new(field_def, lookups) }
 
   context 'a known field' do
     let(:field_def) do
@@ -45,22 +46,42 @@ RSpec.describe Framework::Definition::AST::Field do
     end
 
     context 'with a lookup (non-primitive) type' do
-      let(:field_def) do
-        {
-          kind: :additional,
-          optional: true,
-          type:  'PaymentProfile',
-          field: 'Additional2',
-          from:  'Payment Profile'
-        }
+      context 'on an Additional field' do
+        let(:field_def) do
+          {
+            kind: :additional,
+            optional: true,
+            type:  'PaymentProfile',
+            field: 'Additional2',
+            from:  'Payment Profile'
+          }
+        end
+
+        it { is_expected.to be_lookup }
+        it 'has a lookup_name' do
+          expect(field.lookup_name).to eql('PaymentProfile')
+        end
+        it 'always treats lookups types as :string' do
+          expect(field.primitive_type).to eql(:string)
+        end
       end
 
-      it { is_expected.to be_lookup }
-      it 'has a lookup_name' do
-        expect(field.lookup_name).to eql('PaymentProfile')
-      end
-      it 'always treats lookups types as :string' do
-        expect(field.primitive_type).to eql(:string)
+      context 'A known field' do
+        let(:lookups) do
+          {
+            'PromotionCode' => [
+              'Lease Rental', 'Fleet Management Fee', 'Damage', 'Other Re-charges'
+            ]
+          }
+        end
+        let(:field_def) do
+          { kind: :known, field: 'PromotionCode', from: 'Spend Code' }
+        end
+
+        it { is_expected.to be_lookup }
+        it 'has a lookup name the same as its warehouse name' do
+          expect(field.lookup_name).to eql('PromotionCode')
+        end
       end
     end
   end

--- a/spec/models/framework/definition/ast/field_spec.rb
+++ b/spec/models/framework/definition/ast/field_spec.rb
@@ -3,12 +3,13 @@ require 'rails_helper'
 RSpec.describe Framework::Definition::AST::Field do
   let(:lookups)   { {} }
   subject(:field) { Framework::Definition::AST::Field.new(field_def, lookups) }
+  let(:parser)    { Framework::Definition::Parser.new }
+  let(:cst)       { parser.field_def.parse(source) }
+  let(:field_def) { Framework::Definition::AST::Creator.new.apply(cst) }
 
   describe 'known fields' do
     context 'of a primitive type' do
-      let(:field_def) do
-        { kind: :known, field: 'CustomerURN', from: 'Customer URN' }
-      end
+      let(:source) { "CustomerURN from 'Customer URN'" }
 
       it      { is_expected.not_to be_lookup }
       example { expect(field.primitive_type).to eql(:urn) }
@@ -22,9 +23,7 @@ RSpec.describe Framework::Definition::AST::Field do
           ]
         }
       end
-      let(:field_def) do
-        { kind: :known, field: 'PromotionCode', from: 'Spend Code' }
-      end
+      let(:source) { "PromotionCode from 'Spend Code'" }
 
       it { is_expected.to be_lookup }
 
@@ -36,15 +35,7 @@ RSpec.describe Framework::Definition::AST::Field do
 
   context 'an additional field' do
     context 'with a primitive type of String' do
-      let(:field_def) do
-        {
-          kind: :additional,
-          optional: true,
-          type:  'String',
-          field: 'Additional3',
-          from:  'Subcontractor Supplier Name'
-        }
-      end
+      let(:source) { "optional String Additional3 from 'Subcontractor Supplier Name'" }
 
       it      { is_expected.not_to be_lookup }
       example { expect(field.primitive_type).to eql(:string) }
@@ -52,15 +43,7 @@ RSpec.describe Framework::Definition::AST::Field do
     end
 
     context 'with a primitive type of Date' do
-      let(:field_def) do
-        {
-          kind: :additional,
-          optional: true,
-          type:  'Date',
-          field: 'Additional10',
-          from:  'Lease Start Date'
-        }
-      end
+      let(:source) { "optional Date Additional10 from 'Lease Start Date'" }
 
       it      { is_expected.not_to be_lookup }
       example { expect(field.primitive_type).to eql(:date) }
@@ -68,15 +51,7 @@ RSpec.describe Framework::Definition::AST::Field do
 
     context 'with a lookup (non-primitive) type' do
       context 'on an Additional field' do
-        let(:field_def) do
-          {
-            kind: :additional,
-            optional: true,
-            type:  'PaymentProfile',
-            field: 'Additional2',
-            from:  'Payment Profile'
-          }
-        end
+        let(:source) { "optional PaymentProfile Additional2 from 'Payment Profile'" }
 
         it { is_expected.to be_lookup }
         it 'has a lookup_name' do
@@ -90,9 +65,7 @@ RSpec.describe Framework::Definition::AST::Field do
   end
 
   context 'an unknown field' do
-    let(:field_def) do
-      { kind: :unknown, optional: true, type: 'String', from: 'Cost Centre' }
-    end
+    let(:source) { "optional String from 'Cost Centre'" }
 
     it      { is_expected.not_to be_lookup }
     example { expect(field.primitive_type).to eql(:string) }

--- a/spec/models/framework/definition/ast/field_spec.rb
+++ b/spec/models/framework/definition/ast/field_spec.rb
@@ -4,13 +4,34 @@ RSpec.describe Framework::Definition::AST::Field do
   let(:lookups)   { {} }
   subject(:field) { Framework::Definition::AST::Field.new(field_def, lookups) }
 
-  context 'a known field' do
-    let(:field_def) do
-      { kind: :known, field: 'CustomerURN', from: 'Customer URN' }
+  describe 'known fields' do
+    context 'of a primitive type' do
+      let(:field_def) do
+        { kind: :known, field: 'CustomerURN', from: 'Customer URN' }
+      end
+
+      it      { is_expected.not_to be_lookup }
+      example { expect(field.primitive_type).to eql(:urn) }
     end
 
-    it      { is_expected.not_to be_lookup }
-    example { expect(field.primitive_type).to eql(:urn) }
+    context 'the known field name matches a lookup name' do
+      let(:lookups) do
+        {
+          'PromotionCode' => [
+            'Lease Rental', 'Fleet Management Fee', 'Damage', 'Other Re-charges'
+          ]
+        }
+      end
+      let(:field_def) do
+        { kind: :known, field: 'PromotionCode', from: 'Spend Code' }
+      end
+
+      it { is_expected.to be_lookup }
+
+      it 'has a lookup name the same as its warehouse name' do
+        expect(field.lookup_name).to eql('PromotionCode')
+      end
+    end
   end
 
   context 'an additional field' do
@@ -63,24 +84,6 @@ RSpec.describe Framework::Definition::AST::Field do
         end
         it 'always treats lookups types as :string' do
           expect(field.primitive_type).to eql(:string)
-        end
-      end
-
-      context 'A known field' do
-        let(:lookups) do
-          {
-            'PromotionCode' => [
-              'Lease Rental', 'Fleet Management Fee', 'Damage', 'Other Re-charges'
-            ]
-          }
-        end
-        let(:field_def) do
-          { kind: :known, field: 'PromotionCode', from: 'Spend Code' }
-        end
-
-        it { is_expected.to be_lookup }
-        it 'has a lookup name the same as its warehouse name' do
-          expect(field.lookup_name).to eql('PromotionCode')
         end
       end
     end

--- a/spec/models/framework/definition/ast/field_spec.rb
+++ b/spec/models/framework/definition/ast/field_spec.rb
@@ -1,55 +1,76 @@
 require 'rails_helper'
 
 RSpec.describe Framework::Definition::AST::Field do
-  describe '#primitive_type' do
-    subject(:primitive_type) { Framework::Definition::AST::Field.new(field_def).primitive_type }
+  subject(:field) { Framework::Definition::AST::Field.new(field_def) }
 
-    context 'a known field' do
+  context 'a known field' do
+    let(:field_def) do
+      { kind: :known, field: 'CustomerURN', from: 'Customer URN' }
+    end
+
+    it      { is_expected.not_to be_lookup }
+    example { expect(field.primitive_type).to eql(:urn) }
+  end
+
+  context 'an additional field' do
+    context 'with a primitive type of String' do
       let(:field_def) do
-        { kind: :known, field: 'CustomerURN', from: 'Customer URN' }
+        {
+          kind: :additional,
+          optional: true,
+          type:  'String',
+          field: 'Additional3',
+          from:  'Subcontractor Supplier Name'
+        }
       end
 
-      it { is_expected.to eql(:urn) }
+      it      { is_expected.not_to be_lookup }
+      example { expect(field.primitive_type).to eql(:string) }
+      example { expect(field.lookup_name).to be_nil }
     end
 
-    context 'an additional field' do
-      context 'with a primitive type' do
-        let(:field_def) do
-          {
-            kind: :additional,
-            optional: true,
-            type:  'String',
-            field: 'Additional3',
-            from:  'Subcontractor Supplier Name'
-          }
-        end
-
-        it { is_expected.to eql(:string) }
-      end
-
-      context 'with a lookup type' do
-        let(:field_def) do
-          {
-            kind: :additional,
-            optional: true,
-            type:  'PaymentProfile',
-            field: 'Additional2',
-            from:  'Payment Profile'
-          }
-        end
-
-        it 'always treats lookups types as :string' do
-          expect(primitive_type).to eql(:string)
-        end
-      end
-    end
-
-    context 'an unknown field' do
+    context 'with a primitive type of Date' do
       let(:field_def) do
-        { kind: :unknown, optional: true, type: 'String', from: 'Cost Centre' }
+        {
+          kind: :additional,
+          optional: true,
+          type:  'Date',
+          field: 'Additional10',
+          from:  'Lease Start Date'
+        }
       end
 
-      it { is_expected.to eql(:string) }
+      it      { is_expected.not_to be_lookup }
+      example { expect(field.primitive_type).to eql(:date) }
     end
+
+    context 'with a lookup (non-primitive) type' do
+      let(:field_def) do
+        {
+          kind: :additional,
+          optional: true,
+          type:  'PaymentProfile',
+          field: 'Additional2',
+          from:  'Payment Profile'
+        }
+      end
+
+      it { is_expected.to be_lookup }
+      it 'has a lookup_name' do
+        expect(field.lookup_name).to eql('PaymentProfile')
+      end
+      it 'always treats lookups types as :string' do
+        expect(field.primitive_type).to eql(:string)
+      end
+    end
+  end
+
+  context 'an unknown field' do
+    let(:field_def) do
+      { kind: :unknown, optional: true, type: 'String', from: 'Cost Centre' }
+    end
+
+    it      { is_expected.not_to be_lookup }
+    example { expect(field.primitive_type).to eql(:string) }
   end
 end

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -193,6 +193,21 @@ RSpec.describe Framework::Definition::Language do
             .with_activemodel_type(:string)
             .validated_by(:ingested_date)
         }
+
+        let(:expected_promotion_code_values) do
+          [
+            'Lease Rental',
+            'Fleet Management Fee',
+            'Damage',
+            'Other Re-charges'
+          ]
+        end
+
+        it {
+          is_expected.to have_field('Spend Code')
+            .with_activemodel_type(:string)
+            .validated_by(case_insensitive_inclusion: { in: expected_promotion_code_values })
+        }
       end
     end
 

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -184,6 +184,16 @@ RSpec.describe Framework::Definition::Language do
           )
         }
       end
+
+      describe 'the Invoice fields class' do
+        subject(:invoice_class) { definition::Invoice }
+
+        it {
+          is_expected.to have_field('Lease Start Date')
+            .with_activemodel_type(:string)
+            .validated_by(:ingested_date)
+        }
+      end
     end
 
     context 'our FDL isn\'t valid' do

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -161,6 +161,31 @@ RSpec.describe Framework::Definition::Language do
       end
     end
 
+    context 'Vehicle Leasing framework features' do
+      let(:source) do
+        File.read('app/models/framework/definition/RM858.fdl')
+      end
+
+      describe 'the Management Charge' do
+        subject(:management_charge) { definition.management_charge }
+
+        it {
+          is_expected.to match(
+            an_object_having_attributes(
+              varies_by: 'Spend Code',
+              value_to_percentage: {
+                # ManagementChargeCalculator::ColumnBased downcases its keys
+                'lease rental' => BigDecimal('0.5'),
+                'fleet management fee' => BigDecimal('0.5'),
+                'damage' => 0,
+                'other re-charges' => 0
+              }
+            )
+          )
+        }
+      end
+    end
+
     context 'our FDL isn\'t valid' do
       let(:source) { 'any old rubbish' }
 

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -196,6 +196,34 @@ RSpec.describe Framework::Definition::Language do
       end
     end
 
+    context 'an RM6060-like framework (so we can vary a flat-rate management charge by column)' do
+      let(:source) do
+        <<~FDL
+          Framework RM6060 {
+            Name 'Fake framework'
+            ManagementCharge 0.5% of 'Supplier Price'
+
+            InvoiceFields {
+              InvoiceValue from 'Supplier Price'
+            }
+          }
+        FDL
+      end
+
+      describe '#management_charge' do
+        subject(:management_charge) { definition.management_charge }
+
+        it {
+          is_expected.to match(
+            an_object_having_attributes(
+              column: 'Supplier Price',
+              percentage: BigDecimal('0.5')
+            )
+          )
+        }
+      end
+    end
+
     context 'our FDL isn\'t valid' do
       let(:source) { 'any old rubbish' }
 

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -97,23 +97,23 @@ RSpec.describe Framework::Definition::Parser do
     end
   end
 
-  describe '#type' do
-    subject { parser.type }
+  describe '#type_def' do
+    subject { parser.type_def }
 
-    context 'a lookup type' do
+    context 'a lookup type_def' do
       ##
-      # Anything that isn't a primitive type is considered a lookup type
+      # Anything that isn't a primitive type_def is considered a lookup type_def
       it {
         is_expected.to parse('PromotionCode').as(
-          type: { lookup: 'PromotionCode' }
+          type_def: { lookup: 'PromotionCode' }
         )
       }
     end
 
-    context 'a date type' do
+    context 'a date type_def' do
       it {
         is_expected.to parse('Date').as(
-          type: { primitive: 'Date' }
+          type_def: { primitive: 'Date' }
         )
       }
     end
@@ -145,7 +145,7 @@ RSpec.describe Framework::Definition::Parser do
     context 'mandatory field' do
       it {
         is_expected.to parse("String Additional1 from 'Manufacturers Product Code'").as(
-          type: { primitive: 'String' }, field: 'Additional1', from: { string: 'Manufacturers Product Code' }
+          type_def: { primitive: 'String' }, field: 'Additional1', from: { string: 'Manufacturers Product Code' }
         )
       }
     end
@@ -154,7 +154,7 @@ RSpec.describe Framework::Definition::Parser do
       it {
         is_expected.to parse("optional String Additional1 from 'Manufacturers Product Code'").as(
           optional: 'optional',
-          type: { primitive: 'String' },
+          type_def: { primitive: 'String' },
           field: 'Additional1',
           from: { string: 'Manufacturers Product Code' }
         )
@@ -168,7 +168,7 @@ RSpec.describe Framework::Definition::Parser do
     context 'mandatory field' do
       it {
         is_expected.to parse("String from 'Cost Centre'").as(
-          type: { primitive: 'String' }, from: { string: 'Cost Centre' }
+          type_def: { primitive: 'String' }, from: { string: 'Cost Centre' }
         )
       }
     end
@@ -176,7 +176,7 @@ RSpec.describe Framework::Definition::Parser do
     context 'optional field' do
       it {
         is_expected.to parse("optional String from 'Cost Centre'").as(
-          optional: 'optional', type: { primitive: 'String' }, from: { string: 'Cost Centre' }
+          optional: 'optional', type_def: { primitive: 'String' }, from: { string: 'Cost Centre' }
         )
       }
     end
@@ -196,7 +196,7 @@ RSpec.describe Framework::Definition::Parser do
     it 'has whatever fields are in the block' do
       expect(rule).to parse(fields).as(
         invoice_fields: [
-          { type: { primitive: 'String' }, field: 'Additional1', from: { string: 'Manufacturers Product Code' } },
+          { type_def: { primitive: 'String' }, field: 'Additional1', from: { string: 'Manufacturers Product Code' } },
         ]
       )
     end

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -82,6 +82,28 @@ RSpec.describe Framework::Definition::Parser do
     end
   end
 
+  describe '#type' do
+    subject { parser.type }
+
+    context 'a lookup type' do
+      ##
+      # Anything that isn't a primitive type is considered a lookup type
+      it {
+        is_expected.to parse('PromotionCode').as(
+          type: { lookup: 'PromotionCode' }
+        )
+      }
+    end
+
+    context 'a date type' do
+      it {
+        is_expected.to parse('Date').as(
+          type: { primitive: 'Date' }
+        )
+      }
+    end
+  end
+
   describe '#known_field' do
     subject { parser.known_field }
 
@@ -108,7 +130,7 @@ RSpec.describe Framework::Definition::Parser do
     context 'mandatory field' do
       it {
         is_expected.to parse("String Additional1 from 'Manufacturers Product Code'").as(
-          type: 'String', field: 'Additional1', from: { string: 'Manufacturers Product Code' }
+          type: { primitive: 'String' }, field: 'Additional1', from: { string: 'Manufacturers Product Code' }
         )
       }
     end
@@ -116,7 +138,10 @@ RSpec.describe Framework::Definition::Parser do
     context 'optional field' do
       it {
         is_expected.to parse("optional String Additional1 from 'Manufacturers Product Code'").as(
-          optional: 'optional', type: 'String', field: 'Additional1', from: { string: 'Manufacturers Product Code' }
+          optional: 'optional',
+          type: { primitive: 'String' },
+          field: 'Additional1',
+          from: { string: 'Manufacturers Product Code' }
         )
       }
     end
@@ -128,7 +153,7 @@ RSpec.describe Framework::Definition::Parser do
     context 'mandatory field' do
       it {
         is_expected.to parse("String from 'Cost Centre'").as(
-          type: 'String', from: { string: 'Cost Centre' }
+          type: { primitive: 'String' }, from: { string: 'Cost Centre' }
         )
       }
     end
@@ -136,7 +161,7 @@ RSpec.describe Framework::Definition::Parser do
     context 'optional field' do
       it {
         is_expected.to parse("optional String from 'Cost Centre'").as(
-          optional: 'optional', type: 'String', from: { string: 'Cost Centre' }
+          optional: 'optional', type: { primitive: 'String' }, from: { string: 'Cost Centre' }
         )
       }
     end
@@ -156,7 +181,7 @@ RSpec.describe Framework::Definition::Parser do
     it 'has whatever fields are in the block' do
       expect(rule).to parse(fields).as(
         invoice_fields: [
-          { type: 'String', field: 'Additional1', from: { string: 'Manufacturers Product Code' } },
+          { type: { primitive: 'String' }, field: 'Additional1', from: { string: 'Manufacturers Product Code' } },
         ]
       )
     end

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -50,8 +50,19 @@ RSpec.describe Framework::Definition::Parser do
   describe '#management_charge' do
     subject { parser.management_charge }
 
-    context 'flat rate' do
+    context 'simple flat rate' do
       it { is_expected.to parse('ManagementCharge 0.0%').as(management_charge: { flat_rate: { decimal: '0.0' } }) }
+    end
+
+    context 'flat rate from a named column' do
+      it {
+        is_expected.to parse("ManagementCharge 0.0% of 'Supplier Price'").as(
+          management_charge: {
+            flat_rate: { decimal: '0.0' },
+            column: { string: 'Supplier Price' }
+          }
+        )
+      }
     end
 
     context 'column based' do

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 require 'framework/definition/parser'
 
+##
+# These specs are for Parslet atoms and therefore will be matching the CST,
+# not the AST (which is the result of passing the CST through AST::Creator)
+
 RSpec.describe Framework::Definition::Parser do
   subject(:parser) { Framework::Definition::Parser.new }
   let(:framework_definition) do

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -55,15 +55,21 @@ RSpec.describe Framework::Definition::Parser do
     subject { parser.management_charge }
 
     context 'simple flat rate' do
-      it { is_expected.to parse('ManagementCharge 0.0%').as(management_charge: { flat_rate: { decimal: '0.0' } }) }
+      it {
+        is_expected.to parse('ManagementCharge 0.0%').as(
+          management_charge: { flat_rate: { value: { decimal: '0.0' } } }
+        )
+      }
     end
 
     context 'flat rate from a named column' do
       it {
         is_expected.to parse("ManagementCharge 0.0% of 'Supplier Price'").as(
           management_charge: {
-            flat_rate: { decimal: '0.0' },
-            column: { string: 'Supplier Price' }
+            flat_rate: {
+              value: { decimal: '0.0' },
+              column: { string: 'Supplier Price' }
+            }
           }
         )
       }


### PR DESCRIPTION
# [Implement Management Charge](https://trello.com/c/2Tbi09Gp/896-management-charge-rm858-rm3710)

Implement all three current variations of ManagementCharge currently in use in the `.rb` framework defs - column-based; flat-rate (already implemented before this PR) and flat-rate with a named source column. 

## Examples

### Flat rate with different source column to `total_value_field` 

*a la* `RM6060`:

```
  ManagementCharge 0.5% of 'Supplier Price'
```

### Column-based

```
  ManagementCharge varies_by 'Spend Code' {
    'Lease Rental'         -> 0.5%
    'Fleet Management Fee' -> 0.5%
    'Damage'               -> 0%
    'Other Re-charges'     -> 0%
  }
```

## Additional work

* Made the parser more robust in that Additional fields can't be accidentally parsed as Known fields.
* Added primitive types to the parser. Previously we only had `String`, but this framework required `Date` and `Decimal`. 
* Added `Field::PRIMITIVE_TYPE_VALIDATIONS` for a new type of `:lot_number`
* Upgraded `rake fdl:validations:test[short_name]` such that we can pipe a newline-separated list of `submission.id`s to it, e.g. `cat failures.txt | rake fdl:validations:test[RM858]`
* Add support for Known fields being named the same thing as a Lookup and validating appropriately.