### PR TITLE
Favour case-insensitive inclusion

### DIFF
--- a/app/models/framework/definition/RM3710.rb
+++ b/app/models/framework/definition/RM3710.rb
@@ -54,7 +54,7 @@ class Framework
         field 'Total Manufacturer Discount (%)', :string, exports_to: 'Additional17', ingested_numericality: true, allow_nil: true
         field 'Cost Centre', :string
         field 'Contract Number', :string
-        field 'Spend Code', :string, exports_to: 'PromotionCode', inclusion: { in: ['Lease Rental', 'Fleet Management Fee', 'Damage', 'Other Re-charges'] }
+        field 'Spend Code', :string, exports_to: 'PromotionCode', case_insensitive_inclusion: { in: ['Lease Rental', 'Fleet Management Fee', 'Damage', 'Other Re-charges'] }
       end
     end
   end

--- a/app/models/framework/definition/RM858.rb
+++ b/app/models/framework/definition/RM858.rb
@@ -31,7 +31,7 @@ class Framework
         field 'Invoice Line Total Value ex VAT', :string, exports_to: 'InvoiceValue', ingested_numericality: true
         field 'VAT Applicable', :string, exports_to: 'VATIncluded', case_insensitive_inclusion: { in: %w[Y N], message: "must be 'Y' or 'N'" }
         field 'VAT Amount Charged', :string, exports_to: 'VATCharged', ingested_numericality: true, allow_nil: true
-        field 'Spend Code', :string, exports_to: 'PromotionCode', inclusion: { in: ['Lease Rental', 'Fleet Management Fee', 'Damage', 'Other Re-charges'] }
+        field 'Spend Code', :string, exports_to: 'PromotionCode', case_insensitive_inclusion: { in: ['Lease Rental', 'Fleet Management Fee', 'Damage', 'Other Re-charges'] }
         field 'Invoice Line Product / Service Grouping', :string, exports_to: 'ProductGroup', presence: true
         field 'CAP Code', :string, exports_to: 'ProductCode'
         field 'Vehicle Make', :string, exports_to: 'ProductClass'

--- a/spec/lib/fdl/validation/failing_cases_spec.rb
+++ b/spec/lib/fdl/validation/failing_cases_spec.rb
@@ -168,11 +168,9 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
         }
       end
 
-      it 'behaves slightly differently to the Ruby' do
-        # The Ruby has an +InclusionValidator+ which behaves slightly
-        # differently to the +CaseInsensitiveInclusionValidator+ we use. This is the diff:
-        expect(diff).to eql([['-', 'Spend Code', 'is not included in the list']])
-        # ... and this is the question it raised:
+      it 'no longer behaves slightly differently to the Ruby now we use case-insensitive inclusion' do
+        expect(diff).to be_empty
+        # ... this is the question it raised:
         # https://trello.com/c/CsjBwtkd/929-case-sensitive-vs-case-insensitive-inclusion-validators-what-should-we-do
       end
     end
@@ -180,7 +178,7 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
     context 'All the problems' do
       let(:data) { { 'Contract Number' => 'N/A' } }
 
-      it { is_expected.to eql([['-', 'Spend Code', 'is not included in the list']]) }
+      it { is_expected.to be_empty }
     end
   end
 end


### PR DESCRIPTION
Two vehicle frameworks had case-sensitive validations for 'Spend Code'.
We don't use the usual `inclusion` validator anywhere else, so stop
using it here and relax the validator.