### PR TITLE
(fix) 976 Allow blank values in coda_reference field

### DIFF
--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -10,7 +10,7 @@ class Supplier < ApplicationRecord
   has_many :active_users, -> { active }, through: :memberships, class_name: 'User', source: :user
 
   validates :name, presence: true
-  validates :coda_reference, allow_nil: true, format: {
+  validates :coda_reference, allow_blank: true, format: {
     with: /\AC0\d{4,5}\z/,
     message: 'must start with “C0” and have 4-5 additional numbers, for example: “C012345”'
   }

--- a/spec/features/managing_suppliers_spec.rb
+++ b/spec/features/managing_suppliers_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 RSpec.feature 'Managing suppliers' do
   before do
     FactoryBot.create(:supplier, name: 'Supplier 1', coda_reference: 'C012345')
+    FactoryBot.create(:supplier, name: 'Supplier 2')
     sign_in_as_admin
   end
 
@@ -24,5 +25,16 @@ RSpec.feature 'Managing suppliers' do
     click_button 'Update supplier'
 
     expect(page).to have_content('Enter a supplier name')
+  end
+
+  scenario 'editing a supplier with a blank CODA reference value is successful' do
+    visit admin_suppliers_path
+    click_on 'Supplier 2'
+    click_on 'Edit supplier'
+    fill_in 'Name', with: 'Supplier 2 edited'
+    click_button 'Update supplier'
+
+    expect(page).not_to have_content('must start with “C0” and have 4-5 additional numbers, for example: “C012345”')
+    expect(page).to have_content('Supplier updated successfully')
   end
 end


### PR DESCRIPTION
Previously being set to allow_nil meant that when submitting a empty
value in the frontend resulted in a validation failure.

Changing this to allow_blank fixes the issue.

Trello: https://trello.com/c/vdt9Gq8x