### PR TITLE
(956) Admins can view submission errors

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -8,6 +8,7 @@
 @import "govuk-frontend/components/select/select";
 @import "govuk-frontend/components/breadcrumbs/breadcrumbs";
 @import "govuk-frontend/components/fieldset/fieldset";
+@import "govuk-frontend/components/back-link/back-link";
 
 // custom
 @import "type/type";

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -1,0 +1,5 @@
+class Admin::SubmissionsController < AdminController
+  def show
+    @submission = Submission.find(params[:id])
+  end
+end

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -1,6 +1,4 @@
 class SerializableSubmission < JSONAPI::Serializable::Resource
-  ERRORED_ROW_LIMIT = 10
-
   type 'submissions'
 
   belongs_to :framework
@@ -28,9 +26,7 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
 
   attribute :order_total_value
 
-  attribute :sheet_errors do
-    Hash[submission.sheet_names.map { |sheet_name| [sheet_name, errors_for(sheet_name)] }]
-  end
+  attribute :sheet_errors
 
   attribute :report_no_business?
 
@@ -40,16 +36,5 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
 
   def submission
     @object
-  end
-
-  def errors_for(sheet_name)
-    submission
-      .entries
-      .sheet(sheet_name)
-      .errored
-      .ordered_by_row
-      .limit(ERRORED_ROW_LIMIT)
-      .pluck(:validation_errors)
-      .flatten
   end
 end

--- a/app/views/admin/submissions/_errors_table.html.haml
+++ b/app/views/admin/submissions/_errors_table.html.haml
@@ -1,0 +1,24 @@
+%h4.govuk-heading-s
+  = sheet_name
+
+%table.govuk-table
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__cell
+        Row
+      %th.govuk-table__cell
+        Column
+      %th.govuk-table__cell
+        Help
+  %tbody.govuk-table__body
+    - errors.each do |error|
+      %tr.govuk-table__row
+        %td.govuk-table__cell
+          %p
+            = error['location']['row']
+        %td.govuk-table__cell
+          %p
+            = error['location']['column']
+        %td.govuk-table__cell
+          %p
+            = error['message']

--- a/app/views/admin/submissions/show.html.haml
+++ b/app/views/admin/submissions/show.html.haml
@@ -1,0 +1,7 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      Errors to correct
+
+    - @submission.sheet_errors.each_pair do |sheet_name, errors|
+      = render('errors_table', errors: errors, sheet_name: sheet_name) if errors.any?

--- a/app/views/admin/submissions/show.html.haml
+++ b/app/views/admin/submissions/show.html.haml
@@ -5,3 +5,7 @@
 
     - @submission.sheet_errors.each_pair do |sheet_name, errors|
       = render('errors_table', errors: errors, sheet_name: sheet_name) if errors.any?
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = link_to 'Back', admin_supplier_path(@submission.supplier), { class: 'govuk-back-link', title: 'Back to supplier' }

--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -11,8 +11,11 @@
     %td.govuk-table__cell
       - if task.active_submission.files.any? && task.active_submission.files.first.file.attached?
         = link_to 'Download submission file', rails_blob_url(task.active_submission.files.first.file)
+    %td.govuk-table__cell
+      = link_to 'View', admin_supplier_submission_path(task.supplier, task.active_submission) if task.active_submission.validation_failed?
   - else
     %td.govuk-table__cell
     %td.govuk-table__cell
       = task.status.titlecase
+    %td.govuk-table__cell
     %td.govuk-table__cell

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -16,6 +16,7 @@
             %th.govuk-table__header Submitted
             %th.govuk-table__header Status
             %th.govuk-table__header Submission file
+            %th.govuk-table__header Errors
         %tbody.govuk-table__body
           = render(collection: @tasks, partial: "task")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
         put :activate
         put :deactivate
       end
+      resources :submissions, only: %i[show]
     end
 
     resources :notify_downloads, only: %i[index show]

--- a/spec/features/admin_can_view_submission_errors_spec.rb
+++ b/spec/features/admin_can_view_submission_errors_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin users can' do
+  before do
+    supplier = FactoryBot.create(:supplier, name: 'First Supplier')
+    task = FactoryBot.create(:task, supplier: supplier)
+    FactoryBot.create(
+      :submission_with_invalid_entries,
+      supplier: supplier,
+      task: task
+    )
+    sign_in_as_admin
+  end
+
+  scenario 'view a paged list of suppliers' do
+    visit admin_suppliers_path
+    click_link 'First Supplier'
+    click_link 'View'
+
+    expect(page).to have_content('Required value missing')
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -181,4 +181,50 @@ RSpec.describe Submission do
       end
     end
   end
+
+  describe '#sheet_errors' do
+    let(:submission) { FactoryBot.create(:submission) }
+    let!(:errored_invoice) do
+      FactoryBot.create(
+        :invoice_entry,
+        :errored,
+        column: 'Total',
+        row: 1,
+        error_message: 'missing value',
+        submission: submission
+      )
+    end
+    let!(:errored_order) do
+      FactoryBot.create(
+        :order_entry,
+        :errored,
+        column: 'Total',
+        row: 1,
+        error_message: 'not a number',
+        submission: submission
+      )
+    end
+    let!(:errored_order_2) do
+      FactoryBot.create(
+        :order_entry,
+        :errored,
+        column: 'URN',
+        row: 2,
+        error_message: 'missing value',
+        submission: submission
+      )
+    end
+
+    it 'returns the entry validation errors, grouped by their sheet name' do
+      expect(submission.sheet_errors).to eq(
+        'InvoicesRaised' => [
+          { 'message' => 'missing value', 'location' => { 'row' => 1, 'column' => 'Total' } }
+        ],
+        'OrdersReceived' => [
+          { 'message' => 'not a number', 'location' => { 'row' => 1, 'column' => 'Total' } },
+          { 'message' => 'missing value', 'location' => { 'row' => 2, 'column' => 'URN' } }
+        ]
+      )
+    end
+  end
 end

--- a/spec/serializable/serializable_submission_spec.rb
+++ b/spec/serializable/serializable_submission_spec.rb
@@ -24,52 +24,10 @@ RSpec.describe SerializableSubmission do
     it 'exposes a report_no_business? boolean' do
       expect(serialized_submission.as_jsonapi[:attributes][:report_no_business?]).to eq(true)
     end
-  end
 
-  describe '#sheet_errors' do
-    let(:submission) { FactoryBot.create(:submission) }
-    let!(:errored_invoice) do
-      FactoryBot.create(
-        :invoice_entry,
-        :errored,
-        column: 'Total',
-        row: 1,
-        error_message: 'missing value',
-        submission: submission
-      )
-    end
-    let!(:errored_order) do
-      FactoryBot.create(
-        :order_entry,
-        :errored,
-        column: 'Total',
-        row: 1,
-        error_message: 'not a number',
-        submission: submission
-      )
-    end
-    let!(:errored_order_2) do
-      FactoryBot.create(
-        :order_entry,
-        :errored,
-        column: 'URN',
-        row: 2,
-        error_message: 'missing value',
-        submission: submission
-      )
-    end
-
-    let(:serialized_submission) { SerializableSubmission.new(object: submission) }
-
-    it 'returns the entry validation errors, grouped by their sheet name' do
+    it 'exposes a sheet_errors hash' do
       expect(serialized_submission.as_jsonapi[:attributes][:sheet_errors]).to eq(
-        'InvoicesRaised' => [
-          { 'message' => 'missing value', 'location' => { 'row' => 1, 'column' => 'Total' } }
-        ],
-        'OrdersReceived' => [
-          { 'message' => 'not a number', 'location' => { 'row' => 1, 'column' => 'Total' } },
-          { 'message' => 'missing value', 'location' => { 'row' => 2, 'column' => 'URN' } }
-        ]
+        'InvoicesRaised' => [], 'OrdersReceived' => []
       )
     end
   end


### PR DESCRIPTION
So CCS support staff can assist suppliers who have submissions that have not passed validation we allow them to view the same errors that the supplier sees.

- moved the ```sheet_errors``` method into the submission model, previously only used to send the errors to the supllier app 
- added the submission show view along with the errors as shown to the supplier
- as in ther supplier app, only the first 10 errors are shown

Co-authored-by: james <james@abscond.org>

![Screenshot_2019-03-21 RMI Admin](https://user-images.githubusercontent.com/480578/54751400-c3b2c880-4bd2-11e9-86b3-a80bb779158c.png)

![Screenshot_2019-03-21 RMI Admin(2)](https://user-images.githubusercontent.com/480578/54752193-21e0ab00-4bd5-11e9-8093-b532a7e9a1ec.png)
