### PR TITLE
Treat FDL Integer fields as ActiveModel :string

### DIFF
--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -98,7 +98,7 @@ class Framework
         ##
         # The implementation type. Usually :string
         def activemodel_type
-          %i[integer urn].include?(primitive_type) ? :integer : :string
+          %i[urn].include?(primitive_type) ? :integer : :string
         end
 
         def validators?

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Framework::Definition::Language do
 
         it {
           is_expected.to have_field('UNSPSC')
-            .with_activemodel_type(:integer)
+            .with_activemodel_type(:string)
             .validated_by(ingested_numericality: { only_integer: true })
         }
 


### PR DESCRIPTION
Prevents values such as "111 Big String" being coerced to :integer
111 and passing validation. These should fail with 'not a number'

Co-Authored-By: james <james@abscond.org>