### PR TITLE
rake fdl:validations:test can pipe submission_ids

### DIFF
--- a/lib/tasks/fdl.rake
+++ b/lib/tasks/fdl.rake
@@ -1,14 +1,26 @@
 require 'fdl/validations/test'
 
 namespace :fdl do
-  # rake fdl:validations:test[CM/OSG/05/3565,10]
+  ##
+  # e.g.
+  # rake fdl:validations:test[CM/OSG/05/3565,10] tests against 10 sample entries
+  #   in your development database for the Laundry framework
+  #
+  # cat failures.txt | rake fdl:validations:test[CM/OSG/05/3565] tests
+  #   against submission UUIDs you've previously found to be failing and which are in
+  #   failures.txt with one UUID one per line
   namespace :validations do
     desc 'Test validations transpiled from FDL against validations from the hand-coded Ruby equivalent'
     task :test, %i[framework_short_name sample_row_count] => [:environment] do |_task, args|
       framework_short_name = args[:framework_short_name] or raise ArgumentError 'framework_short_name required'
-      sample_row_count = args[:sample_row_count] || 5000
 
-      test = FDL::Validations::Test.new(framework_short_name, sample_row_count)
+      options = if STDIN.tty?
+                  { sample_row_count: args[:sample_row_count] || 5000 }
+                else
+                  { submission_ids: STDIN.read.split("\n") }
+                end
+
+      test = FDL::Validations::Test.new(framework_short_name, options)
       test.run
       puts test.formatted_report
     end


### PR DESCRIPTION
Pipe specific submission_ids you want to parallel test one per line
like:

`cat failures.txt | rake fdl:validations:test[CM/OSG/05/3565]`

## Note

This came out of #318, extracting it here as it's independent and makes reviewing that slightly easier