### PR TITLE
897 ContractFields class for RM3772

### DIFF
--- a/app/models/framework/definition/RM1031.fdl
+++ b/app/models/framework/definition/RM1031.fdl
@@ -1,0 +1,36 @@
+Framework RM1031 {
+  Name 'Laundry and Linen Services (RM1031)'
+
+  ManagementCharge 0.5%
+
+  InvoiceFields{
+    CustomerName from 'Customer Organisation'
+    optional CustomerPostCode from 'Customer PostCode'
+    CustomerURN from 'Customer URN'
+    InvoiceDate from 'Customer Invoice Date'
+    InvoiceNumber from 'Customer Invoice Number'
+    ProductGroup from 'Service Type'
+    ProductClass from 'Category'
+    ProductDescription from 'Item'
+    ProductCode from 'Item Code'
+    UNSPSC from 'UNSPSC'
+    optional Decimal Additional1 from 'Baseline Price'
+    UnitType from 'Unit of Purchase'
+    UnitPrice from 'Price per Unit'
+    UnitQuantity from 'Quantity'
+    InvoiceValue from 'Total Charge (Ex VAT)'
+    VATCharged from 'VAT amount charged'
+    optional String Additional2 from 'Subcontractor Supplier Name'
+    optional String from 'Cost Centre'
+    optional String from 'Contract Number'
+  }
+
+  ContractFields {
+    optional CustomerName from 'Customer Organisation'
+    optional CustomerPostCode from 'Customer PostCode'
+    CustomerURN from 'Customer URN'
+    optional ProductDescription from 'Project Name'
+    Integer from 'Number of items'
+    ContractValue from 'Customer Order/Contract Value'
+  }
+}

--- a/app/models/framework/definition/RM3772.fdl
+++ b/app/models/framework/definition/RM3772.fdl
@@ -1,0 +1,36 @@
+Framework RM3772 {
+  Name 'Specialist Laundry Services (for Surgical Gowns, D'
+
+  ManagementCharge 0.5% 
+
+  InvoiceFields {
+    CustomerName from 'Customer Organisation'
+    CustomerPostCode from 'Customer PostCode'
+    CustomerURN from 'Customer URN'
+    InvoiceDate from 'Customer Invoice Date'
+    optional InvoiceNumber from 'Customer Invoice Number'
+    ProductGroup from 'Service Type'
+    ProductClass from 'Category'
+    ProductDescription from 'Item'
+    ProductCode from 'Item Code'
+    UNSPSC from 'UNSPSC'
+    Decimal Additional1 from 'Baseline Price'
+    UnitType from 'Unit of Purchase'
+    UnitCost from 'Price per Unit'
+    UnitQuantity from 'Quantity'
+    InvoiceValue from 'Total Charge (Ex VAT)'
+    VATCharged from 'VAT amount charged'
+    optional String Additional2 from 'Subcontractor Supplier Name'
+    optional String from 'Cost Centre'
+    optional String from 'Contract Number'
+  }
+  
+  ContractFields {
+    optional CustomerName from 'Customer Organisation'
+    optional CustomerPostCode from 'Customer PostCode'
+    CustomerURN from 'Customer URN'
+    optional ProductDescription from 'Project Name'
+    optional String from 'Number of items'
+    ContractValue from 'Customer Order/Contract Value'
+  }
+}

--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -101,10 +101,6 @@ class Framework
         def options(lookup_values)
           Field::Options.new(self).build(lookup_values)
         end
-
-        def self.by_name(field_defs, name)
-          Field.new(field_defs.find { |f| f[:field] == name })
-        end
       end
     end
   end

--- a/app/models/framework/definition/ast/presenter.rb
+++ b/app/models/framework/definition/ast/presenter.rb
@@ -1,0 +1,31 @@
+require 'forwardable'
+
+class Framework
+  module Definition
+    module AST
+      ##
+      # A decorator for a plain old +Hash+ containing an AST.
+      # Contains a bit of syntactic sugar to make the +Transpiler+
+      # look less verbose.
+      class Presenter
+        extend Forwardable
+
+        attr_accessor :ast
+        def_delegators :ast, :[], :dig
+
+        def initialize(ast)
+          self.ast = ast
+        end
+
+        def field_defs(entry_type)
+          fields_key = "#{entry_type}_fields".to_sym
+          ast[fields_key]
+        end
+
+        def lookups
+          ast.fetch(:lookups, {})
+        end
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/ast/presenter.rb
+++ b/app/models/framework/definition/ast/presenter.rb
@@ -25,6 +25,11 @@ class Framework
         def lookups
           ast.fetch(:lookups, {})
         end
+
+        def field_by_name(entry_type, name)
+          field_def = field_defs(entry_type).find { |f| f[:field] == name }
+          Field.new(field_def, lookups)
+        end
       end
     end
   end

--- a/app/models/framework/definition/data_warehouse/known_fields.rb
+++ b/app/models/framework/definition/data_warehouse/known_fields.rb
@@ -6,6 +6,7 @@ class Framework
 
         ALL = {
           'InvoiceValue' => :decimal,
+          'ContractValue' => :decimal,
           'CustomerPostCode' => :string,
           'CustomerName' => :string,
           'CustomerURN' => :urn,
@@ -15,6 +16,7 @@ class Framework
           'ProductSubClass' => :string,
           'ProductDescription' => :string,
           'ProductCode' => :string,
+          'UnitCost' => :decimal,
           'UnitPrice' => :decimal,
           'UnitType' => :string,
           'VATIncluded' => :yesno,

--- a/app/models/framework/definition/data_warehouse/known_fields.rb
+++ b/app/models/framework/definition/data_warehouse/known_fields.rb
@@ -2,6 +2,8 @@ class Framework
   module Definition
     module DataWarehouse
       class KnownFields
+        class NotFoundError < KeyError; end
+
         ALL = {
           'InvoiceValue' => :decimal,
           'CustomerPostCode' => :string,
@@ -26,6 +28,8 @@ class Framework
 
         def self.type_for(value)
           ALL.fetch(value)
+        rescue KeyError => e
+          raise NotFoundError, "known field with key not found: '#{e.key}'"
         end
       end
     end

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -12,7 +12,13 @@ class Framework
       rule(:additional_field_identifier) { str('Additional') >> match('[0-9]').repeat(1) }
 
       rule(:framework_identifier) { match(%r{[A-Z0-9/]}).repeat(1).as(:string) }
-      rule(:framework_block)      { braced(spaced(metadata) >> spaced(invoice_fields) >> spaced(lookups_block.as(:lookups)).maybe) }
+      rule(:framework_block) do
+        braced(
+          spaced(metadata) >>
+          spaced(fields_blocks) >>
+          spaced(lookups_block.as(:lookups)).maybe
+        )
+      end
       rule(:framework_name)       { str('Name') >> spaced(string.as(:framework_name)) }
       rule(:management_charge)    { str('ManagementCharge') >> (column_based | flat_rate | sector_based).as(:management_charge) }
       rule(:flat_rate)            { (spaced(percentage).as(:value) >> flat_rate_column.maybe).as(:flat_rate) }
@@ -20,6 +26,8 @@ class Framework
       rule(:column_based)         { spaced(str('varies_by')) >> (spaced(string).as(:column_name) >> spaced(dictionary).as(:value_to_percentage)).as(:column_based) }
       rule(:sector_based)         { spaced(str('sector_based')) >> spaced(dictionary).as(:sector_based) }
       rule(:invoice_fields)       { str('InvoiceFields') >> spaced(fields_block.as(:invoice_fields)) }
+      rule(:contract_fields)      { str('ContractFields') >> spaced(fields_block.as(:contract_fields)) }
+      rule(:fields_blocks)        { (invoice_fields >> contract_fields.maybe) | (contract_fields >> invoice_fields.maybe) }
       rule(:fields_block)         { braced(spaced(field_defs)) }
 
       rule(:field_defs)           { field_def.repeat(1) }

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -36,7 +36,7 @@ class Framework
 
           field_defs = ast.field_defs(entry_type)
 
-          _total_value_field = AST::Field.by_name(field_defs, "#{entry_type_capitalized}Value")
+          _total_value_field = ast.field_by_name(entry_type, "#{entry_type_capitalized}Value")
           total_value_field _total_value_field.sheet_name
 
           lookups ast[:lookups]

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -4,7 +4,7 @@ class Framework
       attr_reader :ast
 
       def initialize(ast)
-        @ast = ast
+        @ast = AST::Presenter.new(ast)
       end
 
       def transpile
@@ -20,27 +20,29 @@ class Framework
 
           management_charge calculator
         end.tap do |klass|
-          klass.const_set('Invoice', invoice_fields_class)
+          klass.const_set('Invoice', entry_data_class(:invoice)) if ast.field_defs(:invoice)
+          klass.const_set('Order', entry_data_class(:contract))  if ast.field_defs(:contract)
         end
       end
 
-      def invoice_fields_class
+      def entry_data_class(entry_type)
         ast = @ast
 
         Class.new(Framework::EntryData) do
+          entry_type_capitalized = entry_type.to_s.capitalize
           define_singleton_method :model_name do
-            ActiveModel::Name.new(self, nil, 'Invoice')
+            ActiveModel::Name.new(self, nil, entry_type_capitalized)
           end
 
-          _total_value_field = AST::Field.by_name(
-            ast[:invoice_fields], 'InvoiceValue'
-          )
+          field_defs = ast.field_defs(entry_type)
+
+          _total_value_field = AST::Field.by_name(field_defs, "#{entry_type_capitalized}Value")
           total_value_field _total_value_field.sheet_name
 
           lookups ast[:lookups]
 
-          ast[:invoice_fields].each do |field_def|
-            field = AST::Field.new(field_def, ast.fetch(:lookups, {}))
+          field_defs.each do |field_def|
+            field = AST::Field.new(field_def, ast.lookups)
             # Always use a case_insensitive_inclusion validator if
             # there's a lookup with the same name as the field
             lookup_values = ast.dig(:lookups, field.lookup_name)

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -265,6 +265,28 @@ RSpec.describe Framework::Definition::Language do
       end
     end
 
+    context 'RM3772 – first ContractFields-using framework' do
+      let(:source) do
+        File.read('app/models/framework/definition/RM3772.fdl')
+      end
+
+      describe 'the invoice fields' do
+        subject { definition::Invoice }
+
+        it {
+          is_expected.to have_field('Customer Organisation').validated_by(:presence)
+        }
+      end
+
+      describe 'the contract fields' do
+        subject { definition::Order }
+
+        it {
+          is_expected.to have_field('Customer PostCode').not_validated_by(:presence)
+        }
+      end
+    end
+
     context 'our FDL isn\'t valid' do
       let(:source) { 'any old rubbish' }
 

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -232,6 +232,26 @@ RSpec.describe Framework::Definition::Parser do
     end
   end
 
+  describe '#contract_fields' do
+    subject(:rule) { parser.contract_fields }
+
+    let(:fields) do
+      <<~FDL.strip
+        ContractFields {
+          String Additional1 from 'Somewhere'
+        }
+      FDL
+    end
+
+    it 'has whatever fields are in the block' do
+      expect(rule).to parse(fields).as(
+        contract_fields: [
+          { type_def: { primitive: 'String' }, field: 'Additional1', from: { string: 'Somewhere' } },
+        ]
+      )
+    end
+  end
+
   describe '#lookups_block' do
     subject(:rule) { parser.lookups_block }
 


### PR DESCRIPTION
# [FDL ContractFields implementation](https://trello.com/b/A1vk6EAn/ccs-rmi-beta-sprints)

Add the ability to define a ContractFields block within FDL, e.g.

```
ContractFields {
   ...
}
```

Introduce an `AST::Presenter` to make the transpiler more readable
by handling generic contract and invoice fields.

- Translate .rb to FDL for RM3772
- Add a bonus framework RM1031 such that we've got more stuff to test with `rake fdl:validations:test`