### PR TITLE
962 fdl lot number definition

### DIFF
--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -40,6 +40,10 @@ class Framework
           @management_charge ||= calculator
         end
 
+        def lots(lots = nil)
+          @lots ||= lots
+        end
+
         def calculate_management_charge(entry)
           management_charge.calculate_for(entry)
         end

--- a/app/models/framework/definition/RM3767.fdl
+++ b/app/models/framework/definition/RM3767.fdl
@@ -1,0 +1,59 @@
+Framework RM3767 {
+  Name 'Supply and Fit of Tyres (RM3767)'
+
+  ManagementCharge 1%
+
+  InvoiceFields {
+    LotNumber from 'Lot Number'
+    CustomerURN from 'Customer URN'
+    CustomerName from 'Customer Organisation Name'
+    InvoiceDate from 'Customer Invoice Date'
+    InvoiceNumber from 'Customer Invoice Number'
+    ProductGroup from 'Product Type'
+    ProductClass from 'Tyre Brand'
+    String from 'Tyre Width'
+    String from 'Aspect Ratio'
+    String from 'Rim Diameter'
+    optional String from 'Load Capacity'
+    optional String from 'Speed Index'
+    ProductSubClass from 'Vehicle Category'
+    TyreGrade Additional1 from 'Tyre Grade'
+    ProductDescription from 'Associated Service'
+    YesNo Additional2 from 'Run Flats (Y/N)'
+    UNSPSC from 'UNSPSC'
+    optional UnitType from 'Unit of Purchase'
+    UnitPrice from 'Price per Unit'
+    UnitQuantity from 'Quantity'
+    InvoiceValue from 'Total Cost (ex VAT)'
+    VATCharged from 'VAT Amount Charged'
+    optional String Additional8 from 'Subcontractor Name'
+  }
+
+  Lookups {
+    ProductGroup [
+      'Tyre - Supply ONLY'
+      'Tyre - Supply + Fit'
+      'Casing Credit'
+    ]
+
+    ProductSubClass [
+      'Car'
+      '4x4'
+      'Van'
+      'Truck'
+      'Motorcycle'
+      'Agrarian'
+    ]
+
+    TyreGrade [
+      'Premium'
+      'Mid-Range'
+      'Budget'
+    ]
+  }
+
+  Lots {
+    '1' -> 'The supply and fit of tyres and associated services to the Police and emergency services'
+    '2' -> 'The supply and fit of tyres and associated services to central Government and the wider public sector'
+  }
+}

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -16,7 +16,8 @@ class Framework
         braced(
           spaced(metadata) >>
           spaced(fields_blocks) >>
-          spaced(lookups_block.as(:lookups)).maybe
+          spaced(lookups_block.as(:lookups)).maybe >>
+          spaced(lots_block).maybe
         )
       end
       rule(:framework_name)       { str('Name') >> spaced(string.as(:framework_name)) }
@@ -45,13 +46,15 @@ class Framework
       rule(:lookup_key_values)    { pascal_case_identifier.as(:lookup_name) >> space >> string_array }
       rule(:string_array)         { square_bracketed(string.repeat(1).as(:list)) }
 
+      rule(:lots_block)           { str('Lots') >> space >> dictionary.as(:lots) }
+
       rule(:depends_on)           { (spaced(str('depends_on')) >> spaced(string).as(:dependent_field) >> dictionary.as(:values)).as(:depends_on) }
 
       rule(:metadata)             { framework_name >> management_charge }
 
       rule(:map)                  { allowable_key.as(:key) >> spaced(str('->')) >> allowable_value.as(:value) >> space? }
       rule(:allowable_key)        { string | pascal_case_identifier }
-      rule(:allowable_value)      { percentage | pascal_case_identifier.as(:lookup_reference) }
+      rule(:allowable_value)      { percentage | pascal_case_identifier.as(:lookup_reference) | string }
       rule(:dictionary)           { braced(map.repeat(1).as(:dictionary)) }
 
       rule(:string) do

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -15,6 +15,7 @@ class Framework
         Class.new(Framework::Definition::Base) do
           framework_name       ast[:framework_name]
           framework_short_name ast[:framework_short_name]
+          lots                 ast[:lots]
 
           calculator = transpiler.choose_management_charge_calculator(ast[:management_charge])
 

--- a/lib/fdl/validations/test.rb
+++ b/lib/fdl/validations/test.rb
@@ -36,7 +36,7 @@ module FDL
       def run
         bar = ProgressBar.new(sample_rows.count)
 
-        sample_rows.each do |entry|
+        sample_rows.find_each do |entry|
           compare = Compare.new(entry, framework_short_name, fdl_definition)
           diff = compare.diff
           bar.increment!

--- a/lib/tasks/fdl.rake
+++ b/lib/tasks/fdl.rake
@@ -15,7 +15,7 @@ namespace :fdl do
       framework_short_name = args[:framework_short_name] or raise ArgumentError 'framework_short_name required'
 
       options = if STDIN.tty?
-                  { sample_row_count: args[:sample_row_count] || 5000 }
+                  { sample_row_count: args[:sample_row_count].to_i || 5000 }
                 else
                   { submission_ids: STDIN.read.split("\n") }
                 end

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -364,6 +364,24 @@ RSpec.describe Framework::Definition::Language do
       end
     end
 
+    context 'RM3767 - Supply and Fit of Tyres' do
+      let(:source) do
+        File.read('app/models/framework/definition/RM3767.fdl')
+      end
+
+      describe '.lots' do
+        subject { definition.lots }
+
+        it {
+          is_expected.to eq(
+            '1' => 'The supply and fit of tyres and associated services to the Police and emergency services',
+            '2' => 'The supply and fit of tyres and associated services to central Government and '\
+                   'the wider public sector'
+          )
+        }
+      end
+    end
+
     context 'our FDL isn\'t valid' do
       let(:source) { 'any old rubbish' }
 

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -351,4 +351,27 @@ RSpec.describe Framework::Definition::Parser do
       )
     end
   end
+
+  describe '#lots_block' do
+    subject(:rule) { parser.lots_block }
+    let(:source) do
+      <<~FDL
+        Lots {
+          '1' -> 'Lot 1'
+          '2a' -> 'Lot the second'
+        }
+      FDL
+    end
+
+    it {
+      is_expected.to parse(source, trace: true).as(
+        lots: {
+          dictionary: [
+            { key: { string: '1' }, value: { string: 'Lot 1' } },
+            { key: { string: '2a' }, value: { string: 'Lot the second' } }
+          ]
+        }
+      )
+    }
+  end
 end


### PR DESCRIPTION
# [FDL: Lot Number definition (`RM3767`)](https://trello.com/c/I3HB1faI/962-fdl-lot-number-definition#)

Add support for defining `Lots` in FDL.

## Example

```
Framework RM3767 {
  Name 'Supply and Fit of Tyres (RM3767)'

  ManagementCharge 1%

  InvoiceFields {
    ...
  }

  Lots {
    '1' -> 'The supply and fit of tyres and associated services to the Police and emergency services'
    '2' -> 'The supply and fit of tyres and associated services to central Government and the wider public sector'
  }
}
```

These are stored on `Framework::Definition::Base.lots`.

## Proof of translation

No diffs from `rake fdl:validations:test[RM3767,1000000]`, based on a Mar 23 DB cut:
```
➜  DataSubmissionServiceAPI git:(962-fdl-lot-number-definition) ✗ be rake fdl:validations:test[RM3767,1000000]
W, [2019-03-27T12:33:38.123253 #36994]  WARN -- Skylight: [SKYLIGHT] [4.0.0-alpha] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
[##############################################################################################################] [261955/261955] [100.00%] [43:47] [00:00] [    99.71/s]
```

## Extra work

- Improve speed of `rake fdl:validations:test` with `find_each`.