### PR TITLE
Remove redundant guard on event

### DIFF
--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -35,11 +35,7 @@ class V1::SubmissionsController < APIController
     submission = Submission.find(params[:id])
     complete_submission!(submission)
 
-    if submission.errors.empty?
-      head :no_content
-    else
-      render jsonapi_errors: submission.errors, status: :bad_request
-    end
+    head :no_content
   end
 
   def validate

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -36,11 +36,7 @@ class Submission < ApplicationRecord
     end
 
     event :reviewed_and_accepted do
-      transitions from: :in_review, to: :completed, guard: :all_entries_valid?
-
-      error do |e|
-        errors.add(:aasm_state, message: e.message)
-      end
+      transitions from: :in_review, to: :completed
     end
 
     event :replace_with_no_business do

--- a/spec/models/submission_completion_spec.rb
+++ b/spec/models/submission_completion_spec.rb
@@ -84,34 +84,6 @@ RSpec.describe SubmissionCompletion do
           end
         end
       end
-
-      context 'with some invalid entries' do
-        let(:submission) { FactoryBot.create(:submission_with_invalid_entries, task: task) }
-
-        it 'leaves the submission in the "in_review" state' do
-          expect { complete_submission.perform! }.not_to change { submission.aasm_state }
-        end
-
-        it 'does not record the user who tried to complete the submission' do
-          expect { complete_submission.perform! }.not_to change { submission.submitted_by }
-        end
-
-        it 'does not record the attempted submission time' do
-          expect { complete_submission.perform! }.not_to change { submission.submitted_at }
-        end
-
-        it 'leaves the task in the "in_progress" state' do
-          expect { complete_submission.perform! }.not_to change { task.status }
-        end
-      end
-    end
-
-    context 'given a "processing" submission' do
-      let(:submission) { FactoryBot.create(:submission_with_unprocessed_entries, aasm_state: :processing, task: task) }
-
-      it 'leaves the submission in its current state' do
-        expect { complete_submission.perform! }.not_to change { submission.aasm_state }
-      end
     end
   end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -207,28 +207,6 @@ RSpec.describe '/v1' do
         end
       end
     end
-
-    context 'given an invalid submission' do
-      it 'returns an error' do
-        task = FactoryBot.create(:task, status: :in_progress)
-
-        submission = FactoryBot.create(
-          :submission_with_invalid_entries,
-          aasm_state: :in_review,
-          task: task
-        )
-
-        post "/v1/submissions/#{submission.id}/complete", headers: { 'X-Auth-Id' => user.auth_id }
-
-        expect(response).to have_http_status(:bad_request)
-        expect(json['errors'][0]['title']).to eql 'Invalid aasm_state'
-
-        submission.reload
-
-        expect(submission).to be_in_review
-        expect(task).to be_in_progress
-      end
-    end
   end
 
   describe 'POST /submissions/:submission_id/validate' do


### PR DESCRIPTION
In commit https://github.com/dxw/DataSubmissionServiceAPI/commit/3b9c2c8e82d3a1e4890e702c06f5309bce952401#diff-8b04dfc748ae7c73f82a96d00a3db3c2 we introduced a new state for `Submission`, `validation_failed`. The submission cannot transition to `in_review` if any of its entries have failed validation.

This has moved the need to guard a state transition to earlier in the chain, but we haven’t removed the second guard, on the `reviewed_and_accepted` event. This creates confusion and bugs, so we are proposing to remove the redundant guard.

Furthermore, there is now nothing in the normal operation that would populate the `submission.errors` for the completion action, so that code is redundant as well.