### PR TITLE
(978) Prevent duplicated entries within a bulk request

### DIFF
--- a/app/controllers/v1/submission_entries_controller.rb
+++ b/app/controllers/v1/submission_entries_controller.rb
@@ -34,7 +34,8 @@ class V1::SubmissionEntriesController < APIController
       entries << entry unless SubmissionEntry.exists?(submission_id: entry.submission_id, source: entry.source)
     end
 
-    SubmissionEntry.import(entries)
+    deduped_entries = entries.uniq { |entry| [entry.submission_id, entry.source] }
+    SubmissionEntry.import(deduped_entries)
 
     render plain: 'success', status: :created
   end

--- a/spec/requests/v1/submission_entries_spec.rb
+++ b/spec/requests/v1/submission_entries_spec.rb
@@ -158,6 +158,21 @@ RSpec.describe '/v1' do
         expect(submission.entries.count).to eq 2
       end
     end
+
+    describe 'POST two duplicate entries in the same bulk request' do
+      it 'creates one entry, ignoring the duplicate' do
+        duplicate_bulk_params = valid_bulk_params
+        duplicate_bulk_params[:data][0][:attributes][:source][:row] = 99
+        duplicate_bulk_params[:data][1][:attributes][:source][:row] = 99
+
+        post "/v1/submissions/#{submission.id}/entries/bulk",
+             params: duplicate_bulk_params.to_json,
+             headers: json_headers
+
+        expect(response).to have_http_status(:created)
+        expect(submission.entries.where("CAST(source->>'row' AS INTEGER) = 99").count).to eq 1
+      end
+    end
   end
 
   context 'scoped to a submission file' do


### PR DESCRIPTION
We'd previously added a guard to prevent new entries being created when
identical ones already exist in the database. When we changed this to do
bulk insert, we'd forgotten to deduplicate the list of entries we bulk
insert.

This lead to at least one submission containing duplicate rows, which
meant its total value and management charge calculations were out by a
significant amount.

The change removes the duplicates in the array before the bulk insert
loads it into the database.