### PR TITLE
Release 65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [release-65] - 2019-04-03
+
+- Prevent duplicate submission entries being saved in bulk request
+- Fix validation snags in RM1557vii and RM3788
+- Fix framework lot names for RM3767
+- FDL: Prevent string values being coerced into integers
+- BUG: Fix reversal invoice creation
+
 ## [release-64] - 2019-04-01
 
 - Submission factories more accurately reflect reality
@@ -427,6 +435,7 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
+[release-65]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-64...release-65
 [release-64]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-63...release-64
 [release-63]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-62...release-63
 [release-62]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-61...release-62


### PR DESCRIPTION
- Prevent duplicate submission entries being saved in bulk request
 - Fix validation snags in RM1557vii and RM3788
 - Fix framework lot names for RM3767
 - FDL: Prevent string values being coerced into integers
 - BUG: Fix reversal invoice creation