### PR TITLE
DW export includes replaced submissions

### DIFF
--- a/app/models/export/submissions/extract.rb
+++ b/app/models/export/submissions/extract.rb
@@ -1,7 +1,7 @@
 module Export
   class Submissions
     module Extract
-      RELEVANT_STATUSES = %w[completed validation_failed].freeze
+      RELEVANT_STATUSES = %w[completed validation_failed replaced].freeze
 
       def self.all_relevant(date_range = nil)
         filters = { aasm_state: RELEVANT_STATUSES }

--- a/app/models/export/submissions/row.rb
+++ b/app/models/export/submissions/row.rb
@@ -28,6 +28,7 @@ module Export
       def status
         {
           'completed'         => 'supplier_accepted',
+          'replaced'          => 'replaced',
           'validation_failed' => 'validation_failed'
         }.fetch(submission.aasm_state)
       end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -6,9 +6,9 @@ namespace :export do
   namespace :all do
     desc 'Export everything that has updated since the last export to CSV'
     task incremental: :environment do
-      export = DataWarehouseExport.new
-      puts "Generating incremental export for #{export.date_range}"
-      export.run
+      puts 'Generating incremental export...'
+      export = DataWarehouseExport.generate!
+      puts "Generated incremental export for #{export.date_range}"
     end
   end
 

--- a/spec/models/export/submissions/extract_spec.rb
+++ b/spec/models/export/submissions/extract_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe Export::Submissions::Extract do
     context 'there are some relevant and some non-relevant submissions' do
       let!(:relevant_submission1)  { create :no_business_submission } # Complete by definition
       let!(:relevant_submission2)  { create :submission, aasm_state: 'validation_failed' }
+      let!(:relevant_submission3)  { create :submission, aasm_state: 'replaced' }
       let!(:irrelevant_submission) { create :submission, aasm_state: 'pending' }
 
       it 'returns the relevant submissions only' do
-        expect(all_relevant).to match_array([relevant_submission1, relevant_submission2])
+        expect(all_relevant).to match_array([relevant_submission1, relevant_submission2, relevant_submission3])
       end
     end
 

--- a/spec/models/export/submissions/row_spec.rb
+++ b/spec/models/export/submissions/row_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Export::Submissions::Row do
       it { is_expected.to eql('validation_failed') }
     end
 
+    context 'the submission state is replaced' do
+      let(:submission) { double 'Submission', aasm_state: 'replaced' }
+      it { is_expected.to eql('replaced') }
+    end
+
     context 'the submission state is not one that should be in the output at all' do
       let(:submission) { double 'Submission', aasm_state: 'in_review' }
       it 'blows up and stops the whole export (there is no error handling)' do


### PR DESCRIPTION
Now "replaced" submissions are a thing, we need to ensure they are explicitly included in the list of exported submissions.

edit: additional commit added when I noticed I broke the rake task in the incremental exports PR!