### PR TITLE
Loosen Coda reference validation

### DIFF
--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -11,8 +11,8 @@ class Supplier < ApplicationRecord
 
   validates :name, presence: true
   validates :coda_reference, allow_nil: true, format: {
-    with: /\AC0\d{5}\z/,
-    message: 'must start with “C0” and have five additional numbers, for example: “C012345”'
+    with: /\AC0\d{4,5}\z/,
+    message: 'must start with “C0” and have 4-5 additional numbers, for example: “C012345”'
   }
 
   scope :excluding, ->(suppliers) { where.not(id: suppliers) }

--- a/spec/models/supplier_spec.rb
+++ b/spec/models/supplier_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Supplier do
   it { is_expected.to have_many(:frameworks).through(:agreements) }
   it { is_expected.to have_many(:memberships) }
 
-  it 'validates coda_reference begins with C0 and ends with 5 more digits' do
-    valid_coda_references = %w[C012345 C002928 C099999]
+  it 'validates coda_reference begins with C0 and ends with 4-5 more digits' do
+    valid_coda_references = %w[C012345 C002928 C099999 C07232]
     invalid_coda_references = %w[C012 D012345 C0AB123]
 
     valid_coda_references.each do |coda_reference|
-      expect(FactoryBot.create(:supplier, coda_reference: coda_reference)).to be_valid
+      expect(FactoryBot.build(:supplier, coda_reference: coda_reference)).to be_valid
     end
 
     invalid_coda_references.each do |coda_reference|


### PR DESCRIPTION
Can now be C0 followed by 4 or 5 numbers (as opposed to just 5) which
means C07232 is now valid.