### PR TITLE
Parse FDL framework short names with roman numerals

### DIFF
--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -11,7 +11,7 @@ class Framework
       rule(:pascal_case_identifier) { (match(/[A-Z]/) >> match(/[a-z0-9]/).repeat).repeat(1) }
       rule(:additional_field_identifier) { str('Additional') >> match('[0-9]').repeat(1) }
 
-      rule(:framework_identifier) { match(%r{[A-Z0-9/]}).repeat(1).as(:string) }
+      rule(:framework_identifier) { match(%r{[A-Za-z0-9/]}).repeat(1).as(:string) }
       rule(:framework_block) do
         braced(
           spaced(metadata) >>

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -429,6 +429,24 @@ RSpec.describe Framework::Definition::Language do
         end
       end
     end
+    context 'Roman numerals in the short_name' do
+      let(:source) do
+        <<~FDL
+          Framework RM1043iii {
+            Name 'DOS-like'
+            ManagementCharge 1%
+
+            InvoiceFields {
+              InvoiceValue from 'Supplier Price'
+            }
+          }
+        FDL
+      end
+
+      it "doesn't grumble" do
+        expect(definition.framework_short_name).to eql('RM1043iii')
+      end
+    end
 
     context 'our FDL isn\'t valid' do
       let(:source) { 'any old rubbish' }

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Framework::Definition::Parser do
 
     it { is_expected.to parse('CM/OSG/05/3565').as(string: 'CM/OSG/05/3565') }
     it { is_expected.to parse('RM3710').as(string: 'RM3710') }
-    it { is_expected.not_to parse('foobar') }
   end
 
   describe '#framework_name' do


### PR DESCRIPTION
We were being overly case-sensitive about framework names