### PR TITLE
965 fdl support to combine lookups

### DIFF
--- a/app/models/framework/definition/RM3787.fdl
+++ b/app/models/framework/definition/RM3787.fdl
@@ -1,0 +1,117 @@
+Framework RM3787 {
+  Name 'Finance & Complex Legal Services'
+  ManagementCharge 1.5%
+
+  InvoiceFields {
+    SupplierReferenceNumber from 'Supplier Reference Number'
+    CustomerURN from 'Customer URN'
+    CustomerName from 'Customer Organisation Name'
+    CustomerPostCode from 'Customer Post Code'
+    CustomerReferenceNumber from 'Matter Name'
+    InvoiceDate from 'Customer Invoice Date'
+    InvoiceNumber from 'Customer Invoice Number'
+    ProductGroup from 'Service Type'
+    ProductClass from 'Primary Specialism' depends_on 'Service Type' {
+      'Core'     -> CoreSpecialisms
+      'Non-core' -> NonCoreSpecialisms
+      'Mixture'  -> PrimarySpecialism
+    }
+    ProductDescription from 'Practitioner Grade'
+    ProductSubClass from 'Pricing Mechanism'
+    UNSPSC from 'UNSPSC'
+    UnitType from 'Unit of Purchase'
+    UnitPrice from 'Price per Unit'
+    UnitQuantity from 'Quantity'
+    InvoiceValue from 'Total Cost (ex VAT)'
+    VATCharged from 'VAT Amount Charged'
+    Decimal Additional1 from 'Pro-Bono Price per Unit'
+    Decimal Additional2 from 'Pro-Bono Quantity'
+    Decimal Additional3 from 'Pro-Bono Total Value'
+    String Additional4 from 'Sub-Contractor Name (If Applicable)'
+  }
+
+  ContractFields {
+    SupplierReferenceNumber from 'Supplier Reference Number'
+    CustomerURN from 'Customer URN'
+    CustomerName from 'Customer Organisation Name'
+    CustomerPostcode from 'Customer Post Code'
+    CustomerReferenceNumber from 'Matter Name'
+    ProductDescription from 'Matter Description'
+    ContractStartDate from 'Contract Start Date'
+    ContractEndDate from 'Contract End Date'
+    ContractValue from 'Expected Total Order Value'
+    String Additional1 from 'Sub-Contractor Name'
+    String Additional2 from 'Expression Of Interest Used (Y/N)'
+    String Additional6 from 'Customer Response Time'
+    CallOffManagingEntity Additional3 from 'Call Off Managing Entity'
+    ContractAwardChannel from 'Award Procedure'
+    String Additional4 from 'Pro-bono work included? (Y/N)'
+    String Additional5 from 'Expected Pro-Bono value'
+  }
+
+  Lookups {
+    ProductGroup [
+      'Core'
+      'Non-core'
+      'Mixture'
+    ]
+
+    CoreSpecialisms [
+      'Corporate Finance'
+      'Rescue, Restructuring &  Insolvency'
+      'Financial services, market and completion regulation'
+      'Investment and Commercial Banking'
+      'Insurance and Reinsurance'
+      'Investment and Asset Management'
+      'Equity Capital Markets'
+      'Debt Capital Markets'
+      'Asset Finance'
+      'High Value or complex transactions and disputes'
+      'High value or complex merger and acquisition activity'
+      'Projects of exceptional innovation and complexity'
+    ]
+
+    NonCoreSpecialisms [
+      'Sovereign debt restructuring including international and EU structures and processes'
+      'International development/aid funding'
+      'International Financial organisations'
+      'All aspects of law and practice relating to international trade agreements investments and associated regulations, and to the United Kingdom’s exit from the European Union, in so far as they relate to the above projects'
+      'Credit / bond insurance, counter indemnities, alternative risk transfer mechanisms'
+    ]
+
+    PricingMechanism [
+      'Time and Material'
+      'Fixed'
+      'Risk-Reward'
+      'Gain-Share'
+      'Pro-Bono'
+    ]
+
+    PrimarySpecialism [
+      CoreSpecialisms
+      NonCoreSpecialisms
+    ]
+
+    PractitionerGrade [
+      'Partner'
+      'Legal Director/Senior Solicitor'
+      'Senior Associate'
+      'Junior Solicitor'
+      'Trainee / Paralegal'
+      'Other Grade / Mix'
+    ]
+
+    UnitOfPurchase [
+      'Hourly'
+      'Daily'
+      'Monthly'
+      'Fixed Price'
+    ]
+
+    CallOffManagingEntity [
+      'CCS'
+      'Central Government Department'
+      '3rd Party Contracting Partner'
+    ]
+  }
+}

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -12,8 +12,7 @@ class Framework
         # Range simplifier
         rule(integer: sequence(:nil)) { nil } # .maybe produces { integer: [] } for empty
 
-        # Lookup simplifier
-        rule(lookup_reference: simple(:r))                { String(r) }
+        rule(lookup_reference: simple(:r))                { LookupReference.new(r) }
 
         # Just stripping Parslet::Slice
         rule(primitive: 'String', range: subtree(:range)) { { primitive: 'String', range: range } }
@@ -65,7 +64,7 @@ class Framework
         # { 'UnitType' => ['Day', 'Each'], 'Other' => ['Value 1', 'Value 2'] }
         rule(lookups: subtree(:lookups)) do
           lookups.each_with_object({}) do |single_key_value, result|
-            lookup_name, value_list = *single_key_value.first
+            lookup_name, value_list = single_key_value.first
             result[lookup_name] = value_list
           end
         end

--- a/app/models/framework/definition/ast/lookup_reference.rb
+++ b/app/models/framework/definition/ast/lookup_reference.rb
@@ -1,0 +1,7 @@
+class Framework
+  module Definition
+    module AST
+      class LookupReference < String; end
+    end
+  end
+end

--- a/app/models/framework/definition/ast/presenter.rb
+++ b/app/models/framework/definition/ast/presenter.rb
@@ -23,7 +23,18 @@ class Framework
         end
 
         def lookups
-          ast.fetch(:lookups, {})
+          @lookups ||= ast.fetch(:lookups, {}).tap do |lookups|
+            lookups.transform_values! do |list|
+              expanded_values = list.map do |item|
+                if item.is_a?(LookupReference)
+                  ast[:lookups][item]
+                else
+                  item
+                end
+              end
+              expanded_values.flatten
+            end
+          end
         end
 
         def field_by_name(entry_type, name)

--- a/app/models/framework/definition/data_warehouse/known_fields.rb
+++ b/app/models/framework/definition/data_warehouse/known_fields.rb
@@ -8,6 +8,7 @@ class Framework
           'InvoiceValue' => :decimal,
           'ContractValue' => :decimal,
           'CustomerPostCode' => :string,
+          'CustomerPostcode' => :string,
           'CustomerName' => :string,
           'CustomerURN' => :urn,
           'InvoiceDate' => :date,
@@ -26,7 +27,12 @@ class Framework
           'VATCharged' => :decimal,
           'LotNumber' => :lot_number,
           'PromotionCode' => :string,
-          'CustomerInvoiceDate' => :date
+          'CustomerInvoiceDate' => :date,
+          'SupplierReferenceNumber' => :integer,
+          'CustomerReferenceNumber' => :string,
+          'ContractStartDate' => :date,
+          'ContractEndDate' => :date,
+          'ContractAwardChannel' => :string
         }.freeze
 
         def self.type_for(value)

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -43,8 +43,10 @@ class Framework
       rule(:optional)             { spaced(str('optional').as(:optional).maybe) }
 
       rule(:lookups_block)        { str('Lookups') >> space >> braced(lookup_key_values.repeat(1)).as(:lookups) }
-      rule(:lookup_key_values)    { pascal_case_identifier.as(:lookup_name) >> space >> string_array }
-      rule(:string_array)         { square_bracketed(string.repeat(1).as(:list)) }
+      rule(:lookup_key_values)    { pascal_case_identifier.as(:lookup_name) >> space >> lookup_item_array }
+      rule(:lookup_item_array)    { square_bracketed(lookup_item.repeat(1).as(:list)) }
+      rule(:lookup_item)          { (string | lookup_reference) >> space? }
+      rule(:lookup_reference)     { pascal_case_identifier.as(:lookup_reference) }
 
       rule(:lots_block)           { str('Lots') >> space >> dictionary.as(:lots) }
 
@@ -54,7 +56,7 @@ class Framework
 
       rule(:map)                  { allowable_key.as(:key) >> spaced(str('->')) >> allowable_value.as(:value) >> space? }
       rule(:allowable_key)        { string | pascal_case_identifier }
-      rule(:allowable_value)      { percentage | pascal_case_identifier.as(:lookup_reference) | string }
+      rule(:allowable_value)      { percentage | lookup_reference | string }
       rule(:dictionary)           { braced(map.repeat(1).as(:dictionary)) }
 
       rule(:string) do

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -26,6 +26,7 @@ class Framework
         end
       end
 
+      # rubocop:disable Metrics/AbcSize - we need this to resemble a class
       def entry_data_class(entry_type)
         ast = @ast
 
@@ -40,17 +41,18 @@ class Framework
           _total_value_field = ast.field_by_name(entry_type, "#{entry_type_capitalized}Value")
           total_value_field _total_value_field.sheet_name
 
-          lookups ast[:lookups]
+          lookups ast.lookups
 
           field_defs.each do |field_def|
             field = AST::Field.new(field_def, ast.lookups)
             # Always use a case_insensitive_inclusion validator if
             # there's a lookup with the same name as the field
-            lookup_values = ast.dig(:lookups, field.lookup_name)
+            lookup_values = ast.lookups[field.lookup_name]
             field field.sheet_name, field.activemodel_type, field.options(lookup_values)
           end
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def choose_management_charge_calculator(info)
         if info[:column_based]

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -382,6 +382,54 @@ RSpec.describe Framework::Definition::Language do
       end
     end
 
+    context 'Composing lookups from other lookups - RM3787' do
+      let(:source) do
+        <<~FDL
+          Framework 3787 {
+            Name 'Fake framework'
+            ManagementCharge 1%
+
+            InvoiceFields {
+              InvoiceValue from 'Supplier Price'
+            }
+
+            Lookups {
+              CoreSpecialisms [
+                'One'
+                'Two'
+              ]
+
+              NonCoreSpecialisms [
+                'Three'
+                'Four'
+              ]
+
+              PrimarySpecialism [
+                CoreSpecialisms
+                NonCoreSpecialisms
+                'Five'
+              ]
+            }
+          }
+        FDL
+      end
+
+      describe 'the Invoice fields class' do
+        subject(:invoice_class) { definition::Invoice }
+
+        describe '.lookups' do
+          subject { invoice_class.lookups }
+          it {
+            is_expected.to eql(
+              'CoreSpecialisms'    => %w[One Two],
+              'NonCoreSpecialisms' => %w[Three Four],
+              'PrimarySpecialism'  => %w[One Two Three Four Five]
+            )
+          }
+        end
+      end
+    end
+
     context 'our FDL isn\'t valid' do
       let(:source) { 'any old rubbish' }
 

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -326,12 +326,18 @@ RSpec.describe Framework::Definition::Parser do
             'Type1'
             'Type2'
           ]
+
+          SomeRandomComposition [
+            PaymentProfile
+            ServiceType
+            'Foo'
+          ]
         }
       FDL
     end
 
     it 'parses the lookup fields' do
-      expect(rule).to parse(source).as(
+      expect(rule).to parse(source, trace: true).as(
         lookups: [
           {
             lookup_name: 'PaymentProfile',
@@ -345,6 +351,14 @@ RSpec.describe Framework::Definition::Parser do
             list: [
               { string: 'Type1' },
               { string: 'Type2' }
+            ]
+          },
+          {
+            lookup_name: 'SomeRandomComposition',
+            list: [
+              { lookup_reference: 'PaymentProfile' },
+              { lookup_reference: 'ServiceType' },
+              { string: 'Foo' },
             ]
           }
         ]

--- a/spec/support/export_spec_expectation_truncations.rb
+++ b/spec/support/export_spec_expectation_truncations.rb
@@ -21,7 +21,8 @@ RSpec.configure do |config|
   [
     %r{/spec/lib/tasks/export},
     %r{/spec/lib/fdl/validation},
-    %r{/spec/models/export}
+    %r{/spec/models/export},
+    %r{/spec/models/framework/definition}
   ].each do |file_path|
     config.define_derived_metadata(file_path: file_path) do |metadata|
       metadata[:exporter_spec] = true


### PR DESCRIPTION
# [FDL: Support to combine lookups](https://trello.com/c/GXogoe3A/965-fdl-support-to-combine-lookups)

FDL support to compose lookups from other lookups  …
A few of our Ruby framework defs have "lookups" composed of constants,
e.g.

```
PRIMARY_SPECIALISM_VALUES = (
  CORE_SPECIALISMS +
  NON_CORE_SPECIALISMS
).freeze
```

Add equivalent FDL support, but without the '+' operator.

Example:

```
Lookups {
  One [ '1' ]
  Two [ '2' ]
  Three [ One Two '3' ]
}
```

This will create three lookups:

```
{
  'One'   => ['1'],
  'Two'   => ['2'],
  'Three' => ['1', '2', '3']
}
```

To do this, we needed to start using the `lookup_reference` rule in
two places, once in our new `lookup_item` rule and the existing usage
in `dictionary`'s `allowable_values`. It still needs to behave like a
String but stand out as a LookupReference, so create a String derivative
with no methods so that we can expand references to other lookups
as we encounter them in `AST::Presenter#lookups`.
