### PR TITLE
Feature/899 dependent field lookups rm6060

### DIFF
--- a/app/models/framework/definition/RM6060.fdl
+++ b/app/models/framework/definition/RM6060.fdl
@@ -1,0 +1,124 @@
+Framework RM6060 {
+   Name 'Vehicle Purchase'
+
+   ManagementCharge 0.5% of 'Supplier Price'
+
+   InvoiceFields {
+    CustomerName from 'Customer Organisation Name'
+    CustomerURN from 'Customer Unique Reference Number (URN)'
+    CustomerInvoiceDate from 'Customer Invoice/Credit Note Date'
+    InvoiceNumber from 'Customer Invoice/Credit Note Number'
+    LotNumber from 'Lot Number'
+    String Additional1 from 'Vehicle Registration Number'
+    String Additional2 from 'Vehicle CAP Code'
+    String Additional3 from 'Vehicle Make'
+    String Additional4 from 'Vehicle Model'
+    String Additional5 from 'Vehicle Trim/Derivative'
+    ProductGroup from 'Vehicle Segment' depends_on 'Lot Number' {
+      '1' -> Lot1Segment
+      '2' -> Lot2Segment
+      '3' -> Lot3Segment
+      '4' -> Lot4Segment
+      '5' -> Lot5Segment
+      '6' -> Lot6Segment
+      '7' -> Lot7Segment
+    }
+    FuelType Additional6 from 'Fuel Type'
+    optional Decimal Additional7 from 'CO2 Emissions'
+    Decimal Additional8 from 'MRP Excluding Options'
+    Decimal Additional9 from 'Customer Support Terms'
+    Decimal Additional10 from 'Additional Support Terms'
+    Decimal Additional11 from 'Supplier Price'
+    Decimal Additional12 from 'Conversion Cost'
+    Decimal Additional13 from 'Parts Cost'
+    InvoiceValue from 'Total Vehicle Cost'
+    LeasingCompany Additional14 from 'Leasing Company'
+    String Additional15 from 'eAuction Contract Number'
+  }
+
+  Lookups {
+    Lot1Segment [
+      '4x4/SUV'
+      'Executive'
+      'Lower Medium'
+      'Mini'
+      'MPV'
+      'Pickup'
+      'Specialist Sports'
+      'Supermini'
+      'Upper Medium'
+    ]
+
+    Lot2Segment [
+      'Car Derived Van'
+      'LCV'
+      'MPV'
+      'Pickup'
+    ]
+
+    Lot3Segment [
+      'HGV'
+    ]
+
+    Lot4Segment [
+      'Motorcycle'
+    ]
+
+    Lot5Segment [
+      'Bus'
+      'Coach'
+    ]
+
+    Lot6Segment [
+      '4x4/SUV/All Terrain vehicle'
+      'Executive'
+      'Lower Medium'
+      'Mini'
+      'MPV'
+      'Pickup'
+      'Specialist Sports'
+      'Supermini'
+      'Upper Medium'
+      'Motorcycle'
+    ]
+
+    Lot7Segment [
+      'Car Derived Van'
+      'Car Derived Van 4X4 variant'
+      'Minibus'
+      'LCV'
+      'Pickup'
+    ]
+
+    FuelType [
+      'Diesel'
+      'Electric'
+      'Petrol'
+      'Petrol Hybrid'
+      'Diesel Hybrid'
+    ]
+
+    LeasingCompany [
+      'ALD Automotive Ltd'
+      'Alphabet (GB) Ltd'
+      'Arnold Clark Vehicle Management'
+      'Arval UK Ltd'
+      'BT Fleet'
+      'Dawsonrentals Truck and Trailer Ltd'
+      'Fleetcare (PSCSM) Ltd'
+      'Fraikin Ltd'
+      'GMP Drivercare ltd'
+      'Hitachi Capital Vehicle Solutions'
+      'Inchcape Fleet Solutions'
+      'Knowles Associates Total Fleet Management Ltd'
+      'LeasePlan UK Ltd'
+      'Lex Autolease'
+      'Lookers Leasing'
+      'Mercedes-Benz Financial Services UK Ltd (Daimler Fleet Management)'
+      'Ryder Ltd'
+      'Volkswagen Financial Services'
+      'Zenith'
+      'N/A'
+    ]
+  }
+}

--- a/app/models/framework/definition/RM858.fdl
+++ b/app/models/framework/definition/RM858.fdl
@@ -23,7 +23,7 @@ Framework RM858 {
     InvoiceValue from 'Invoice Line Total Value ex VAT'
     VATIncluded from 'VAT Applicable'
     optional VATCharged from 'VAT Amount Charged'
-    PromotionCode from 'Spend Code'
+    optional PromotionCode from 'Spend Code'
     ProductGroup from 'Invoice Line Product / Service Grouping'
     optional ProductCode from 'CAP Code'
     optional ProductClass from 'Vehicle Make'

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -64,7 +64,8 @@ class Framework
         # real hash                      { key1 => value1, key2 => value2 }
         rule(dictionary: subtree(:dictionary)) do
           dictionary.each_with_object({}) do |kv, result|
-            result[kv.keys.first] = kv.values.first
+            value = kv.values.first.is_a?(Parslet::Slice) ? kv.values.first.to_s : kv.values.first
+            result[kv.keys.first] = value
           end
         end
 

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -4,9 +4,10 @@ class Framework
       # This transform exists for the express purpose of creating an AST for generating
       # an ActiveModel class with validations for a Framework
       class Creator < Parslet::Transform
-        rule(string: simple(:s))  { String(s) }
-        rule(decimal: simple(:d)) { BigDecimal(d) }
-        rule(integer: simple(:i)) { Integer(i) }
+        rule(string: simple(:s))           { String(s) }
+        rule(lookup_reference: simple(:r)) { String(r) }
+        rule(decimal: simple(:d))          { BigDecimal(d) }
+        rule(integer: simple(:i))          { Integer(i) }
 
         rule(primitive: simple(:primitive)) { primitive }
         rule(lookup: simple(:lookup))       { lookup }
@@ -64,8 +65,7 @@ class Framework
         # real hash                      { key1 => value1, key2 => value2 }
         rule(dictionary: subtree(:dictionary)) do
           dictionary.each_with_object({}) do |kv, result|
-            value = kv.values.first.is_a?(Parslet::Slice) ? kv.values.first.to_s : kv.values.first
-            result[kv.keys.first] = value
+            result[kv.keys.first] = kv.values.first
           end
         end
 

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -16,6 +16,9 @@ class Framework
         rule(optional: simple(:optional), field: simple(:field), from: simple(:from)) do
           { kind: :known, optional: true, field: field.to_s, from: from.to_s }
         end
+        rule(field: simple(:field), from: simple(:from), depends_on: subtree(:depends_on)) do
+          { kind: :known, field: field.to_s, from: from.to_s, depends_on: depends_on }
+        end
 
         # optional Additional field rule
         rule(optional: simple(:optional), type_def: simple(:type), field: simple(:field), from: subtree(:from)) do

--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -101,6 +101,20 @@ class Framework
         def options(lookup_values)
           Field::Options.new(self).build(lookup_values)
         end
+
+        def dependent_field_inclusion?
+          field_def[:depends_on].present?
+        end
+
+        def dependent_field
+          field_def[:depends_on][:dependent_field]
+        end
+
+        def dependent_field_inclusion_values
+          field_def[:depends_on][:values].transform_values do |lookup_name|
+            lookups[lookup_name]
+          end
+        end
       end
     end
   end

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -25,7 +25,7 @@ class Framework
 
           def add_inclusion_validators(lookup_values)
             options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
-            options[:dependent_field_inclusion] =  { parent: field.dependent_field, in: field.dependent_field_inclusion_values } if field.dependent_field_inclusion?
+            options[:dependent_field_inclusion] =  { parent: field.dependent_field, in: { field.dependent_field => field.dependent_field_inclusion_values } } if field.dependent_field_inclusion?
           end
 
           def no_presence_required?

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -31,7 +31,7 @@ class Framework
           def no_presence_required?
             # Validators like UrnValidator and the case_insensitive_inclusion used for
             # YesNo fields don't require an accompanying +presence: true+
-            %i[urn yesno].include?(field.primitive_type) || field.lookup? || field.dependent_field_inclusion?
+            %i[urn yesno].include?(field.primitive_type)
           end
 
           def set_optional_modifiers!

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -17,16 +17,21 @@ class Framework
             options.delete(:presence) if no_presence_required?
             set_optional_modifiers! if field.optional?
 
-            options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
+            add_inclusion_validators(lookup_values)
             options
           end
 
           private
 
+          def add_inclusion_validators(lookup_values)
+            options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
+            options[:dependent_field_inclusion] =  { parent: field.dependent_field, in: field.dependent_field_inclusion_values } if field.dependent_field_inclusion?
+          end
+
           def no_presence_required?
             # Validators like UrnValidator and the case_insensitive_inclusion used for
             # YesNo fields don't require an accompanying +presence: true+
-            %i[urn yesno].include?(field.primitive_type) || field.lookup?
+            %i[urn yesno].include?(field.primitive_type) || field.lookup? || field.dependent_field_inclusion?
           end
 
           def set_optional_modifiers!

--- a/app/models/framework/definition/data_warehouse/known_fields.rb
+++ b/app/models/framework/definition/data_warehouse/known_fields.rb
@@ -25,7 +25,8 @@ class Framework
           'UNSPSC' => :integer,
           'VATCharged' => :decimal,
           'LotNumber' => :lot_number,
-          'PromotionCode' => :string
+          'PromotionCode' => :string,
+          'CustomerInvoiceDate' => :date
         }.freeze
 
         def self.type_for(value)

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -32,7 +32,7 @@ class Framework
 
       rule(:field_defs)           { field_def.repeat(1) }
       rule(:field_def)            { unknown_field | known_field | additional_field }
-      rule(:known_field)          { optional >> additional_field_identifier.absent? >> pascal_case_identifier.as(:field) >> from_specifier }
+      rule(:known_field)          { optional >> additional_field_identifier.absent? >> pascal_case_identifier.as(:field) >> from_specifier >> depends_on.maybe }
       rule(:additional_field)     { optional >> type_def >> space >> additional_field_identifier.as(:field) >> from_specifier }
       rule(:unknown_field)        { optional >> primitive_type_def.as(:type_def) >> space >> from_specifier }
       rule(:type_def)             { (primitive_type_def | pascal_case_identifier.as(:lookup)).as(:type_def) }
@@ -44,11 +44,13 @@ class Framework
       rule(:lookup_key_values)    { pascal_case_identifier.as(:lookup_name) >> space >> string_array }
       rule(:string_array)         { square_bracketed(string.repeat(1).as(:list)) }
 
+      rule(:depends_on)           { (spaced(str('depends_on')) >> spaced(string).as(:dependent_field) >> dictionary.as(:values)).as(:depends_on) }
+
       rule(:metadata)             { framework_name >> management_charge }
 
       rule(:map)                  { allowable_key.as(:key) >> spaced(str('->')) >> allowable_value.as(:value) >> space? }
       rule(:allowable_key)        { string | pascal_case_identifier }
-      rule(:allowable_value)      { percentage }
+      rule(:allowable_value)      { percentage | pascal_case_identifier.as(:string) }
       rule(:dictionary)           { braced(map.repeat(1).as(:dictionary)) }
 
       rule(:string) do

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -50,7 +50,7 @@ class Framework
 
       rule(:map)                  { allowable_key.as(:key) >> spaced(str('->')) >> allowable_value.as(:value) >> space? }
       rule(:allowable_key)        { string | pascal_case_identifier }
-      rule(:allowable_value)      { percentage | pascal_case_identifier.as(:string) }
+      rule(:allowable_value)      { percentage | pascal_case_identifier }
       rule(:dictionary)           { braced(map.repeat(1).as(:dictionary)) }
 
       rule(:string) do

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -50,7 +50,7 @@ class Framework
 
       rule(:map)                  { allowable_key.as(:key) >> spaced(str('->')) >> allowable_value.as(:value) >> space? }
       rule(:allowable_key)        { string | pascal_case_identifier }
-      rule(:allowable_value)      { percentage | pascal_case_identifier }
+      rule(:allowable_value)      { percentage | pascal_case_identifier.as(:lookup_reference) }
       rule(:dictionary)           { braced(map.repeat(1).as(:dictionary)) }
 
       rule(:string) do

--- a/spec/lib/fdl/validation/failing_cases_spec.rb
+++ b/spec/lib/fdl/validation/failing_cases_spec.rb
@@ -181,4 +181,44 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
       it { is_expected.to be_empty }
     end
   end
+
+  context 'Framework RM6060' do
+    let(:short_name) { 'RM6060' }
+    let(:supplier)   { create :supplier }
+    let(:entry)      { build(:submission_entry, submission: submission, data: data) }
+    let!(:agreement) { create :agreement, supplier: supplier, framework: framework }
+    let(:submission) { create :submission, supplier: supplier, framework: framework }
+    let(:framework)  { create :framework, short_name: short_name }
+    let!(:lot)       { create :framework_lot, number: 1, framework: framework }
+    let(:data) do
+      {
+        'Fuel Type' => 'Petrol',
+        'Lot Number' => 1,
+        'Parts Cost' => 0,
+        'Vehicle Make' => 'CAPTUR',
+        'CO2 Emissions' => 122,
+        'Vehicle Model' => 'Renault',
+        'Supplier Price' => 10026,
+        'Conversion Cost' => 0,
+        'Leasing Company' => 'Arnold Clark Vehicle Management',
+        'Vehicle Segment' => '4x4/SUV',
+        'Vehicle CAP Code' => 'N/A',
+        'Total Vehicle Cost' => 13925,
+        'MRP Excluding Options' => 13383.33,
+        'Customer Support Terms' => 28,
+        'Vehicle Trim/Derivative' => '3ICN T90',
+        'Additional Support Terms' => 0,
+        'eAuction Contract Number' => 'N/A',
+        'Customer Organisation Name' => 'London North West Healthcare NHS Trust',
+        'Vehicle Registration Number' => 'AX68XEF',
+        'Customer Invoice/Credit Note Date' => '1/22/19',
+        'Customer Invoice/Credit Note Number' => 'N/A',
+        'Customer Unique Reference Number (URN)' => 10042256
+      }
+    end
+
+    it do
+      is_expected.to be_empty
+    end
+  end
 end

--- a/spec/lib/fdl/validation/failing_cases_spec.rb
+++ b/spec/lib/fdl/validation/failing_cases_spec.rb
@@ -167,12 +167,6 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
           'Contract Number' => '99999'
         }
       end
-
-      it 'no longer behaves slightly differently to the Ruby now we use case-insensitive inclusion' do
-        expect(diff).to be_empty
-        # ... this is the question it raised:
-        # https://trello.com/c/CsjBwtkd/929-case-sensitive-vs-case-insensitive-inclusion-validators-what-should-we-do
-      end
     end
 
     context 'All the problems' do
@@ -190,35 +184,49 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
     let(:submission) { create :submission, supplier: supplier, framework: framework }
     let(:framework)  { create :framework, short_name: short_name }
     let!(:lot)       { create :framework_lot, number: 1, framework: framework }
-    let(:data) do
-      {
-        'Fuel Type' => 'Petrol',
-        'Lot Number' => 1,
-        'Parts Cost' => 0,
-        'Vehicle Make' => 'CAPTUR',
-        'CO2 Emissions' => 122,
-        'Vehicle Model' => 'Renault',
-        'Supplier Price' => 10026,
-        'Conversion Cost' => 0,
-        'Leasing Company' => 'Arnold Clark Vehicle Management',
-        'Vehicle Segment' => '4x4/SUV',
-        'Vehicle CAP Code' => 'N/A',
-        'Total Vehicle Cost' => 13925,
-        'MRP Excluding Options' => 13383.33,
-        'Customer Support Terms' => 28,
-        'Vehicle Trim/Derivative' => '3ICN T90',
-        'Additional Support Terms' => 0,
-        'eAuction Contract Number' => 'N/A',
-        'Customer Organisation Name' => 'London North West Healthcare NHS Trust',
-        'Vehicle Registration Number' => 'AX68XEF',
-        'Customer Invoice/Credit Note Date' => '1/22/19',
-        'Customer Invoice/Credit Note Number' => 'N/A',
-        'Customer Unique Reference Number (URN)' => 10042256
-      }
+
+    context 'dependent field inclusion not working' do
+      let(:data) do
+        {
+          'Fuel Type' => 'Petrol',
+          'Lot Number' => 1,
+          'Parts Cost' => 0,
+          'Vehicle Make' => 'CAPTUR',
+          'CO2 Emissions' => 122,
+          'Vehicle Model' => 'Renault',
+          'Supplier Price' => 10026,
+          'Conversion Cost' => 0,
+          'Leasing Company' => 'Arnold Clark Vehicle Management',
+          'Vehicle Segment' => '4x4/SUV',
+          'Vehicle CAP Code' => 'N/A',
+          'Total Vehicle Cost' => 13925,
+          'MRP Excluding Options' => 13383.33,
+          'Customer Support Terms' => 28,
+          'Vehicle Trim/Derivative' => '3ICN T90',
+          'Additional Support Terms' => 0,
+          'eAuction Contract Number' => 'N/A',
+          'Customer Organisation Name' => 'London North West Healthcare NHS Trust',
+          'Vehicle Registration Number' => 'AX68XEF',
+          'Customer Invoice/Credit Note Date' => '1/22/19',
+          'Customer Invoice/Credit Note Number' => 'N/A',
+          'Customer Unique Reference Number (URN)' => 10042256
+        }
+      end
+
+      it do
+        is_expected.to be_empty
+      end
     end
 
-    it do
-      is_expected.to be_empty
+    context 'various optional fields' do
+      let(:data) { { 'Lot Number' => 6, 'Parts Cost' => 442301 } }
+
+      it 'has some outstanding errors that we know about, but these need to go away' do
+        # https://trello.com/c/mXblTePD/967-bug-fdl-original-rb-framework-comparisons-invalid
+        is_expected.to eql(
+          [['~', 'Customer Invoice/Credit Note Date', "can't be blank", 'must be in the format dd/mm/yyyy']]
+        )
+      end
     end
   end
 end

--- a/spec/models/framework/definition/ast/field_spec.rb
+++ b/spec/models/framework/definition/ast/field_spec.rb
@@ -31,6 +31,32 @@ RSpec.describe Framework::Definition::AST::Field do
         expect(field.lookup_name).to eql('PromotionCode')
       end
     end
+
+    context 'the known field validates dependent on another field' do
+      let(:lookups) do
+        {
+          'Lot2Segment' => ['Car Derived Van', 'LCV', 'MPV', 'Pickup'],
+          'Lot3Segment' => ['HGV'],
+        }
+      end
+      let(:source) do
+        <<~FDL
+          ProductGroup from 'Vehicle Segment' depends_on 'Lot Number' {
+            '2' -> Lot2Segment
+            '3' -> Lot3Segment
+          }
+        FDL
+      end
+
+      it { is_expected.to be_dependent_field_inclusion }
+
+      it 'expands the Lot Segments out to their literal values' do
+        expect(field.dependent_field_inclusion_values).to eq(
+          '2' => ['Car Derived Van', 'LCV', 'MPV', 'Pickup'],
+          '3' => ['HGV'],
+        )
+      end
+    end
   end
 
   context 'an additional field' do

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -296,13 +296,16 @@ RSpec.describe Framework::Definition::Language do
         subject(:invoice_class) { definition::Invoice }
         let(:mappings) do
           {
-            '1' => invoice_class.lookups['Lot1Segment'],
-            '2' => invoice_class.lookups['Lot2Segment'],
-            '3' => invoice_class.lookups['Lot3Segment'],
-            '4' => invoice_class.lookups['Lot4Segment'],
-            '5' => invoice_class.lookups['Lot5Segment'],
-            '6' => invoice_class.lookups['Lot6Segment'],
-            '7' => invoice_class.lookups['Lot7Segment']
+            'Lot Number' =>
+             {
+               '1' => invoice_class.lookups['Lot1Segment'],
+               '2' => invoice_class.lookups['Lot2Segment'],
+               '3' => invoice_class.lookups['Lot3Segment'],
+               '4' => invoice_class.lookups['Lot4Segment'],
+               '5' => invoice_class.lookups['Lot5Segment'],
+               '6' => invoice_class.lookups['Lot6Segment'],
+               '7' => invoice_class.lookups['Lot7Segment']
+             }
           }
         end
 

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -287,6 +287,32 @@ RSpec.describe Framework::Definition::Language do
       end
     end
 
+    context 'RM6060 - Vehicle Purchase' do
+      let(:source) do
+        File.read('app/models/framework/definition/RM6060.fdl')
+      end
+
+      describe 'the Invoice fields class' do
+        subject(:invoice_class) { definition::Invoice }
+        let(:mappings) do
+          {
+            '1' => invoice_class.lookups['Lot1Segment'],
+            '2' => invoice_class.lookups['Lot2Segment'],
+            '3' => invoice_class.lookups['Lot3Segment'],
+            '4' => invoice_class.lookups['Lot4Segment'],
+            '5' => invoice_class.lookups['Lot5Segment'],
+            '6' => invoice_class.lookups['Lot6Segment'],
+            '7' => invoice_class.lookups['Lot7Segment']
+          }
+        end
+
+        it {
+          is_expected.to have_field('Vehicle Segment')
+            .validated_by(dependent_field_inclusion: { parent: 'Lot Number', in: mappings })
+        }
+      end
+    end
+
     context 'our FDL isn\'t valid' do
       let(:source) { 'any old rubbish' }
 

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -167,6 +167,32 @@ RSpec.describe Framework::Definition::Parser do
         )
       }
     end
+
+    context 'with dependencies' do
+      let(:source) do
+        <<~FDL
+          ProductGroup from 'Vehicle Segment' depends_on 'Lot Number' {
+              '1' -> Lot1Segment
+              '2' -> Lot2Segment
+            }
+        FDL
+      end
+      it {
+        is_expected.to parse(source).as(
+          field: 'ProductGroup',
+          from: { string: 'Vehicle Segment' },
+          depends_on: {
+            dependent_field: { string: 'Lot Number' },
+            values: {
+              dictionary: [
+                { key: { string: '1' }, value: { string: 'Lot1Segment' } },
+                { key: { string: '2' }, value: { string: 'Lot2Segment' } }
+              ]
+            }
+          }
+        )
+      }
+    end
   end
 
   describe '#additional_field' do

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -185,8 +185,8 @@ RSpec.describe Framework::Definition::Parser do
             dependent_field: { string: 'Lot Number' },
             values: {
               dictionary: [
-                { key: { string: '1' }, value: { string: 'Lot1Segment' } },
-                { key: { string: '2' }, value: { string: 'Lot2Segment' } }
+                { key: { string: '1' }, value: 'Lot1Segment' },
+                { key: { string: '2' }, value: 'Lot2Segment' }
               ]
             }
           }

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -185,8 +185,8 @@ RSpec.describe Framework::Definition::Parser do
             dependent_field: { string: 'Lot Number' },
             values: {
               dictionary: [
-                { key: { string: '1' }, value: 'Lot1Segment' },
-                { key: { string: '2' }, value: 'Lot2Segment' }
+                { key: { string: '1' }, value: { lookup_reference: 'Lot1Segment' } },
+                { key: { string: '2' }, value: { lookup_reference: 'Lot2Segment' } }
               ]
             }
           }

--- a/spec/support/export_spec_expectation_truncations.rb
+++ b/spec/support/export_spec_expectation_truncations.rb
@@ -1,4 +1,4 @@
-# Export spec failures truncate their buffer to 14.
+# Export spec and FDL validations failures truncate their buffer to 14.
 # This isn't good on long CSV lines.
 # Make it bigger for our export specs.
 
@@ -18,7 +18,7 @@ module ExporterExampleGroup
 end
 
 RSpec.configure do |config|
-  config.define_derived_metadata(file_path: %r{/spec/lib/tasks/export}) do |metadata|
+  config.define_derived_metadata(file_path: %r{/spec/lib/(tasks/export|fdl/validation)}) do |metadata|
     metadata[:exporter_spec] = true
   end
 

--- a/spec/support/matchers/have_field.rb
+++ b/spec/support/matchers/have_field.rb
@@ -31,7 +31,7 @@ RSpec::Matchers.define :have_field do |field_name|
     return "Expected '#{field_name}' to exist" unless introspector.field_exists?(field_name)
 
     actual_type = introspector.type_of(field_name)
-    type_message = if actual_type == @expected_activemodel_type
+    type_message = if @expected_activemodel_type.nil? || (actual_type == @expected_activemodel_type)
                      nil
                    else
                      "Type: expected field to be of type #{@expected_activemodel_type}, got #{actual_type}\n"


### PR DESCRIPTION
# [Dependent field lookups (`RM6060`)](https://trello.com/c/FFJrLQDZ/899-dependent-field-lookups-rm6060)

Add a language feature to FDL whereby a field can be validated against a `Lookup` depending on the value in another field. This compiles to the existing `dependent_field_inclusion` validator.

e.g. 

```
    ProductGroup from 'Vehicle Segment' depends_on 'Lot Number' {
      '1' -> Lot1Segment
      '2' -> Lot2Segment
    }

...

  Lookups {
     Lot1Segment [
      '4x4/SUV'
      'Executive'
    ]

    Lot2Segment [
      'Car Derived Van'
      'LCV'
    ]
  }
```

Unlike the existing `dependent_field_inclusion` validator it does not generate constants for the lookups; when transpiling the individual validator it expands the values at that point. That means, for example, instead of generating something like

```ruby
field 'Vehicle Segment', :string, exports_to: 'ProductGroup', 
  dependent_field_inclusion: { parent: 'Lot Number', in: MAPPING }
```

it generates:

```ruby
field 'Vehicle Segment', :string, exports_to: 'ProductGroup', 
  dependent_field_inclusion: { 
    parent: 'Lot Number', 
    in: {'1' => ['4x4/SUV', 'Executive'], '2' => ['Car Derived Van', 'LCV']
  } 
}
```

## Work not done

1. While putting this together we noticed that all our previous comparisons are invalid. [Bummer](https://trello.com/c/mXblTePD/967-bug-fdl-original-rb-framework-comparisons-invalid).
2. While putting this together we noticed that other frameworks need to combine lookups (eg `MY_LOOKUP = [ONE_LOOKUP + ANOTHER]`. RM6060 isn't one of the frameworks that does this, so open a new [card](https://trello.com/c/GXogoe3A/965-support-to-combine-lookups-with-the-operator) that covers this case.
