### PR TITLE
(818) Incomplete correction submission

### DIFF
--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -56,6 +56,13 @@ class V1::TasksController < APIController
     end
   end
 
+  def cancel_correction
+    task = current_user.tasks.find(params[:id])
+    task.cancel_correction!
+
+    render jsonapi: task
+  end
+
   private
 
   def task_params

--- a/app/models/export/tasks/row.rb
+++ b/app/models/export/tasks/row.rb
@@ -11,13 +11,17 @@ module Export
         "#{task.period_year}-#{format('%02d', task.period_month)}"
       end
 
+      def status
+        task.status == 'correcting' ? 'completed' : task.status
+      end
+
       def row_values
         [
           task.id,
           year_and_month,
           task.supplier.salesforce_id,
           task.framework.short_name,
-          task.status,
+          status,
           FIXED_TASK_TYPE,
           EMPTY_FOR_NOW,
           EMPTY_FOR_NOW

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,9 +5,10 @@ class Task < ApplicationRecord
     state :unstarted, initial: true
     state :in_progress
     state :completed
+    state :correcting
 
     event :completed do
-      transitions from: %i[unstarted in_progress completed], to: :completed
+      transitions from: %i[unstarted in_progress correcting completed], to: :completed
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -27,6 +27,7 @@ class Task < ApplicationRecord
     order(Arel.sql("CASE submissions.aasm_state WHEN 'completed' THEN 1 ELSE 2 END"), created_at: :desc)
   end
   has_one :active_submission, completed_or_latest_scope, class_name: 'Submission', inverse_of: :task
+  has_one :latest_submission, -> { order(created_at: :desc) }, class_name: 'Submission', inverse_of: :task
 
   def file_no_business!(user)
     transaction do

--- a/app/serializable/serializable_task.rb
+++ b/app/serializable/serializable_task.rb
@@ -2,6 +2,7 @@ class SerializableTask < JSONAPI::Serializable::Resource
   type 'tasks'
 
   has_one :active_submission
+  has_one :latest_submission
   has_many :submissions
   belongs_to :framework
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       member do
         post :complete
         post :no_business
+        patch :cancel_correction
       end
     end
 

--- a/spec/models/export/tasks/row_spec.rb
+++ b/spec/models/export/tasks/row_spec.rb
@@ -7,4 +7,18 @@ RSpec.describe Export::Tasks::Row do
       expect(row.year_and_month).to eql('2018-08')
     end
   end
+
+  describe '#status' do
+    it 'reports "correcting" as "completed"' do
+      row = Export::Tasks::Row.new(FactoryBot.build(:task, status: 'correcting'))
+      expect(row.status).to eql('completed')
+    end
+
+    (Task.aasm.states.map(&:name) - [:correcting]).each do |state|
+      it "reports \"#{state}\" as \"#{state}\"" do
+        row = Export::Tasks::Row.new(FactoryBot.build(:task, status: state))
+        expect(row.status).to eql(state.to_s)
+      end
+    end
+  end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -102,6 +102,9 @@ RSpec.describe '/v1' do
 
     context 'when there is a completed submission against the task' do
       let!(:old_submission) { FactoryBot.create(:submission, task: task, aasm_state: 'completed') }
+      before do
+        task.completed!
+      end
 
       context 'and it is not a correction' do
         it 'does not create a new submission' do


### PR DESCRIPTION
API code in support of users being able to view the tasks where they have an incomplete correction submission on the homepage:
* New `correcting` status for `Task`.
* User can cancel the correction. The correction files are deleted.
* Data warehouse status reports `correcting` as `completed`.

Required for https://github.com/dxw/DataSubmissionService/pull/209