### PR TITLE
Fix has_one :reversal_invoice relation

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,8 +9,16 @@ class Submission < ApplicationRecord
 
   has_many :files, dependent: :nullify, class_name: 'SubmissionFile'
   has_many :entries, dependent: :nullify, class_name: 'SubmissionEntry'
-  has_one :invoice, dependent: :nullify, class_name: 'SubmissionInvoice'
-  has_one :reversal_invoice, dependent: :nullify, class_name: 'SubmissionInvoice'
+  has_one :invoice,
+          -> { where(reversal: false) },
+          dependent: :nullify,
+          class_name: 'SubmissionInvoice',
+          inverse_of: :submission
+  has_one :reversal_invoice,
+          -> { where(reversal: true) },
+          dependent: :nullify,
+          class_name: 'SubmissionInvoice',
+          inverse_of: :submission
 
   aasm do
     state :pending, initial: true

--- a/db/migrate/20190314145427_add_reversal_to_submission_invoices.rb
+++ b/db/migrate/20190314145427_add_reversal_to_submission_invoices.rb
@@ -1,0 +1,5 @@
+class AddReversalToSubmissionInvoices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submission_invoices, :reversal, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_12_173622) do
+ActiveRecord::Schema.define(version: 2019_03_14_145427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2019_03_12_173622) do
     t.string "workday_reference"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "reversal", default: false, null: false
     t.index ["submission_id"], name: "index_submission_invoices_on_submission_id"
   end
 


### PR DESCRIPTION
In https://github.com/dxw/DataSubmissionServiceAPI/pull/312 we did not put enough scoping on the invoice and reversal_invoice relation on Submission, which made them link to the same invoice.