### PR TITLE
(983) Fix arguments processed by state machine events

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -46,7 +46,7 @@ class Submission < ApplicationRecord
     event :replace_with_no_business do
       transitions from: :completed, to: :replaced, guard: :replaceable?
 
-      after do |*user|
+      after do |user|
         enqueue_reversal_invoice_creation_job(user) if create_reversal_invoice?
       end
     end
@@ -54,7 +54,7 @@ class Submission < ApplicationRecord
     event :mark_as_replaced do
       transitions from: :completed, to: :replaced
 
-      after do |*user|
+      after do |user|
         enqueue_reversal_invoice_creation_job(user) if create_reversal_invoice?
       end
     end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -46,10 +46,13 @@ RSpec.describe Submission do
       context 'when there is an invoice for the submission' do
         let!(:invoice) { FactoryBot.create(:submission_invoice, submission: submission) }
 
-        it 'enqueues the creation of a reversal invoice' do
+        it 'enqueues the creation of a reversal invoice with the correct arguments' do
+          allow(SubmissionReversalInvoiceCreationJob).to receive(:perform_later)
+
           submission.replace_with_no_business(correcting_user)
 
-          expect(SubmissionReversalInvoiceCreationJob).to have_been_enqueued
+          expect(SubmissionReversalInvoiceCreationJob).to have_received(:perform_later)
+            .with(submission, correcting_user)
         end
       end
 
@@ -101,10 +104,13 @@ RSpec.describe Submission do
       context 'when there is an invoice for the submission' do
         let!(:invoice) { FactoryBot.create(:submission_invoice, submission: submission) }
 
-        it 'enqueues the creation of a reversal invoice' do
+        it 'enqueues the creation of a reversal invoice with the correct arguments' do
+          allow(SubmissionReversalInvoiceCreationJob).to receive(:perform_later)
+
           submission.mark_as_replaced(correcting_user)
 
-          expect(SubmissionReversalInvoiceCreationJob).to have_been_enqueued
+          expect(SubmissionReversalInvoiceCreationJob).to have_received(:perform_later)
+            .with(submission, correcting_user)
         end
       end
 


### PR DESCRIPTION
It turns out that the splat was not only unnecessary, but harmful.

Unfortunately, the queued jobs have already received the bad argument, so they'll keep retrying for no good.