### PR TITLE
(958) Admin user can edit supplier details

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'haml-rails'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'kaminari'
+gem 'simple_form'
 
 gem 'aws-sdk-cloudwatch', require: false
 gem 'aws-sdk-s3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,6 +367,9 @@ GEM
     sidekiq-cron (1.0.4)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
+    simple_form (4.1.0)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
     skylight (4.0.0.alpha)
       skylight-core (= 4.0.0.alpha)
     skylight-core (4.0.0.alpha)
@@ -452,6 +455,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   sidekiq-cron
+  simple_form
   skylight (= 4.0.0.alpha)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,0 +1,3 @@
+window.onload = function() {
+  window.GOVUKFrontend.initAll()
+};

--- a/app/controllers/admin/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers_controller.rb
@@ -7,4 +7,24 @@ class Admin::SuppliersController < AdminController
     @supplier = Supplier.find(params[:id])
     @tasks = @supplier.tasks.includes(:framework, :active_submission).order(due_on: :desc)
   end
+
+  def edit
+    @supplier = Supplier.find(params[:id])
+  end
+
+  def update
+    @supplier = Supplier.find(params[:id])
+    if @supplier.update(supplier_params)
+      flash[:success] = 'Supplier updated successfully.'
+      redirect_to admin_supplier_path(@supplier)
+    else
+      render action: :edit
+    end
+  end
+
+  private
+
+  def supplier_params
+    params.require(:supplier).permit(:name, :salesforce_id, :coda_reference)
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -14,10 +14,10 @@ class Admin::UsersController < AdminController
 
   def create
     @user = User.new(user_params)
-    create_user
-
-    return redirect_to admin_user_path(@user) if @user.persisted?
-
+    if @user.valid?
+      create_user
+      return redirect_to admin_user_path(@user) if @user.persisted?
+    end
     render action: :new
   end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -4,6 +4,8 @@ class AdminController < ActionController::Base
 
   helper_method :current_user
 
+  add_flash_types :success, :failure, :notice, :warning
+
   private
 
   def current_user

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -9,4 +9,14 @@ module AdminHelper
     end
     to_sentence(supplier_links)
   end
+
+  def flash_types_css_class(type)
+    {
+      success: 'ccs-in-service-alert--success',
+      failure: 'ccs-in-service-alert--failure',
+      notice: 'ccs-in-service-alert--notice',
+      warning: 'ccs-in-service-alert--warning',
+      alert: 'ccs-in-service-alert--failure'
+    }[type.to_sym]
+  end
 end

--- a/app/views/admin/suppliers/edit.html.haml
+++ b/app/views/admin/suppliers/edit.html.haml
@@ -1,0 +1,13 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = simple_form_for [:admin, @supplier] do |form|
+      %fieldset.govuk-fieldset
+        %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
+          %h1.govuk-fieldset__heading
+            Edit supplier
+        = render partial: 'shared/error_summary', locals: { entity: @supplier } if @supplier.errors.present?
+
+        = form.input :name
+        = form.input :salesforce_id
+        = form.input :coda_reference
+        = form.button :submit, value: 'Update supplier'

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -1,6 +1,13 @@
 .govuk-grid-row
-  .govuk-grid-column-full
+  .govuk-grid-column-three-quarters
     %h1.govuk-heading-xl= @supplier.name
+
+  .govuk-grid-column-one-quarter
+    %nav.govuk-page-actions{"aria-labelledby" => "page-actions-title"}
+      %h2#page-actions-title.govuk-heading-s{"aria-label" => "Page actions"} Actions
+      %ul.govuk-page-actions--actions
+        %li.govuk-page-actions--action
+          = link_to 'Edit supplier', edit_admin_supplier_path(@supplier)
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/admin/users/new.html.haml
+++ b/app/views/admin/users/new.html.haml
@@ -5,14 +5,9 @@
         %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
           %h1.govuk-fieldset__heading
             Add a new user
-        - if @user.errors.present?
-          .govuk-error-summary
-            %h2#error-summary-title.govuk-error-summary__title
-              There is a problem
-            .govuk-error-summary__body
-              %ul.govuk-list.govuk-error-summary__list
-                - @user.errors.full_messages.each do |message|
-                  %li= message
+
+        = render partial: 'shared/error_summary', locals: { entity: @user } if @user.errors.present?
+
         = form.input :name
         = form.input :email
         = form.button :submit, value: 'Add new user'

--- a/app/views/admin/users/new.html.haml
+++ b/app/views/admin/users/new.html.haml
@@ -1,6 +1,6 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for [:admin, @user] do |form|
+    = simple_form_for [:admin, @user] do |form|
       %fieldset.govuk-fieldset
         %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
           %h1.govuk-fieldset__heading
@@ -13,11 +13,6 @@
               %ul.govuk-list.govuk-error-summary__list
                 - @user.errors.full_messages.each do |message|
                   %li= message
-        .govuk-form-group
-          = form.label :name, class: 'govuk-label'
-          = form.text_field :name, class: 'govuk-input'
-        .govuk-form-group
-          = form.label :email, 'Email address', class: 'govuk-label'
-          = form.text_field :email, class: 'govuk-input'
-        .govuk-form-group
-          = form.submit 'Add new user', 'aria-label': 'Add new user', class: 'govuk-button'
+        = form.input :name
+        = form.input :email
+        = form.button :submit, value: 'Add new user'

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -36,7 +36,8 @@
 
       %main{ role: 'main', id: 'main-content', class: 'govuk-main-wrapper'}
 
-        = render 'shared/alert' if flash[:alert]
+        - flash.each do |key, value|
+          = render partial: 'shared/alert', locals: { type:key, message: value }
 
         = yield
 

--- a/app/views/shared/_alert.html.haml
+++ b/app/views/shared/_alert.html.haml
@@ -1,5 +1,5 @@
 .grid-row
   .column-full
-    .ccs-in_service_alert.ccs-in_service_alert--failure{:role => "alert", :tabindex =>"-1"}
+    .ccs-in-service-alert.ccs-in-service-alert--failure{:role => "alert", :tabindex =>"-1"}
       %h2.govuk-heading-s
         = flash[:alert]

--- a/app/views/shared/_alert.html.haml
+++ b/app/views/shared/_alert.html.haml
@@ -1,5 +1,5 @@
 .grid-row
   .column-full
-    .ccs-in-service-alert.ccs-in-service-alert--failure{:role => "alert", :tabindex =>"-1"}
+    .ccs-in-service-alert{:role => "alert", :tabindex =>"-1", :class => flash_types_css_class(type) }
       %h2.govuk-heading-s
-        = flash[:alert]
+        = message

--- a/app/views/shared/_error_summary.html.haml
+++ b/app/views/shared/_error_summary.html.haml
@@ -1,0 +1,9 @@
+%div{ 'data-module' => "error-summary", 'class' => 'govuk-error-summary', 'aria-labelledby' => "error-summary-title", 'role'=>"alert", 'tabindex' => "-1" }
+  %h2#error-summary-title.govuk-error-summary__title
+    There is a problem
+  .govuk-error-summary__body
+    %ul.govuk-list.govuk-error-summary__list
+      - entity.errors.each do |attribute, error|
+        %li
+          %a{href: "##{entity.model_name.element}_#{attribute}"}
+            = error

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,55 @@
+require Rails.root.join('lib', 'simple_form', 'optional_labels')
+
+SimpleForm::Components::Labels.prepend SimpleForm::Components::OptionalLabels
+SimpleForm::Components::Labels::ClassMethods.include SimpleForm::Components::OptionalLabels::ClassMethods
+
+SimpleForm.setup do |config|
+  config.wrappers :default, tag: 'div',
+                            class: 'govuk-form-group', error_class: 'govuk-form-group--error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.use :label, class: 'govuk-label'
+    b.use :full_error, wrap_with: { tag: 'span', class: 'govuk-error-message' }
+    b.use :hint, wrap_with: { tag: 'span', class: 'govuk-hint' }
+    b.use :input, class: 'govuk-input', error_class: 'govuk-input--error'
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :inline
+
+  # Default class for buttons
+  config.button_class = 'govuk-button'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # Whether attributes are required by default (or not). Default is true.
+  config.required_by_default = false
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Append 'optional' label instead of prepending
+  config.label_text = ->(label, optional, _explicit_label) { "#{label}<span class=\"govuk-hint\">#{optional}</span>" }
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,10 @@ en:
             email:
               blank: 'Enter an email address'
               invalid: 'Enter an email address in the correct format, like name@example.com'
+        supplier:
+          attributes:
+            name:
+              blank: 'Enter a supplier name'
   errors:
     format: "%{message}"
     messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,21 @@
 ---
 en:
+  activerecord:
+    attributes:
+      user:
+        email: 'Email address'
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: 'Enter an email address'
+              invalid: 'Enter an email address in the correct format, like name@example.com'
   errors:
+    format: "%{message}"
     messages:
+      blank: 'Enter your %{attribute}'
+      taken: '%{attribute} has already been taken.'
       invalid_urn: 'is not a recognised URN'
       invalid_ingested_date: 'must be in the format dd/mm/yyyy'
       invalid_optional_ingested_date: 'must be in the format dd/mm/yyyy or left blank'

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :suppliers, only: %i[index show] do
+    resources :suppliers, only: %i[index show edit update] do
       resources :agreements, only: [] do
         get :confirm_activation
         get :confirm_deactivation

--- a/lib/simple_form/optional_labels.rb
+++ b/lib/simple_form/optional_labels.rb
@@ -1,0 +1,28 @@
+module SimpleForm
+  module Components
+    module OptionalLabels
+      module ClassMethods
+        def translate_optional_html
+          i18n_cache :translate_optional_html do
+            I18n.t(
+              :"simple_form.optional.html",
+              default: translate_optional_text
+            )
+          end
+        end
+
+        def translate_optional_text
+          I18n.t(:"simple_form.optional.text", default: 'This value is optional')
+        end
+      end
+
+      protected
+
+      def required_label_text #:nodoc:
+        return if required_field?
+
+        self.class.translate_optional_html.dup
+      end
+    end
+  end
+end

--- a/spec/features/adding_a_user_spec.rb
+++ b/spec/features/adding_a_user_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Adding a user' do
     fill_in 'Name', with: 'New User'
     fill_in 'Email address', with: 'new@example.com'
     click_button 'Add new user'
-    expect(page).to have_content('Email has already been taken')
+    expect(page).to have_content('Email address has already been taken')
   end
 
   scenario 'with Auth0 error' do

--- a/spec/features/managing_suppliers_spec.rb
+++ b/spec/features/managing_suppliers_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+RSpec.feature 'Managing suppliers' do
+  before do
+    FactoryBot.create(:supplier, name: 'Supplier 1', coda_reference: 'C012345')
+    sign_in_as_admin
+  end
+
+  scenario 'editing a supplier successfully' do
+    visit admin_suppliers_path
+    click_on 'Supplier 1'
+    click_on 'Edit supplier'
+    fill_in 'Name', with: 'Edited Supplier'
+    click_button 'Update supplier'
+
+    expect(page).to have_content('Edited Supplier')
+    expect(page).to have_content('Supplier updated successfully')
+  end
+
+  scenario 'editing a supplier unsuccessfully' do
+    visit admin_suppliers_path
+    click_on 'Supplier 1'
+    click_on 'Edit supplier'
+    fill_in 'Name', with: ''
+    click_button 'Update supplier'
+
+    expect(page).to have_content('Enter a supplier name')
+  end
+end


### PR DESCRIPTION
We want admin users to be able to edit supplier details.

The edit forms needed to closely follow the GOVUK patterns so we took advice from @leeky and used the Simple Form gem to let us setup how forms get rendered in the applicaiton globally. 

We got Simple Form setup and working with the exisiting New User form and then added the Supplier editing functionality.

We took some time to make sure the errors messages followed the recomendations as well, which meant adding some locale info.

We can now render GOVUK forms that include appropriate errors super simply:

```
= simple_form_for [:admin, @supplier] do |form|
  = render partial: 'shared/error_summary', locals: { entity: @supplier } if @supplier.errors.present?
  
  = form.input :name
  = form.input :salesforce_id
  = form.input :coda_reference
  = form.button :submit, value: 'Update supplier'
```

Gives us:

![Screenshot_2019-03-28 RMI Admin](https://user-images.githubusercontent.com/480578/55155064-552fb680-514e-11e9-94be-edafaecfb99f.png)

Another issue we noticed during this work was that the Rails flashes were styled as 'failures' i.e. red even when an action was successful, so we have added new flash types in line with the styles the app has:

- failure
- success
- warning
- notice

which can be used like regular flashes:

```flash[:success] = 'Supplier updated successfully.'```

![Screenshot_2019-03-28 RMI Admin(1)](https://user-images.githubusercontent.com/480578/55155338-00d90680-514f-11e9-98d0-dd4069619aa4.png)

Trello: https://trello.com/c/ln6EIHGW

