### PR TITLE
Implement sector-based management charge

### DIFF
--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -64,6 +64,12 @@ class Framework
             result[kv.keys.first] = kv.values.first
           end
         end
+
+        # Sector-based management charges need
+        # keys like CentralGovernment transformed to :central_government
+        rule(sector_based: subtree(:sector_kv)) do
+          { sector_based: sector_kv.transform_keys { |key| key.to_s.underscore.to_sym } }
+        end
       end
     end
   end

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -14,10 +14,11 @@ class Framework
       rule(:framework_identifier) { match(%r{[A-Z0-9/]}).repeat(1).as(:string) }
       rule(:framework_block)      { braced(spaced(metadata) >> spaced(invoice_fields) >> spaced(lookups_block.as(:lookups)).maybe) }
       rule(:framework_name)       { str('Name') >> spaced(string.as(:framework_name)) }
-      rule(:management_charge)    { str('ManagementCharge') >> (column_based | flat_rate).as(:management_charge) }
+      rule(:management_charge)    { str('ManagementCharge') >> (column_based | flat_rate | sector_based).as(:management_charge) }
       rule(:flat_rate)            { (spaced(percentage).as(:value) >> flat_rate_column.maybe).as(:flat_rate) }
       rule(:flat_rate_column)     { spaced(str('of')) >> string.as(:column) }
       rule(:column_based)         { spaced(str('varies_by')) >> (spaced(string).as(:column_name) >> spaced(dictionary).as(:value_to_percentage)).as(:column_based) }
+      rule(:sector_based)         { spaced(str('sector_based')) >> spaced(dictionary).as(:sector_based) }
       rule(:invoice_fields)       { str('InvoiceFields') >> spaced(fields_block.as(:invoice_fields)) }
       rule(:fields_block)         { braced(spaced(field_defs)) }
 
@@ -37,7 +38,9 @@ class Framework
 
       rule(:metadata)             { framework_name >> management_charge }
 
-      rule(:map)                  { string.as(:key) >> spaced(str('->')) >> percentage.as(:value) >> space? }
+      rule(:map)                  { allowable_key.as(:key) >> spaced(str('->')) >> allowable_value.as(:value) >> space? }
+      rule(:allowable_key)        { string | pascal_case_identifier }
+      rule(:allowable_value)      { percentage }
       rule(:dictionary)           { braced(map.repeat(1).as(:dictionary)) }
 
       rule(:string) do

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -52,13 +52,18 @@ class Framework
       def choose_management_charge_calculator(info)
         if info[:column_based]
           ManagementChargeCalculator::ColumnBased.new(
-            varies_by: info.dig(:column_based, :column_name),
+            varies_by:           info.dig(:column_based, :column_name),
             value_to_percentage: info.dig(:column_based, :value_to_percentage)
+          )
+        elsif info[:sector_based]
+          ManagementChargeCalculator::SectorBased.new(
+            central_government:  info.dig(:sector_based, :central_government),
+            wider_public_sector: info.dig(:sector_based, :wider_public_sector)
           )
         elsif info[:flat_rate]
           ManagementChargeCalculator::FlatRate.new(
             percentage: info.dig(:flat_rate, :value),
-            column: info.dig(:flat_rate, :column)
+            column:     info.dig(:flat_rate, :column)
           )
         end
       end

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -52,18 +52,18 @@ class Framework
       def choose_management_charge_calculator(info)
         if info[:column_based]
           ManagementChargeCalculator::ColumnBased.new(
-            varies_by:           info.dig(:column_based, :column_name),
-            value_to_percentage: info.dig(:column_based, :value_to_percentage)
+            varies_by:           info[:column_based][:column_name],
+            value_to_percentage: info[:column_based][:value_to_percentage]
           )
         elsif info[:sector_based]
           ManagementChargeCalculator::SectorBased.new(
-            central_government:  info.dig(:sector_based, :central_government),
-            wider_public_sector: info.dig(:sector_based, :wider_public_sector)
+            central_government:  info[:sector_based][:central_government],
+            wider_public_sector: info[:sector_based][:wider_public_sector]
           )
         elsif info[:flat_rate]
           ManagementChargeCalculator::FlatRate.new(
-            percentage: info.dig(:flat_rate, :value),
-            column:     info.dig(:flat_rate, :column)
+            percentage: info[:flat_rate][:value],
+            column:     info[:flat_rate][:column]
           )
         end
       end

--- a/app/models/framework/management_charge_calculator/sector_based.rb
+++ b/app/models/framework/management_charge_calculator/sector_based.rb
@@ -1,0 +1,24 @@
+class Framework
+  module ManagementChargeCalculator
+    class SectorBased
+      attr_reader :central_government, :wider_public_sector
+
+      def initialize(central_government:, wider_public_sector:)
+        @central_government = central_government
+        @wider_public_sector = wider_public_sector
+      end
+
+      def calculate_for(entry)
+        (entry.total_value * (percentage(entry) / 100)).truncate(4)
+      end
+
+      private
+
+      def percentage(entry)
+        urn = entry.customer_urn
+        sector = Customer.select(:sector).find_by(urn: urn).sector
+        send(sector)
+      end
+    end
+  end
+end

--- a/spec/models/framework/definition/ast/field_spec.rb
+++ b/spec/models/framework/definition/ast/field_spec.rb
@@ -50,16 +50,14 @@ RSpec.describe Framework::Definition::AST::Field do
     end
 
     context 'with a lookup (non-primitive) type' do
-      context 'on an Additional field' do
-        let(:source) { "optional PaymentProfile Additional2 from 'Payment Profile'" }
+      let(:source) { "optional PaymentProfile Additional2 from 'Payment Profile'" }
 
-        it { is_expected.to be_lookup }
-        it 'has a lookup_name' do
-          expect(field.lookup_name).to eql('PaymentProfile')
-        end
-        it 'always treats lookups types as :string' do
-          expect(field.primitive_type).to eql(:string)
-        end
+      it { is_expected.to be_lookup }
+      it 'has a lookup_name' do
+        expect(field.lookup_name).to eql('PaymentProfile')
+      end
+      it 'always treats lookups types as :string' do
+        expect(field.primitive_type).to eql(:string)
       end
     end
   end

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -101,6 +101,30 @@ RSpec.describe Framework::Definition::Parser do
         )
       }
     end
+
+    context 'sector_based' do
+      let(:source) do
+        <<~FDL.strip
+          ManagementCharge sector_based  {
+            CentralGovernment -> 0.5%
+            WiderPublicSector -> 0.6%
+           }
+        FDL
+      end
+
+      it {
+        is_expected.to parse(source).as(
+          management_charge: {
+            sector_based: {
+              dictionary: [
+                { key: 'CentralGovernment', value: { decimal: '0.5' } },
+                { key: 'WiderPublicSector', value: { decimal: '0.6' } }
+              ]
+            }
+          }
+        )
+      }
+    end
   end
 
   describe '#type_def' do

--- a/spec/models/framework/management_charge_calculator/sector_based_spec.rb
+++ b/spec/models/framework/management_charge_calculator/sector_based_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Framework::ManagementChargeCalculator::SectorBased do
+  let(:calculator) do
+    Framework::ManagementChargeCalculator::SectorBased.new(
+      central_government: BigDecimal('50'),
+      wider_public_sector: BigDecimal('100')
+    )
+  end
+  let(:data)     { { 'Customer URN' => customer.urn } }
+  let(:entry)    { build(:submission_entry, data: data, total_value: 1000, customer_urn: customer.urn) }
+
+  describe '#calculate_for' do
+    subject { calculator.calculate_for(entry) }
+
+    context 'central government' do
+      let(:customer) { create(:customer, :central_government) }
+
+      it { is_expected.to eq(entry.total_value / 2) }
+    end
+
+    context 'wider public sector' do
+      let(:customer) { create(:customer, :wider_public_sector) }
+
+      it { is_expected.to eq(entry.total_value) }
+    end
+  end
+end


### PR DESCRIPTION
`Framework::ManagementChargeCalculator::SectorBased` calculates the
management charge for a submission entry dependent on whether the customer is
central government or the wider public sector. This is determined from the
customer's URN.

## Syntax

```
ManagementCharge sector_based {
  CentralGovernment -> 0.5%
  WiderPublicSector -> 1.2%
}
```

## Note

There are no current onboarded frameworks that use this charging style. RM3774 and RM3796 will.