### PR TITLE
BUG: FDL <-> Original RB framework comparisons invalid

### DIFF
--- a/app/models/framework/definition/CM_OSG_05_3565.fdl
+++ b/app/models/framework/definition/CM_OSG_05_3565.fdl
@@ -14,7 +14,7 @@ Framework CM/OSG/05/3565 {
     optional ProductCode from 'Item Code'
 
     optional String Additional1 from 'Manufacturers Product Code'
-    String Additional2 from 'Unit Quantity'
+    optional String Additional2 from 'Unit Quantity'
 
     UnitPrice from 'Price per Item'
     UnitType from 'Unit of Purchase'

--- a/app/models/framework/definition/RM6060.rb
+++ b/app/models/framework/definition/RM6060.rb
@@ -109,7 +109,7 @@ class Framework
 
         field 'Customer Organisation Name', :string, exports_to: 'CustomerName', presence: true
         field 'Customer Unique Reference Number (URN)', :integer, exports_to: 'CustomerURN', urn: true
-        field 'Customer Invoice/Credit Note Date', :string, exports_to: 'CustomerInvoiceDate', ingested_date: true, presence: true
+        field 'Customer Invoice/Credit Note Date', :string, exports_to: 'CustomerInvoiceDate', ingested_date: true
         field 'Customer Invoice/Credit Note Number', :string, exports_to: 'InvoiceNumber', presence: true
         field 'Lot Number', :string, exports_to: 'LotNumber', presence: true, lot_in_agreement: true
         field 'Vehicle Registration Number', :string, exports_to: 'Additional1', presence: true, length: { maximum: 8 }
@@ -118,7 +118,7 @@ class Framework
         field 'Vehicle Model', :string, exports_to: 'Additional4', presence: true
         field 'Vehicle Trim/Derivative', :string, exports_to: 'Additional5', presence: true
         field 'Vehicle Segment', :string, exports_to: 'ProductGroup', dependent_field_inclusion: { parent: 'Lot Number', in: MAPPING }
-        field 'Fuel Type', :string, exports_to: 'Additional6', presence: true, case_insensitive_inclusion: { in: FUEL_TYPES }
+        field 'Fuel Type', :string, exports_to: 'Additional6', case_insensitive_inclusion: { in: FUEL_TYPES }
         field 'CO2 Emissions', :string, exports_to: 'Additional7', ingested_numericality: true, allow_nil: true
         field 'MRP Excluding Options', :string, exports_to: 'Additional8', ingested_numericality: true
         field 'Customer Support Terms', :string, exports_to: 'Additional9', ingested_numericality: true
@@ -127,7 +127,7 @@ class Framework
         field 'Conversion Cost', :string, exports_to: 'Additional12', ingested_numericality: true
         field 'Parts Cost', :string, exports_to: 'Additional13', ingested_numericality: true
         field 'Total Vehicle Cost', :string, exports_to: 'InvoiceValue', ingested_numericality: true
-        field 'Leasing Company', :string, exports_to: 'Additional14', presence: true, case_insensitive_inclusion: { in: LEASING_COMPANIES }
+        field 'Leasing Company', :string, exports_to: 'Additional14', case_insensitive_inclusion: { in: LEASING_COMPANIES }
         field 'eAuction Contract Number', :string, exports_to: 'Additional15', presence: true, length: { maximum: 6 }
       end
     end

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -31,7 +31,9 @@ class Framework
           def no_presence_required?
             # Validators like UrnValidator and the case_insensitive_inclusion used for
             # YesNo fields don't require an accompanying +presence: true+
-            %i[urn yesno].include?(field.primitive_type)
+            # IngestedNumericality validator treats nil as an error so should
+            # have +allow_nil: true+ for optional fields, not +presence: true+ for mandatory fields
+            %i[urn yesno decimal integer date].include?(field.primitive_type) || field.lookup? || field.dependent_field_inclusion?
           end
 
           def set_optional_modifiers!

--- a/lib/fdl/validations/test/compare.rb
+++ b/lib/fdl/validations/test/compare.rb
@@ -20,7 +20,7 @@ module FDL
 
         def original_errors
           original_invoice.validate
-          original_invoice.errors.to_h
+          original_invoice.errors.to_hash.transform_values(&:sort)
         end
 
         def fdl_invoice
@@ -30,7 +30,7 @@ module FDL
         def fdl_errors
           invoice = fdl_invoice
           invoice.validate
-          invoice.errors.to_h
+          invoice.errors.to_hash.transform_values(&:sort)
         end
 
         def diff_s

--- a/spec/lib/fdl/validation/failing_cases_spec.rb
+++ b/spec/lib/fdl/validation/failing_cases_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
 
     context 'various optional fields' do
       let(:data) { { 'Lot Number' => 6, 'Parts Cost' => 442301 } }
-      
+
       it do
         is_expected.to be_empty
       end

--- a/spec/lib/fdl/validation/failing_cases_spec.rb
+++ b/spec/lib/fdl/validation/failing_cases_spec.rb
@@ -220,12 +220,9 @@ RSpec.describe 'Failing cases we found via rake fdl:validation:test' do
 
     context 'various optional fields' do
       let(:data) { { 'Lot Number' => 6, 'Parts Cost' => 442301 } }
-
-      it 'has some outstanding errors that we know about, but these need to go away' do
-        # https://trello.com/c/mXblTePD/967-bug-fdl-original-rb-framework-comparisons-invalid
-        is_expected.to eql(
-          [['~', 'Customer Invoice/Credit Note Date', "can't be blank", 'must be in the format dd/mm/yyyy']]
-        )
+      
+      it do
+        is_expected.to be_empty
       end
     end
   end

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Framework::Definition::Language do
             expect(invoice_class.export_mappings['InvoiceValue']).to eq('Total Spend')
           end
 
-          it 'validates numericality and presence' do
-            expect(invoice_class).to have_field('Total Spend').validated_by(:presence, :ingested_numericality)
+          it 'validates numericality' do
+            expect(invoice_class).to have_field('Total Spend').validated_by(:ingested_numericality)
           end
 
           it 'is a string validate as a number' do
@@ -101,9 +101,9 @@ RSpec.describe Framework::Definition::Language do
             expect(invoice_class.export_mappings['InvoiceDate']).to eq('Customer Invoice Date')
           end
 
-          it 'is assumed to be present and a valid date' do
+          it 'is assumed to be a valid date' do
             expect(invoice_class).to have_field('Customer Invoice Date')
-              .validated_by(:presence, :ingested_date)
+              .validated_by(:ingested_date)
           end
         end
 
@@ -312,6 +312,11 @@ RSpec.describe Framework::Definition::Language do
         it {
           is_expected.to have_field('Vehicle Segment')
             .validated_by(dependent_field_inclusion: { parent: 'Lot Number', in: mappings })
+        }
+
+        it {
+          is_expected.to have_field('Additional Support Terms')
+            .validated_by(:ingested_numericality)
         }
       end
     end

--- a/spec/validators/ingested_numericality_validator_spec.rb
+++ b/spec/validators/ingested_numericality_validator_spec.rb
@@ -43,4 +43,11 @@ RSpec.describe IngestedNumericalityValidator do
     expect(instance).not_to be_valid
     expect(instance.errors['test'].first).to eq 'is not a number'
   end
+
+  it 'does not validate values that are nil' do
+    instance = entry_data_class.new(SubmissionEntry.new(data: { 'test' => nil }))
+
+    expect(instance).not_to be_valid
+    expect(instance.errors['test'].first).to eq 'is not a number'
+  end
 end


### PR DESCRIPTION
# [BUG: FDL <-> Original RB framework comparisons invalid](https://trello.com/c/mXblTePD/967-bug-fdl-original-rb-framework-comparisons-invalid)

To check if the FDL versions of the framework classes match the original Ruby versions of the framework classes we have been running SubmissionEntry lines through both versions of the framework classes and checking if the validations match. 

However, we eventually realised that HashDiff was not accurately comparing the error hashes. Because we were using to_h rather than to_hash in the FDL::Validations::Test::Compare class in both original_errors and fdl_errors we were unwittingly collapsing all errors on a field to only the first error. 

Also the hash values were not sorted, meaning arrays with identical contents in different orders were being marked as different.

Before:
```
        def original_errors
          original_invoice.validate
          original_invoice.errors.to_h
        end
```
After:
```
        def original_errors
          original_invoice.validate
          original_invoice.errors.to_hash.transform_values(&:sort)
        end
```

Making these changes surfaced a problem with the `.rb` implementations of the frameworks, in that `presence: true` was not needed when a stricter validator is on the same field. Having both validators on the field was a problem for FDL - the fewer permutations of validators we need, the less complex FDL can be. 

This PR:

- Makes FDL::Validations::Test::Compare more accurate
- Removes any extra `presence: true` validators from fields which have a stricter validator on them
- Adds an extra test to `ingested_numericality_validator_spec.rb` to prove that the validator does not allow nil by default
