### PR TITLE
(932) Return error on create submission if task already completed

### DIFF
--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -13,7 +13,7 @@ class V1::SubmissionsController < APIController
     task = Task.find(params.dig(:submission, :task_id))
 
     if !correcting_submission? && task.active_submission&.completed?
-      render jsonapi: task.active_submission, status: :ok
+      render jsonapi_errors: [{ title: 'Task already has completed submission.' }], status: :conflict
       return
     end
 

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -112,11 +112,12 @@ RSpec.describe '/v1' do
           end.to_not change { task.submissions.count }
         end
 
-        it 'returns the latest submission' do
+        it 'responds with an error status' do
           post "/v1/submissions?task_id=#{task.id}",
                params: params.to_json,
                headers: json_headers.merge('X-Auth-Id' => user.auth_id)
-          expect(json['data']).to have_id(old_submission.id)
+
+          expect(response).to_not be_successful
         end
       end
 


### PR DESCRIPTION
Currently, when receiving a request to create a new submission for a task where the active submission is already completed, if it's not a correction request, the create submission method responds with the active submission.

This is creating issues in unexpected places, such as when the correction parameter is lost, and the user ends up creating a new file against the completed submission.

We want the API to respond with an error status.

Co-authored-by: james <james@abscond.org>