### PR TITLE
936 fdl support various field length validations rm6060

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -112,3 +112,11 @@ Naming/MemoizedInstanceVariableName:
 Lint/UnderscorePrefixedVariableName:
     Exclude:
         - 'app/models/framework/definition/transpiler.rb'
+
+Metrics/CyclomaticComplexity:
+    Exclude:
+        - 'app/models/framework/definition/ast/field.rb'
+
+Metrics/PerceivedComplexity:
+    Exclude:
+        - 'app/models/framework/definition/ast/field.rb'

--- a/app/models/framework/definition/RM6060.fdl
+++ b/app/models/framework/definition/RM6060.fdl
@@ -9,8 +9,8 @@ Framework RM6060 {
     CustomerInvoiceDate from 'Customer Invoice/Credit Note Date'
     InvoiceNumber from 'Customer Invoice/Credit Note Number'
     LotNumber from 'Lot Number'
-    String Additional1 from 'Vehicle Registration Number'
-    String Additional2 from 'Vehicle CAP Code'
+    String(..8) Additional1 from 'Vehicle Registration Number'
+    String(..20) Additional2 from 'Vehicle CAP Code'
     String Additional3 from 'Vehicle Make'
     String Additional4 from 'Vehicle Model'
     String Additional5 from 'Vehicle Trim/Derivative'
@@ -33,7 +33,7 @@ Framework RM6060 {
     Decimal Additional13 from 'Parts Cost'
     InvoiceValue from 'Total Vehicle Cost'
     LeasingCompany Additional14 from 'Leasing Company'
-    String Additional15 from 'eAuction Contract Number'
+    String(..6) Additional15 from 'eAuction Contract Number'
   }
 
   Lookups {

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -4,13 +4,21 @@ class Framework
       # This transform exists for the express purpose of creating an AST for generating
       # an ActiveModel class with validations for a Framework
       class Creator < Parslet::Transform
-        rule(string: simple(:s))           { String(s) }
-        rule(lookup_reference: simple(:r)) { String(r) }
-        rule(decimal: simple(:d))          { BigDecimal(d) }
-        rule(integer: simple(:i))          { Integer(i) }
+        # Primitive type casts
+        rule(string: simple(:s))      { String(s) }
+        rule(decimal: simple(:d))     { BigDecimal(d) }
+        rule(integer: simple(:i))     { Integer(i) }
 
-        rule(primitive: simple(:primitive)) { primitive }
-        rule(lookup: simple(:lookup))       { lookup }
+        # Range simplifier
+        rule(integer: sequence(:nil)) { nil } # .maybe produces { integer: [] } for empty
+
+        # Lookup simplifier
+        rule(lookup_reference: simple(:r))                { String(r) }
+
+        # Just stripping Parslet::Slice
+        rule(primitive: 'String', range: subtree(:range)) { { primitive: 'String', range: range } }
+        rule(primitive: simple(:primitive))               { { primitive: String(primitive) } }
+        rule(lookup: simple(:lookup))                     { { lookup: String(lookup) } }
 
         # match known fields only
         rule(field: simple(:field), from: simple(:from)) { { kind: :known, field: field.to_s, from: from.to_s } }
@@ -22,18 +30,22 @@ class Framework
         end
 
         # optional Additional field rule
-        rule(optional: simple(:optional), type_def: simple(:type), field: simple(:field), from: subtree(:from)) do
-          { kind: :additional, optional: true, type: type.to_s, field: field.to_s, from: from }
+        rule(optional: simple(:optional), type_def: subtree(:type), field: simple(:field), from: subtree(:from)) do
+          { kind: :additional, optional: true, type: type, field: field.to_s, from: from }
         end
 
         # Additional field rule
-        rule(type_def: simple(:type), field: simple(:field), from: subtree(:from)) do
-          { kind: :additional, type: type.to_s, field: field.to_s, from: from }
+        rule(type_def: subtree(:type), field: simple(:field), from: subtree(:from)) do
+          { kind: :additional, type: type, field: field.to_s, from: from }
         end
 
-        # Unknown fields rule
-        rule(optional: simple(:optional), type_def: simple(:type), from: simple(:from)) do
-          { kind: :unknown, optional: true, type: type.to_s, from: from }
+        # Unknown fields rules
+        rule(type_def: subtree(:type), from: simple(:from)) do
+          { kind: :unknown, type: type, from: from }
+        end
+
+        rule(optional: simple(:optional), type_def: subtree(:type), from: simple(:from)) do
+          { kind: :unknown, optional: true, type: type, from: from }
         end
 
         # Lookups

--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -64,13 +64,20 @@ class Framework
         end
 
         ##
+        # The source type; the literal string of the type. e.g.
+        # String, Date, SomeLookupName
+        def source_type
+          field_def.dig(:type, :primitive) || field_def.dig(:type, :lookup)
+        end
+
+        ##
         # 'Our' type; things like :string, :yesno, :decimal
         def primitive_type
           case kind
           when :known
             DataWarehouse::KnownFields.type_for(warehouse_name)
           else
-            PRIMITIVE_TYPES[field_def[:type]] || :string
+            PRIMITIVE_TYPES[source_type] || :string
           end
         end
 
@@ -78,14 +85,14 @@ class Framework
           if known?
             lookups.key?(warehouse_name)
           else
-            field_def[:type] && PRIMITIVE_TYPES[field_def[:type]].nil?
+            source_type && PRIMITIVE_TYPES[source_type].nil?
           end
         end
 
         def lookup_name
           return nil unless lookup?
 
-          known? ? warehouse_name : field_def[:type]
+          known? ? warehouse_name : source_type
         end
 
         ##
@@ -113,6 +120,22 @@ class Framework
         def dependent_field_inclusion_values
           field_def[:depends_on][:values].transform_values do |lookup_name|
             lookups[lookup_name]
+          end
+        end
+
+        def length_options
+          range = field_def.dig(:type, :range)
+
+          return {} if range.nil?
+
+          if range[:min] && range[:max]
+            { in: range[:min]..range[:max] }
+          elsif range[:min]
+            { minimum: range[:min] }
+          elsif range[:max]
+            { maximum: range[:max] }
+          elsif range[:is]
+            { is: range[:is] }
           end
         end
       end

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -18,6 +18,8 @@ class Framework
             set_optional_modifiers! if field.optional?
 
             add_inclusion_validators(lookup_values)
+            set_length_options!
+
             options
           end
 
@@ -26,6 +28,10 @@ class Framework
           def add_inclusion_validators(lookup_values)
             options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
             options[:dependent_field_inclusion] =  { parent: field.dependent_field, in: { field.dependent_field => field.dependent_field_inclusion_values } } if field.dependent_field_inclusion?
+          end
+
+          def set_length_options!
+            options[:length] = field.length_options if field.length_options.any?
           end
 
           def no_presence_required?

--- a/app/models/framework/definition/ast/presenter.rb
+++ b/app/models/framework/definition/ast/presenter.rb
@@ -28,6 +28,8 @@ class Framework
 
         def field_by_name(entry_type, name)
           field_def = field_defs(entry_type).find { |f| f[:field] == name }
+          raise ArgumentError, "No #{entry_type} field '#{name}' found" unless field_def
+
           Field.new(field_def, lookups)
         end
       end

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -62,6 +62,8 @@ class Framework
       rule(:integer)    { match(/[0-9]/).repeat.as(:integer) >> space? }
       rule(:decimal)    { (match(/[0-9]/).repeat >> (str('.') >> match(/[0-9]/).repeat >> space?)).as(:decimal) >> space? }
       rule(:percentage) { (decimal | integer) >> str('%') }
+      rule(:range)      { (range_exp | integer).as(:range) }
+      rule(:range_exp)  { integer.as(:min).maybe >> str('..') >> integer.as(:max).maybe }
 
       rule(:space)   { match(/\s/).repeat(1) }
       rule(:space?)  { space.maybe }

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -36,7 +36,8 @@ class Framework
       rule(:additional_field)     { optional >> type_def >> space >> additional_field_identifier.as(:field) >> from_specifier }
       rule(:unknown_field)        { optional >> primitive_type_def.as(:type_def) >> space >> from_specifier }
       rule(:type_def)             { (primitive_type_def | pascal_case_identifier.as(:lookup)).as(:type_def) }
-      rule(:primitive_type_def)   { (str('String') | str('Date') | str('Integer') | str('Decimal') | str('YesNo')).as(:primitive) }
+      rule(:primitive_type_def)   { string_def | (str('Date') | str('Integer') | str('Decimal') | str('YesNo')).as(:primitive) }
+      rule(:string_def)           { str('String').as(:primitive) >> parenthesised(range).maybe }
       rule(:from_specifier)       { spaced(str('from')) >> string.as(:from) }
       rule(:optional)             { spaced(str('optional').as(:optional).maybe) }
 
@@ -59,8 +60,8 @@ class Framework
         ).repeat.as(:string) >> str("'") >> space?
       end
 
-      rule(:integer)    { match(/[0-9]/).repeat.as(:integer) >> space? }
-      rule(:decimal)    { (match(/[0-9]/).repeat >> (str('.') >> match(/[0-9]/).repeat >> space?)).as(:decimal) >> space? }
+      rule(:integer)    { match(/[0-9]/).repeat.as(:integer) }
+      rule(:decimal)    { (match(/[0-9]/).repeat >> (str('.') >> match(/[0-9]/).repeat >> space?)).as(:decimal) }
       rule(:percentage) { (decimal | integer) >> str('%') }
       rule(:range)      { (range_exp | integer).as(:range) }
       rule(:range_exp)  { integer.as(:min).maybe >> str('..') >> integer.as(:max).maybe }
@@ -70,6 +71,8 @@ class Framework
 
       rule(:lbrace)  { str('{') >> space? }
       rule(:rbrace)  { str('}') >> space? }
+      rule(:lparen)  { str('(') }
+      rule(:rparen)  { str(')') }
       rule(:lsquare) { str('[') >> space? }
       rule(:rsquare) { str(']') >> space? }
 
@@ -92,6 +95,13 @@ class Framework
       # lsquare >> atom 1 >> atom2 >> rsquare in most situations.
       def square_bracketed(atom)
         lsquare >> atom >> rsquare
+      end
+
+      ##
+      # parenthesised(atom1 >> atom 2) reads better than
+      # lparen >> atom 1 >> atom2 >> rparen in most situations.
+      def parenthesised(atom)
+        lparen >> atom >> rparen
       end
     end
   end

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -63,7 +63,7 @@ class Framework
       rule(:integer)    { match(/[0-9]/).repeat.as(:integer) }
       rule(:decimal)    { (match(/[0-9]/).repeat >> (str('.') >> match(/[0-9]/).repeat >> space?)).as(:decimal) }
       rule(:percentage) { (decimal | integer) >> str('%') }
-      rule(:range)      { (range_exp | integer).as(:range) }
+      rule(:range)      { (range_exp | integer.as(:is)).as(:range) }
       rule(:range_exp)  { integer.as(:min).maybe >> str('..') >> integer.as(:max).maybe }
 
       rule(:space)   { match(/\s/).repeat(1) }

--- a/spec/models/framework/definition/ast/field_spec.rb
+++ b/spec/models/framework/definition/ast/field_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Framework::Definition::AST::Field do
       let(:source) { "optional Date Additional10 from 'Lease Start Date'" }
 
       it      { is_expected.not_to be_lookup }
+      example { expect(field.source_type).to eql('Date') }
       example { expect(field.primitive_type).to eql(:date) }
     end
 
@@ -83,7 +84,33 @@ RSpec.describe Framework::Definition::AST::Field do
         expect(field.lookup_name).to eql('PaymentProfile')
       end
       it 'always treats lookups types as :string' do
+        expect(field.source_type).to eql('PaymentProfile')
         expect(field.primitive_type).to eql(:string)
+      end
+    end
+
+    describe '#length_options' do
+      subject { field.length_options }
+
+      context 'minimum length' do
+        let(:source) { "String(3..) Additional2 from 'Payment Profile'" }
+        it { is_expected.to eq(minimum: 3) }
+        example { expect(field.source_type).to eql('String') }
+      end
+
+      context 'maximum length' do
+        let(:source) { "String(..8) Additional2 from 'Payment Profile'" }
+        it { is_expected.to eq(maximum: 8) }
+      end
+
+      context 'exact length' do
+        let(:source) { "String(5) Additional2 from 'Payment Profile'" }
+        it { is_expected.to eq(is: 5) }
+      end
+
+      context 'with a min and a max' do
+        let(:source) { "String(5..10) Additional2 from 'Payment Profile'" }
+        it { is_expected.to eq(in: 5..10) }
       end
     end
   end
@@ -92,6 +119,7 @@ RSpec.describe Framework::Definition::AST::Field do
     let(:source) { "optional String from 'Cost Centre'" }
 
     it      { is_expected.not_to be_lookup }
+    example { expect(field.source_type).to eql('String') }
     example { expect(field.primitive_type).to eql(:string) }
   end
 end

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Framework::Definition::Parser do
   describe '#range' do
     subject { parser.range }
 
-    it { is_expected.to parse('5').as(range: { integer: '5' }) }
+    it { is_expected.to parse('5').as(range: { is: { integer: '5' } }) }
     it { is_expected.to parse('1..5').as(range: { min: { integer: '1' }, max: { integer: '5' } }) }
     it { is_expected.to parse('..5').as(range: { min: { integer: [] }, max: { integer: '5' } }) }
     it { is_expected.to parse('1..').as(range: { min: { integer: '1' }, max: { integer: [] } }) }
@@ -263,7 +263,7 @@ RSpec.describe Framework::Definition::Parser do
     context 'field with String length' do
       it {
         is_expected.to parse("String(5) from 'Somewhere'", trace: true).as(
-          type_def: { primitive: 'String', range: { integer: '5' } }, from: { string: 'Somewhere' }
+          type_def: { primitive: 'String', range: { is: { integer: '5' } } }, from: { string: 'Somewhere' }
         )
       }
 

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe Framework::Definition::Parser do
     it { is_expected.to parse('0.0%') }
   end
 
+  describe '#range' do
+    subject { parser.range }
+
+    it { is_expected.to parse('5').as(range: { integer: '5' }) }
+    it { is_expected.to parse('1..5').as(range: { min: { integer: '1' }, max: { integer: '5' } }) }
+    it { is_expected.to parse('..5').as(range: { min: { integer: [] }, max: { integer: '5' } }) }
+    it { is_expected.to parse('1..').as(range: { min: { integer: '1' }, max: { integer: [] } }) }
+  end
+
   describe '#management_charge' do
     subject { parser.management_charge }
 

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -156,6 +156,20 @@ RSpec.describe Framework::Definition::Parser do
         )
       }
     end
+
+    context 'a String type_def' do
+      context 'simple' do
+        it { is_expected.to parse('String').as(type_def: { primitive: 'String' }) }
+      end
+
+      context 'with a range' do
+        it {
+          is_expected.to parse('String(1..5)').as(
+            type_def: { primitive: 'String', range: { min: { integer: '1' }, max: { integer: '5' } } }
+          )
+        }
+      end
+    end
   end
 
   describe '#known_field' do
@@ -244,6 +258,16 @@ RSpec.describe Framework::Definition::Parser do
           optional: 'optional', type_def: { primitive: 'String' }, from: { string: 'Cost Centre' }
         )
       }
+    end
+
+    context 'field with String length' do
+      it {
+        is_expected.to parse("String(5) from 'Somewhere'", trace: true).as(
+          type_def: { primitive: 'String', range: { integer: '5' } }, from: { string: 'Somewhere' }
+        )
+      }
+
+      example { expect(parser.range).not_to parse('1..10   ') }
     end
   end
 


### PR DESCRIPTION
# [FDL: Support various field length validations (RM6060)](https://trello.com/c/QmEdUhOR/936-fdl-support-various-field-length-validations-rm6060)

Add support for fields that validate minimum, maximum, or exact `String` lengths. For example:

```
Framework RM6060 {
  Name 'Fake framework'
  ManagementCharge 0.5%
   InvoiceFields {
    InvoiceValue from 'Somewhere'
    String(..6) from 'Up to 6 chars'
    String(3..) from 'Over 3 chars'
    String(5) from 'Exactly 5 chars'
    String(4..8) from 'Between 4 and 8 chars'
  }
}
```

These transpile, respectively, to:

```ruby
field 'Over 3 chars', :string, length: { minimum: 3 }
field 'Up to 6 chars', :string, length: { maximum: 6 }
field 'Exactly 5 chars', :string, length: { is: 5 }
field 'Between 4 and 8 chars', :string, length: { minimum: 4, maximum: 8 }
```

## Additional work

- Update RM6060 to use these validations