### PR TITLE
Remove space in RM1043.5 `Invoice Date`

### DIFF
--- a/app/models/framework/definition/RM1043_5.rb
+++ b/app/models/framework/definition/RM1043_5.rb
@@ -68,7 +68,7 @@ class Framework
         field 'Opportunity ID', :string, exports_to: 'SupplierReferenceNumber', presence: true, length: { minimum: 4 }, ingested_numericality: { only_integer: true }
         field 'Customer Organisation Name', :string, exports_to: 'CustomerName', presence: true
         field 'Customer Unique Reference Number (URN)', :integer, exports_to: 'CustomerURN', urn: true
-        field 'Customer Invoice/Credit Note Date', :string, exports_to: 'Invoice Date', ingested_date: true, presence: true
+        field 'Customer Invoice/Credit Note Date', :string, exports_to: 'InvoiceDate', ingested_date: true, presence: true
         field 'Customer Invoice/Credit Note Number', :string, exports_to: 'InvoiceNumber', presence: true
         field 'Lot Number', :string, exports_to: 'LotNumber', presence: true, lot_in_agreement: true
         field 'Service Provided', :string, exports_to: 'ProductGroup', presence: true, dependent_field_inclusion: { parent: 'Lot Number', in: MAPPING }


### PR DESCRIPTION
Apropos of translating the framework to FDL, the generator gave us a
file that did not parse, because `InvoiceDate` had a space in it.

We are finding `#NOTINDATA` for that column in the export.

Remove the space.