### PR TITLE
(1020) Allow us to run rake export:all:reexport to reexport everything

### DIFF
--- a/app/models/data_warehouse_export.rb
+++ b/app/models/data_warehouse_export.rb
@@ -3,8 +3,8 @@ class DataWarehouseExport < ApplicationRecord
 
   after_initialize :set_date_range
 
-  def self.generate!
-    new.tap do |export|
+  def self.generate!(reexport: false)
+    new(range_from: (EARLIEST_RANGE_FROM if reexport)).tap do |export|
       ActiveRecord::Base.transaction(isolation: :repeatable_read) do
         files = export.generate_files
         Export::S3Upload.new(files).perform

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,14 +1,18 @@
 # Tasks to export per-entity CSV files for CCS BI
 namespace :export do
-  desc 'Export everything to CSV'
-  task all: %i[environment tasks submissions invoices contracts]
-
   namespace :all do
     desc 'Export everything that has updated since the last export to CSV'
     task incremental: :environment do
       puts 'Generating incremental export...'
       export = DataWarehouseExport.generate!
       puts "Generated incremental export for #{export.date_range}"
+    end
+
+    desc 'reexport everything from scratch'
+    task reexport: :environment do
+      puts 'Generating re-export...'
+      export = DataWarehouseExport.generate!(reexport: true)
+      puts "Generated re-export for #{export.date_range}"
     end
   end
 


### PR DESCRIPTION
We currently export anything that has an updated_at date more recent than the last export. But sometimes we make code changes to the export that means we want to re-export *everything* again to make sure that any changes are reflected in the data warehouse.

This adds a new rake task `export:all:reexport` that uses a new feature of DataWarehouseExport.generate! to ignore the previous export date and just re-export everything.

I have also removed the `export:all` rake task, as it was referencing tasks that no longer exist.