### PR TITLE
Correct sidekiq_schedule.yml

### DIFF
--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -7,6 +7,6 @@ monthly_tasks_generation:
   class: 'MonthlyTasksGenerationJob'
   queue: default
 daily_data_warehouse_export:
-  cron: '0 23 0 0 0'
+  cron: '0 23 * * *'
   class: DataWarehouseExportJob
   queue: default


### PR DESCRIPTION
This cron config was incorrect, which was causing sidekiq to not launch correctly.