### PR TITLE
960 adding and editing fdl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,4 +93,5 @@ group :test do
   gem 'capybara'
   gem 'climate_control'
   gem 'webmock'
+  gem 'launchy'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,8 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -435,6 +437,7 @@ DEPENDENCIES
   jsonapi-rails
   jsonapi-rspec
   kaminari
+  launchy
   listen (>= 3.0.5, < 3.2)
   lograge
   lolsoap

--- a/app/assets/javascripts/prism.js
+++ b/app/assets/javascripts/prism.js
@@ -1,0 +1,729 @@
+/* PrismJS 1.16.0
+https://prismjs.com/download.html#themes=prism&languages=clike+ruby */
+var _self = (typeof window !== 'undefined')
+	? window   // if in browser
+	: (
+		(typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope)
+		? self // if in worker
+		: {}   // if in node js
+	);
+
+/**
+ * Prism: Lightweight, robust, elegant syntax highlighting
+ * MIT license http://www.opensource.org/licenses/mit-license.php/
+ * @author Lea Verou http://lea.verou.me
+ */
+
+var Prism = (function (_self){
+
+// Private helper vars
+var lang = /\blang(?:uage)?-([\w-]+)\b/i;
+var uniqueId = 0;
+
+var _ = {
+	manual: _self.Prism && _self.Prism.manual,
+	disableWorkerMessageHandler: _self.Prism && _self.Prism.disableWorkerMessageHandler,
+	util: {
+		encode: function (tokens) {
+			if (tokens instanceof Token) {
+				return new Token(tokens.type, _.util.encode(tokens.content), tokens.alias);
+			} else if (Array.isArray(tokens)) {
+				return tokens.map(_.util.encode);
+			} else {
+				return tokens.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\u00a0/g, ' ');
+			}
+		},
+
+		type: function (o) {
+			return Object.prototype.toString.call(o).slice(8, -1);
+		},
+
+		objId: function (obj) {
+			if (!obj['__id']) {
+				Object.defineProperty(obj, '__id', { value: ++uniqueId });
+			}
+			return obj['__id'];
+		},
+
+		// Deep clone a language definition (e.g. to extend it)
+		clone: function deepClone(o, visited) {
+			var clone, id, type = _.util.type(o);
+			visited = visited || {};
+
+			switch (type) {
+				case 'Object':
+					id = _.util.objId(o);
+					if (visited[id]) {
+						return visited[id];
+					}
+					clone = {};
+					visited[id] = clone;
+
+					for (var key in o) {
+						if (o.hasOwnProperty(key)) {
+							clone[key] = deepClone(o[key], visited);
+						}
+					}
+
+					return clone;
+
+				case 'Array':
+					id = _.util.objId(o);
+					if (visited[id]) {
+						return visited[id];
+					}
+					clone = [];
+					visited[id] = clone;
+
+					o.forEach(function (v, i) {
+						clone[i] = deepClone(v, visited);
+					});
+
+					return clone;
+
+				default:
+					return o;
+			}
+		}
+	},
+
+	languages: {
+		extend: function (id, redef) {
+			var lang = _.util.clone(_.languages[id]);
+
+			for (var key in redef) {
+				lang[key] = redef[key];
+			}
+
+			return lang;
+		},
+
+		/**
+		 * Insert a token before another token in a language literal
+		 * As this needs to recreate the object (we cannot actually insert before keys in object literals),
+		 * we cannot just provide an object, we need an object and a key.
+		 * @param inside The key (or language id) of the parent
+		 * @param before The key to insert before.
+		 * @param insert Object with the key/value pairs to insert
+		 * @param root The object that contains `inside`. If equal to Prism.languages, it can be omitted.
+		 */
+		insertBefore: function (inside, before, insert, root) {
+			root = root || _.languages;
+			var grammar = root[inside];
+			var ret = {};
+
+			for (var token in grammar) {
+				if (grammar.hasOwnProperty(token)) {
+
+					if (token == before) {
+						for (var newToken in insert) {
+							if (insert.hasOwnProperty(newToken)) {
+								ret[newToken] = insert[newToken];
+							}
+						}
+					}
+
+					// Do not insert token which also occur in insert. See #1525
+					if (!insert.hasOwnProperty(token)) {
+						ret[token] = grammar[token];
+					}
+				}
+			}
+
+			var old = root[inside];
+			root[inside] = ret;
+
+			// Update references in other language definitions
+			_.languages.DFS(_.languages, function(key, value) {
+				if (value === old && key != inside) {
+					this[key] = ret;
+				}
+			});
+
+			return ret;
+		},
+
+		// Traverse a language definition with Depth First Search
+		DFS: function DFS(o, callback, type, visited) {
+			visited = visited || {};
+
+			var objId = _.util.objId;
+
+			for (var i in o) {
+				if (o.hasOwnProperty(i)) {
+					callback.call(o, i, o[i], type || i);
+
+					var property = o[i],
+					    propertyType = _.util.type(property);
+
+					if (propertyType === 'Object' && !visited[objId(property)]) {
+						visited[objId(property)] = true;
+						DFS(property, callback, null, visited);
+					}
+					else if (propertyType === 'Array' && !visited[objId(property)]) {
+						visited[objId(property)] = true;
+						DFS(property, callback, i, visited);
+					}
+				}
+			}
+		}
+	},
+	plugins: {},
+
+	highlightAll: function(async, callback) {
+		_.highlightAllUnder(document, async, callback);
+	},
+
+	highlightAllUnder: function(container, async, callback) {
+		var env = {
+			callback: callback,
+			selector: 'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code'
+		};
+
+		_.hooks.run("before-highlightall", env);
+
+		var elements = env.elements || container.querySelectorAll(env.selector);
+
+		for (var i=0, element; element = elements[i++];) {
+			_.highlightElement(element, async === true, env.callback);
+		}
+	},
+
+	highlightElement: function(element, async, callback) {
+		// Find language
+		var language, grammar, parent = element;
+
+		while (parent && !lang.test(parent.className)) {
+			parent = parent.parentNode;
+		}
+
+		if (parent) {
+			language = (parent.className.match(lang) || [,''])[1].toLowerCase();
+			grammar = _.languages[language];
+		}
+
+		// Set language on the element, if not present
+		element.className = element.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
+
+		if (element.parentNode) {
+			// Set language on the parent, for styling
+			parent = element.parentNode;
+
+			if (/pre/i.test(parent.nodeName)) {
+				parent.className = parent.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
+			}
+		}
+
+		var code = element.textContent;
+
+		var env = {
+			element: element,
+			language: language,
+			grammar: grammar,
+			code: code
+		};
+
+		var insertHighlightedCode = function (highlightedCode) {
+			env.highlightedCode = highlightedCode;
+
+			_.hooks.run('before-insert', env);
+
+			env.element.innerHTML = env.highlightedCode;
+
+			_.hooks.run('after-highlight', env);
+			_.hooks.run('complete', env);
+			callback && callback.call(env.element);
+		}
+
+		_.hooks.run('before-sanity-check', env);
+
+		if (!env.code) {
+			_.hooks.run('complete', env);
+			return;
+		}
+
+		_.hooks.run('before-highlight', env);
+
+		if (!env.grammar) {
+			insertHighlightedCode(_.util.encode(env.code));
+			return;
+		}
+
+		if (async && _self.Worker) {
+			var worker = new Worker(_.filename);
+
+			worker.onmessage = function(evt) {
+				insertHighlightedCode(evt.data);
+			};
+
+			worker.postMessage(JSON.stringify({
+				language: env.language,
+				code: env.code,
+				immediateClose: true
+			}));
+		}
+		else {
+			insertHighlightedCode(_.highlight(env.code, env.grammar, env.language));
+		}
+	},
+
+	highlight: function (text, grammar, language) {
+		var env = {
+			code: text,
+			grammar: grammar,
+			language: language
+		};
+		_.hooks.run('before-tokenize', env);
+		env.tokens = _.tokenize(env.code, env.grammar);
+		_.hooks.run('after-tokenize', env);
+		return Token.stringify(_.util.encode(env.tokens), env.language);
+	},
+
+	matchGrammar: function (text, strarr, grammar, index, startPos, oneshot, target) {
+		for (var token in grammar) {
+			if(!grammar.hasOwnProperty(token) || !grammar[token]) {
+				continue;
+			}
+
+			if (token == target) {
+				return;
+			}
+
+			var patterns = grammar[token];
+			patterns = (_.util.type(patterns) === "Array") ? patterns : [patterns];
+
+			for (var j = 0; j < patterns.length; ++j) {
+				var pattern = patterns[j],
+					inside = pattern.inside,
+					lookbehind = !!pattern.lookbehind,
+					greedy = !!pattern.greedy,
+					lookbehindLength = 0,
+					alias = pattern.alias;
+
+				if (greedy && !pattern.pattern.global) {
+					// Without the global flag, lastIndex won't work
+					var flags = pattern.pattern.toString().match(/[imuy]*$/)[0];
+					pattern.pattern = RegExp(pattern.pattern.source, flags + "g");
+				}
+
+				pattern = pattern.pattern || pattern;
+
+				// Don’t cache length as it changes during the loop
+				for (var i = index, pos = startPos; i < strarr.length; pos += strarr[i].length, ++i) {
+
+					var str = strarr[i];
+
+					if (strarr.length > text.length) {
+						// Something went terribly wrong, ABORT, ABORT!
+						return;
+					}
+
+					if (str instanceof Token) {
+						continue;
+					}
+
+					if (greedy && i != strarr.length - 1) {
+						pattern.lastIndex = pos;
+						var match = pattern.exec(text);
+						if (!match) {
+							break;
+						}
+
+						var from = match.index + (lookbehind ? match[1].length : 0),
+						    to = match.index + match[0].length,
+						    k = i,
+						    p = pos;
+
+						for (var len = strarr.length; k < len && (p < to || (!strarr[k].type && !strarr[k - 1].greedy)); ++k) {
+							p += strarr[k].length;
+							// Move the index i to the element in strarr that is closest to from
+							if (from >= p) {
+								++i;
+								pos = p;
+							}
+						}
+
+						// If strarr[i] is a Token, then the match starts inside another Token, which is invalid
+						if (strarr[i] instanceof Token) {
+							continue;
+						}
+
+						// Number of tokens to delete and replace with the new match
+						delNum = k - i;
+						str = text.slice(pos, p);
+						match.index -= pos;
+					} else {
+						pattern.lastIndex = 0;
+
+						var match = pattern.exec(str),
+							delNum = 1;
+					}
+
+					if (!match) {
+						if (oneshot) {
+							break;
+						}
+
+						continue;
+					}
+
+					if(lookbehind) {
+						lookbehindLength = match[1] ? match[1].length : 0;
+					}
+
+					var from = match.index + lookbehindLength,
+					    match = match[0].slice(lookbehindLength),
+					    to = from + match.length,
+					    before = str.slice(0, from),
+					    after = str.slice(to);
+
+					var args = [i, delNum];
+
+					if (before) {
+						++i;
+						pos += before.length;
+						args.push(before);
+					}
+
+					var wrapped = new Token(token, inside? _.tokenize(match, inside) : match, alias, match, greedy);
+
+					args.push(wrapped);
+
+					if (after) {
+						args.push(after);
+					}
+
+					Array.prototype.splice.apply(strarr, args);
+
+					if (delNum != 1)
+						_.matchGrammar(text, strarr, grammar, i, pos, true, token);
+
+					if (oneshot)
+						break;
+				}
+			}
+		}
+	},
+
+	tokenize: function(text, grammar) {
+		var strarr = [text];
+
+		var rest = grammar.rest;
+
+		if (rest) {
+			for (var token in rest) {
+				grammar[token] = rest[token];
+			}
+
+			delete grammar.rest;
+		}
+
+		_.matchGrammar(text, strarr, grammar, 0, 0, false);
+
+		return strarr;
+	},
+
+	hooks: {
+		all: {},
+
+		add: function (name, callback) {
+			var hooks = _.hooks.all;
+
+			hooks[name] = hooks[name] || [];
+
+			hooks[name].push(callback);
+		},
+
+		run: function (name, env) {
+			var callbacks = _.hooks.all[name];
+
+			if (!callbacks || !callbacks.length) {
+				return;
+			}
+
+			for (var i=0, callback; callback = callbacks[i++];) {
+				callback(env);
+			}
+		}
+	},
+
+	Token: Token
+};
+
+_self.Prism = _;
+
+function Token(type, content, alias, matchedStr, greedy) {
+	this.type = type;
+	this.content = content;
+	this.alias = alias;
+	// Copy of the full string this token was created from
+	this.length = (matchedStr || "").length|0;
+	this.greedy = !!greedy;
+}
+
+Token.stringify = function(o, language) {
+	if (typeof o == 'string') {
+		return o;
+	}
+
+	if (Array.isArray(o)) {
+		return o.map(function(element) {
+			return Token.stringify(element, language);
+		}).join('');
+	}
+
+	var env = {
+		type: o.type,
+		content: Token.stringify(o.content, language),
+		tag: 'span',
+		classes: ['token', o.type],
+		attributes: {},
+		language: language
+	};
+
+	if (o.alias) {
+		var aliases = Array.isArray(o.alias) ? o.alias : [o.alias];
+		Array.prototype.push.apply(env.classes, aliases);
+	}
+
+	_.hooks.run('wrap', env);
+
+	var attributes = Object.keys(env.attributes).map(function(name) {
+		return name + '="' + (env.attributes[name] || '').replace(/"/g, '&quot;') + '"';
+	}).join(' ');
+
+	return '<' + env.tag + ' class="' + env.classes.join(' ') + '"' + (attributes ? ' ' + attributes : '') + '>' + env.content + '</' + env.tag + '>';
+};
+
+if (!_self.document) {
+	if (!_self.addEventListener) {
+		// in Node.js
+		return _;
+	}
+
+	if (!_.disableWorkerMessageHandler) {
+		// In worker
+		_self.addEventListener('message', function (evt) {
+			var message = JSON.parse(evt.data),
+				lang = message.language,
+				code = message.code,
+				immediateClose = message.immediateClose;
+
+			_self.postMessage(_.highlight(code, _.languages[lang], lang));
+			if (immediateClose) {
+				_self.close();
+			}
+		}, false);
+	}
+
+	return _;
+}
+
+//Get current script and highlight
+var script = document.currentScript || [].slice.call(document.getElementsByTagName("script")).pop();
+
+if (script) {
+	_.filename = script.src;
+
+	if (!_.manual && !script.hasAttribute('data-manual')) {
+		if(document.readyState !== "loading") {
+			if (window.requestAnimationFrame) {
+				window.requestAnimationFrame(_.highlightAll);
+			} else {
+				window.setTimeout(_.highlightAll, 16);
+			}
+		}
+		else {
+			document.addEventListener('DOMContentLoaded', _.highlightAll);
+		}
+	}
+}
+
+return _;
+
+})(_self);
+
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = Prism;
+}
+
+// hack for components to work correctly in node.js
+if (typeof global !== 'undefined') {
+	global.Prism = Prism;
+}
+;
+Prism.languages.clike = {
+	'comment': [
+		{
+			pattern: /(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,
+			lookbehind: true
+		},
+		{
+			pattern: /(^|[^\\:])\/\/.*/,
+			lookbehind: true,
+			greedy: true
+		}
+	],
+	'string': {
+		pattern: /(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
+		greedy: true
+	},
+	'class-name': {
+		pattern: /((?:\b(?:class|interface|extends|implements|trait|instanceof|new)\s+)|(?:catch\s+\())[\w.\\]+/i,
+		lookbehind: true,
+		inside: {
+			punctuation: /[.\\]/
+		}
+	},
+	'keyword': /\b(?:if|else|while|do|for|return|in|instanceof|function|new|try|throw|catch|finally|null|break|continue)\b/,
+	'boolean': /\b(?:true|false)\b/,
+	'function': /\w+(?=\()/,
+	'number': /\b0x[\da-f]+\b|(?:\b\d+\.?\d*|\B\.\d+)(?:e[+-]?\d+)?/i,
+	'operator': /--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&?|\|\|?|\?|\*|\/|~|\^|%/,
+	'punctuation': /[{}[\];(),.:]/
+};
+
+/**
+ * Original by Samuel Flores
+ *
+ * Adds the following new token classes:
+ * 		constant, builtin, variable, symbol, regex
+ */
+(function(Prism) {
+	Prism.languages.ruby = Prism.languages.extend('clike', {
+		'comment': [
+			/#.*/,
+			{
+				pattern: /^=begin\s[\s\S]*?^=end/m,
+				greedy: true
+			}
+		],
+		'keyword': /\b(?:alias|and|BEGIN|begin|break|case|class|def|define_method|defined|do|each|else|elsif|END|end|ensure|false|for|if|in|module|new|next|nil|not|or|protected|private|public|raise|redo|require|rescue|retry|return|self|super|then|throw|true|undef|unless|until|when|while|yield)\b/
+	});
+
+	var interpolation = {
+		pattern: /#\{[^}]+\}/,
+		inside: {
+			'delimiter': {
+				pattern: /^#\{|\}$/,
+				alias: 'tag'
+			},
+			rest: Prism.languages.ruby
+		}
+	};
+
+	delete Prism.languages.ruby.function;
+
+	Prism.languages.insertBefore('ruby', 'keyword', {
+		'regex': [
+			{
+				pattern: /%r([^a-zA-Z0-9\s{(\[<])(?:(?!\1)[^\\]|\\[\s\S])*\1[gim]{0,3}/,
+				greedy: true,
+				inside: {
+					'interpolation': interpolation
+				}
+			},
+			{
+				pattern: /%r\((?:[^()\\]|\\[\s\S])*\)[gim]{0,3}/,
+				greedy: true,
+				inside: {
+					'interpolation': interpolation
+				}
+			},
+			{
+				// Here we need to specifically allow interpolation
+				pattern: /%r\{(?:[^#{}\\]|#(?:\{[^}]+\})?|\\[\s\S])*\}[gim]{0,3}/,
+				greedy: true,
+				inside: {
+					'interpolation': interpolation
+				}
+			},
+			{
+				pattern: /%r\[(?:[^\[\]\\]|\\[\s\S])*\][gim]{0,3}/,
+				greedy: true,
+				inside: {
+					'interpolation': interpolation
+				}
+			},
+			{
+				pattern: /%r<(?:[^<>\\]|\\[\s\S])*>[gim]{0,3}/,
+				greedy: true,
+				inside: {
+					'interpolation': interpolation
+				}
+			},
+			{
+				pattern: /(^|[^/])\/(?!\/)(\[.+?]|\\.|[^/\\\r\n])+\/[gim]{0,3}(?=\s*($|[\r\n,.;})]))/,
+				lookbehind: true,
+				greedy: true
+			}
+		],
+		'variable': /[@$]+[a-zA-Z_]\w*(?:[?!]|\b)/,
+		'symbol': {
+			pattern: /(^|[^:]):[a-zA-Z_]\w*(?:[?!]|\b)/,
+			lookbehind: true
+		},
+		'method-definition': {
+			pattern: /(\bdef\s+)[\w.]+/,
+			lookbehind: true,
+			inside: {
+				'function': /\w+$/,
+				rest: Prism.languages.ruby
+			}
+		}
+	});
+
+	Prism.languages.insertBefore('ruby', 'number', {
+		'builtin': /\b(?:Array|Bignum|Binding|Class|Continuation|Dir|Exception|FalseClass|File|Stat|Fixnum|Float|Hash|Integer|IO|MatchData|Method|Module|NilClass|Numeric|Object|Proc|Range|Regexp|String|Struct|TMS|Symbol|ThreadGroup|Thread|Time|TrueClass)\b/,
+		'constant': /\b[A-Z]\w*(?:[?!]|\b)/
+	});
+
+	Prism.languages.ruby.string = [
+		{
+			pattern: /%[qQiIwWxs]?([^a-zA-Z0-9\s{(\[<])(?:(?!\1)[^\\]|\\[\s\S])*\1/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		},
+		{
+			pattern: /%[qQiIwWxs]?\((?:[^()\\]|\\[\s\S])*\)/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		},
+		{
+			// Here we need to specifically allow interpolation
+			pattern: /%[qQiIwWxs]?\{(?:[^#{}\\]|#(?:\{[^}]+\})?|\\[\s\S])*\}/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		},
+		{
+			pattern: /%[qQiIwWxs]?\[(?:[^\[\]\\]|\\[\s\S])*\]/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		},
+		{
+			pattern: /%[qQiIwWxs]?<(?:[^<>\\]|\\[\s\S])*>/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		},
+		{
+			pattern: /("|')(?:#\{[^}]+\}|\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
+			greedy: true,
+			inside: {
+				'interpolation': interpolation
+			}
+		}
+	];
+
+	Prism.languages.rb = Prism.languages.ruby;
+}(Prism));
+

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -25,3 +25,4 @@
 @import "autocomplete/autocomplete";
 @import "search/search";
 @import "actions/all";
+@import "code/fdl";

--- a/app/assets/stylesheets/components/code/fdl.scss
+++ b/app/assets/stylesheets/components/code/fdl.scss
@@ -1,7 +1,11 @@
 @import 'prism';
 
-.simple_form.new_framework .govuk-error-summary, .simple_form.edit_framework .govuk-error-summary {
-  display: none;
+.simple_form.new_framework, .simple_form.edit_framework {
+  .govuk-error-summary__list a[href='#framework_definition_source'] {
+    white-space: pre-wrap;
+    text-decoration: none;
+    font-weight: normal;
+  }
 }
 
 .framework_definition_source .govuk-error-message {

--- a/app/assets/stylesheets/components/code/fdl.scss
+++ b/app/assets/stylesheets/components/code/fdl.scss
@@ -1,3 +1,11 @@
+.simple_form.new_framework .govuk-error-summary, .simple_form.edit_framework .govuk-error-summary {
+  display: none;
+}
+
+.framework_definition_source .govuk-error-message {
+  display: none;
+}
+
 textarea.govuk-textarea--fdl-source {
   min-height: 30em;
   min-width: 100%;

--- a/app/assets/stylesheets/components/code/fdl.scss
+++ b/app/assets/stylesheets/components/code/fdl.scss
@@ -1,0 +1,5 @@
+textarea.govuk-textarea--fdl-source {
+  min-height: 30em;
+  min-width: 100%;
+  font-family: "Fira Code", "Menlo", "Consolas", monospace;
+}

--- a/app/assets/stylesheets/components/code/fdl.scss
+++ b/app/assets/stylesheets/components/code/fdl.scss
@@ -1,3 +1,5 @@
+@import 'prism';
+
 .simple_form.new_framework .govuk-error-summary, .simple_form.edit_framework .govuk-error-summary {
   display: none;
 }
@@ -6,8 +8,7 @@
   display: none;
 }
 
-textarea.govuk-textarea--fdl-source {
-  min-height: 30em;
+.govuk-textarea--fdl-source {
+  min-height: 40em;
   min-width: 100%;
-  font-family: "Fira Code", "Menlo", "Consolas", monospace;
 }

--- a/app/assets/stylesheets/components/code/prism.css
+++ b/app/assets/stylesheets/components/code/prism.css
@@ -1,0 +1,142 @@
+/* PrismJS 1.16.0
+https://prismjs.com/download.html#themes=prism&languages=clike+ruby */
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+code[class*="language-"],
+textarea[class*="language-"], pre[class*="language-"] {
+	color: black;
+	background: none;
+	text-shadow: 0 1px white;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+textarea[class*="language-"], pre[class*="language-"]::-moz-selection, textarea[class*="language-"], pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+textarea[class*="language-"], pre[class*="language-"]::selection, textarea[class*="language-"], pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+@media print {
+	code[class*="language-"],
+	textarea[class*="language-"], pre[class*="language-"] {
+		text-shadow: none;
+	}
+}
+
+/* Code blocks */
+textarea[class*="language-"], pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+}
+
+:not(pre) > code[class*="language-"],
+textarea[class*="language-"], pre[class*="language-"] {
+	background: #f5f2f0;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: slategray;
+}
+
+.token.punctuation {
+	color: #999;
+}
+
+.namespace {
+	opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: #905;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: #690;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+	color: #9a6e3a;
+	background: hsla(0, 0%, 100%, .5);
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+	color: #07a;
+}
+
+.token.function,
+.token.class-name {
+	color: #DD4A68;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+	color: #e90;
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}
+

--- a/app/assets/stylesheets/components/in_service_alerts/_in_service_alerts.scss
+++ b/app/assets/stylesheets/components/in_service_alerts/_in_service_alerts.scss
@@ -19,6 +19,14 @@
   @include bgalert-color-borderleft-color(govuk-colour("failure"), 55%);
 }
 
+.ccs-in-service-alert--fdl-failure {
+  @extend .ccs-in-service-alert--failure;
+  .govuk-heading-s {
+    white-space: pre-wrap;
+    font-weight: normal;
+  }
+}
+
 .ccs-in-service-alert--success {
   @include bgalert-color-borderleft-color(govuk-colour("success"), 55%);
 }

--- a/app/assets/stylesheets/components/in_service_alerts/_in_service_alerts.scss
+++ b/app/assets/stylesheets/components/in_service_alerts/_in_service_alerts.scss
@@ -19,14 +19,6 @@
   @include bgalert-color-borderleft-color(govuk-colour("failure"), 55%);
 }
 
-.ccs-in-service-alert--fdl-failure {
-  @extend .ccs-in-service-alert--failure;
-  .govuk-heading-s {
-    white-space: pre-wrap;
-    font-weight: normal;
-  }
-}
-
 .ccs-in-service-alert--success {
   @include bgalert-color-borderleft-color(govuk-colour("success"), 55%);
 }

--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -17,7 +17,7 @@ class Admin::FrameworksController < AdminController
     framework_def = begin
                       Framework::Definition::Language.generate_framework_definition(definition_source, logger)
                     rescue Parslet::ParseFailed => e
-                      flash[:error] = e.parse_failure_cause.ascii_tree
+                      flash[:fdl_failure] = e.parse_failure_cause.ascii_tree
                       @framework = Framework.new(definition_source: definition_source)
                       render action: :new
                       return

--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -2,4 +2,34 @@ class Admin::FrameworksController < AdminController
   def index
     @frameworks = Framework.all
   end
+
+  def new
+    @framework = Framework.new
+  end
+
+  def show
+    @framework = Framework.find(params[:id])
+  end
+
+  def create
+    definition_source = framework_params[:definition_source]
+    framework_def = Framework::Definition::Language.generate_framework_definition(definition_source)
+
+    @framework =  Framework.new(
+      name:              framework_def.name,
+      short_name:        framework_def.framework_short_name,
+      definition_source: definition_source
+    )
+
+    if @framework.save
+      flash[:success] = 'Definition saved successfully'
+      redirect_to admin_framework_path(@framework)
+    end
+  end
+
+  private
+
+  def framework_params
+    params.require(:framework).permit(:definition_source)
+  end
 end

--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -36,24 +36,11 @@ class Admin::FrameworksController < AdminController
   def update
     @framework = Framework.find(params[:id])
 
-    definition_source = framework_params[:definition_source]
-
-    framework_def = begin
-      Framework::Definition::Language.generate_framework_definition(@framework.definition_source, logger)
-    rescue Parslet::ParseFailed => e
-      flash[:fdl_failure] = e.parse_failure_cause.ascii_tree
-      render action: :edit
-      return
-    end
-
-    if @framework.update(
-      name:              framework_def.name,
-      short_name:        framework_def.framework_short_name,
-      definition_source: definition_source
-    )
+    if @framework.update_from_fdl(framework_params[:definition_source])
       flash[:success] = 'Framework saved successfully.'
       redirect_to admin_framework_path(@framework)
     else
+      flash[:fdl_failure] = @framework.errors[:definition_source].first
       render action: :edit
     end
   end

--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -15,7 +15,6 @@ class Admin::FrameworksController < AdminController
     @framework = Framework.new_from_fdl(framework_params[:definition_source])
 
     if @framework.errors[:definition_source].any?
-      flash[:fdl_failure] = @framework.errors[:definition_source].first
       render action: :new
       return
     end
@@ -40,7 +39,6 @@ class Admin::FrameworksController < AdminController
       flash[:success] = 'Framework saved successfully.'
       redirect_to admin_framework_path(@framework)
     else
-      flash[:fdl_failure] = @framework.errors[:definition_source].first
       render action: :edit
     end
   end

--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -38,6 +38,35 @@ class Admin::FrameworksController < AdminController
     end
   end
 
+  def edit
+    @framework = Framework.find(params[:id])
+  end
+
+  def update
+    @framework = Framework.find(params[:id])
+
+    definition_source = framework_params[:definition_source]
+
+    framework_def = begin
+      Framework::Definition::Language.generate_framework_definition(@framework.definition_source, logger)
+    rescue Parslet::ParseFailed => e
+      flash[:fdl_failure] = e.parse_failure_cause.ascii_tree
+      render action: :edit
+      return
+    end
+
+    if @framework.update(
+      name:              framework_def.name,
+      short_name:        framework_def.framework_short_name,
+      definition_source: definition_source
+    )
+      flash[:success] = 'Framework saved successfully.'
+      redirect_to admin_framework_path(@framework)
+    else
+      render action: :edit
+    end
+  end
+
   private
 
   def framework_params

--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -1,0 +1,5 @@
+class Admin::FrameworksController < AdminController
+  def index
+    @frameworks = Framework.all
+  end
+end

--- a/app/controllers/v1/frameworks_controller.rb
+++ b/app/controllers/v1/frameworks_controller.rb
@@ -2,7 +2,7 @@ class V1::FrameworksController < APIController
   skip_before_action :authenticate, :reject_without_user!
 
   def index
-    frameworks = Framework.all.sort_by(&:short_name)
+    frameworks = Framework.published.order(:short_name)
 
     render jsonapi: frameworks
   end

--- a/app/controllers/v1/frameworks_controller.rb
+++ b/app/controllers/v1/frameworks_controller.rb
@@ -1,0 +1,9 @@
+class V1::FrameworksController < APIController
+  skip_before_action :authenticate, :reject_without_user!
+
+  def index
+    frameworks = Framework.all.sort_by(&:short_name)
+
+    render jsonapi: frameworks
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -14,9 +14,14 @@ module AdminHelper
     {
       success: 'ccs-in-service-alert--success',
       failure: 'ccs-in-service-alert--failure',
+      fdl_failure: 'ccs-in-service-alert--fdl-failure',
       notice: 'ccs-in-service-alert--notice',
       warning: 'ccs-in-service-alert--warning',
       alert: 'ccs-in-service-alert--failure'
     }[type.to_sym]
+  end
+
+  def flash_header_for(key)
+    'Definition error' if key.to_s == 'fdl_failure'
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -14,14 +14,9 @@ module AdminHelper
     {
       success: 'ccs-in-service-alert--success',
       failure: 'ccs-in-service-alert--failure',
-      fdl_failure: 'ccs-in-service-alert--fdl-failure',
       notice: 'ccs-in-service-alert--notice',
       warning: 'ccs-in-service-alert--warning',
       alert: 'ccs-in-service-alert--failure'
     }[type.to_sym]
-  end
-
-  def flash_header_for(key)
-    'Definition error' if key.to_s == 'fdl_failure'
   end
 end

--- a/app/helpers/frameworks_helper.rb
+++ b/app/helpers/frameworks_helper.rb
@@ -1,0 +1,5 @@
+module FrameworksHelper
+  def published_status(framework)
+    framework.published ? 'Published' : 'New'
+  end
+end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -11,7 +11,22 @@ class Framework < ApplicationRecord
     message: 'must start with “40” and have four additional numbers, for example: “401234”'
   }
 
+  validates :definition_source, fdl: true, allow_nil: true
+
   def definition
     @definition ||= Definition[short_name]
+  end
+
+  def self.new_from_fdl(definition_source)
+    Framework.new(definition_source: definition_source).tap do |framework|
+      definition = Framework::Definition::Language.generate_framework_definition(definition_source, logger)
+      framework.name       = definition.framework_name
+      framework.short_name = definition.framework_short_name
+    rescue Parslet::ParseFailed => e
+      framework.errors.add(
+        :definition_source, :fdl,
+        value: definition_source, message: e.parse_failure_cause.ascii_tree
+      )
+    end
   end
 end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -13,6 +13,8 @@ class Framework < ApplicationRecord
 
   validates :definition_source, fdl: true, allow_nil: true
 
+  scope :published, -> { where(published: true) }
+
   def definition
     @definition ||= Definition[short_name]
   end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -29,4 +29,18 @@ class Framework < ApplicationRecord
       )
     end
   end
+
+  def update_from_fdl(definition_source)
+    definition = begin
+                   Framework::Definition::Language.generate_framework_definition(definition_source, logger)
+                 rescue Parslet::ParseFailed
+                   return update(definition_source: definition_source)
+                 end
+
+    update(
+      definition_source: definition_source,
+      name: definition.framework_name,
+      short_name: definition.framework_short_name
+    )
+  end
 end

--- a/app/models/framework/definition/language.rb
+++ b/app/models/framework/definition/language.rb
@@ -27,8 +27,6 @@ class Framework
           generate_framework_definition(File.read(fdl_filename))
         end
 
-        private
-
         def parse(source, logger)
           Framework::Definition::Parser.new.parse(source, reporter: Parslet::ErrorReporter::Deepest.new)
         rescue Parslet::ParseFailed => e

--- a/app/models/framework/definition/language.rb
+++ b/app/models/framework/definition/language.rb
@@ -13,7 +13,7 @@ class Framework
           cst = parse(source, logger)
           ast = Framework::Definition::AST::Creator.new.apply(cst)
 
-          Transpiler.new(ast).transpile
+          Framework::Definition::Transpiler.new(ast).transpile
         end
 
         def [](framework_short_name)

--- a/app/validators/fdl_validator.rb
+++ b/app/validators/fdl_validator.rb
@@ -1,0 +1,7 @@
+class FdlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    Framework::Definition::Language.parse(value, Logger.new('/dev/null'))
+  rescue Parslet::ParseFailed => e
+    record.errors.add(attribute, :fdl, value: value, message: e.parse_failure_cause.ascii_tree)
+  end
+end

--- a/app/views/admin/frameworks/edit.html.haml
+++ b/app/views/admin/frameworks/edit.html.haml
@@ -7,10 +7,10 @@
     = simple_form_for [:admin, @framework] do |form|
       %fieldset.govuk-fieldset
         %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
-          %h1.govuk-fieldset__heading
+          %h2.govuk-fieldset__heading
             Edit framework definition
 
         = render partial: 'shared/error_summary', locals: { entity: @framework } if @framework.errors.present?
 
-        = form.input :definition_source, input_html: { class: 'govuk-textarea govuk-textarea--fdl-source', rows: '5' }
+        = form.input :definition_source, input_html: { class: 'govuk-textarea govuk-textarea--fdl-source language-ruby', rows: '5' }
         = form.button :submit, value: 'Save definition'

--- a/app/views/admin/frameworks/edit.html.haml
+++ b/app/views/admin/frameworks/edit.html.haml
@@ -3,7 +3,7 @@
     %h1.govuk-heading-xl= "#{@framework.short_name} #{@framework.name}"
 
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
+  .govuk-grid-column-full
     = simple_form_for [:admin, @framework] do |form|
       %fieldset.govuk-fieldset
         %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
@@ -12,5 +12,5 @@
 
         = render partial: 'shared/error_summary', locals: { entity: @framework } if @framework.errors.present?
 
-        = form.input :definition_source, input_html: { class: 'govuk-textarea', rows: '5' }
+        = form.input :definition_source, input_html: { class: 'govuk-textarea govuk-textarea--fdl-source', rows: '5' }
         = form.button :submit, value: 'Save definition'

--- a/app/views/admin/frameworks/edit.html.haml
+++ b/app/views/admin/frameworks/edit.html.haml
@@ -1,0 +1,16 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl= "#{@framework.short_name} #{@framework.name}"
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = simple_form_for [:admin, @framework] do |form|
+      %fieldset.govuk-fieldset
+        %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
+          %h1.govuk-fieldset__heading
+            Edit framework definition
+
+        = render partial: 'shared/error_summary', locals: { entity: @framework } if @framework.errors.present?
+
+        = form.input :definition_source, input_html: { class: 'govuk-textarea', rows: '5' }
+        = form.button :submit, value: 'Save definition'

--- a/app/views/admin/frameworks/index.html.haml
+++ b/app/views/admin/frameworks/index.html.haml
@@ -22,7 +22,7 @@
           - @frameworks.each do |framework|
             %tr.govuk-table__row
               %td.govuk-table__cell= link_to framework.name, admin_framework_path(framework.id)
-              %td.govuk-table__cell Published
+              %td.govuk-table__cell= published_status(framework)
 
     - else
       %p

--- a/app/views/admin/frameworks/index.html.haml
+++ b/app/views/admin/frameworks/index.html.haml
@@ -1,0 +1,23 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl
+      Frameworks
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    - if @frameworks.present?
+      %table.govuk-table{:class => 'govuk-!-margin-top-7'}
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header Name
+            %th.govuk-table__header Status
+        %tbody.govuk-table__body
+          - @frameworks.each do |framework|
+            %tr.govuk-table__row
+              %td.govuk-table__cell= link_to framework.name, '#'
+              %td.govuk-table__cell Published
+
+    - else
+      %p
+        No frameworks.
+

--- a/app/views/admin/frameworks/index.html.haml
+++ b/app/views/admin/frameworks/index.html.haml
@@ -21,7 +21,7 @@
         %tbody.govuk-table__body
           - @frameworks.each do |framework|
             %tr.govuk-table__row
-              %td.govuk-table__cell= link_to framework.name, '#'
+              %td.govuk-table__cell= link_to framework.name, admin_framework_path(framework.id)
               %td.govuk-table__cell Published
 
     - else

--- a/app/views/admin/frameworks/index.html.haml
+++ b/app/views/admin/frameworks/index.html.haml
@@ -3,6 +3,13 @@
     %h1.govuk-heading-xl
       Frameworks
 
+  .govuk-grid-column-one-third
+    %nav.govuk-page-actions{"aria-labelledby" => "page-actions-title"}
+      %h2#page-actions-title.govuk-heading-s{"aria-label" => "Page actions"} Actions
+      %ul.govuk-page-actions--actions
+        %li.govuk-page-actions--action
+          = link_to 'New Framework', new_admin_framework_path
+
 .govuk-grid-row
   .govuk-grid-column-full
     - if @frameworks.present?

--- a/app/views/admin/frameworks/new.html.haml
+++ b/app/views/admin/frameworks/new.html.haml
@@ -7,5 +7,5 @@
   %fieldset.govuk-fieldset
     = render partial: 'shared/error_summary', locals: { entity: @framework } if @framework.errors.present?
 
-    = form.input :definition_source, input_html: { class: 'govuk-textarea--fdl-source', rows: '5' }
+    = form.input :definition_source, input_html: { class: 'govuk-textarea--fdl-source language-ruby', rows: '5' }
     = form.button :submit, value: 'Save definition'

--- a/app/views/admin/frameworks/new.html.haml
+++ b/app/views/admin/frameworks/new.html.haml
@@ -1,0 +1,11 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      New framework
+
+= simple_form_for [:admin, @framework] do |form|
+  %fieldset.govuk-fieldset
+    = render partial: 'shared/error_summary', locals: { entity: @framework } if @framework.errors.present?
+
+    = form.input :definition_source, input_html: { class: 'govuk-textarea--fdl-source', rows: '5' }
+    = form.button :submit, value: 'Save definition'

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -1,0 +1,15 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl= "#{@framework.short_name} #{@framework.name}"
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = simple_form_for [:admin, @framework] do |form|
+      %fieldset.govuk-fieldset
+        %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
+          %h1.govuk-fieldset__heading
+            Definition
+
+        = render partial: 'shared/error_summary', locals: { entity: @framework } if @framework.errors.present?
+
+        = form.input :definition_source, input_html: { class: 'govuk-textarea', rows: '5' }

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -2,6 +2,13 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= "#{@framework.short_name} #{@framework.name}"
 
+  .govuk-grid-column-one-third
+    %nav.govuk-page-actions{"aria-labelledby" => "page-actions-title"}
+      %h2#page-actions-title.govuk-heading-s{"aria-label" => "Page actions"} Actions
+      %ul.govuk-page-actions--actions
+        %li.govuk-page-actions--action
+          = link_to 'Edit definition', edit_admin_framework_path(@framework.id)
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = simple_form_for [:admin, @framework] do |form|
@@ -12,4 +19,4 @@
 
         = render partial: 'shared/error_summary', locals: { entity: @framework } if @framework.errors.present?
 
-        = form.input :definition_source, input_html: { class: 'govuk-textarea', rows: '5' }
+        = form.input :definition_source, input_html: { class: 'govuk-textarea', rows: '5' }, disabled: true

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -10,7 +10,7 @@
           = link_to 'Edit definition', edit_admin_framework_path(@framework.id)
 
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
+  .govuk-grid-column-full
     = simple_form_for [:admin, @framework] do |form|
       %fieldset.govuk-fieldset
         %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
@@ -19,4 +19,4 @@
 
         = render partial: 'shared/error_summary', locals: { entity: @framework } if @framework.errors.present?
 
-        = form.input :definition_source, input_html: { class: 'govuk-textarea', rows: '5' }, disabled: true
+        = form.input :definition_source, input_html: { class: 'govuk-textarea govuk-textarea--fdl-source', rows: '5' }, disabled: true

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -11,12 +11,10 @@
 
 .govuk-grid-row
   .govuk-grid-column-full
-    = simple_form_for [:admin, @framework] do |form|
-      %fieldset.govuk-fieldset
-        %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
-          %h1.govuk-fieldset__heading
-            Definition
+    %fieldset.govuk-fieldset
+      %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
+        %h2.govuk-fieldset__heading
+          Definition
 
-        = render partial: 'shared/error_summary', locals: { entity: @framework } if @framework.errors.present?
-
-        = form.input :definition_source, input_html: { class: 'govuk-textarea govuk-textarea--fdl-source', rows: '5' }, disabled: true
+      %pre
+        %code.language-ruby= @framework.definition_source

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -37,7 +37,7 @@
       %main{ role: 'main', id: 'main-content', class: 'govuk-main-wrapper'}
 
         - flash.each do |key, value|
-          = render partial: 'shared/alert', locals: { type:key, message: value }
+          = render partial: 'shared/alert', locals: { type:key, message: value, header: flash_header_for(key) }
 
         = yield
 

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -37,7 +37,7 @@
       %main{ role: 'main', id: 'main-content', class: 'govuk-main-wrapper'}
 
         - flash.each do |key, value|
-          = render partial: 'shared/alert', locals: { type:key, message: value, header: flash_header_for(key) }
+          = render partial: 'shared/alert', locals: { type: key, message: value }
 
         = yield
 

--- a/app/views/shared/_alert.html.haml
+++ b/app/views/shared/_alert.html.haml
@@ -1,5 +1,6 @@
 .grid-row
   .column-full
     .ccs-in-service-alert{:role => "alert", :tabindex =>"-1", :class => flash_types_css_class(type) }
-      %h2.govuk-heading-s
-        = message
+      - if header.present?
+        %h1.govuk-heading-m= header
+      %h2.govuk-heading-s= message

--- a/app/views/shared/_alert.html.haml
+++ b/app/views/shared/_alert.html.haml
@@ -1,6 +1,4 @@
 .grid-row
   .column-full
     .ccs-in-service-alert{:role => "alert", :tabindex =>"-1", :class => flash_types_css_class(type) }
-      - if header.present?
-        %h1.govuk-heading-m= header
       %h2.govuk-heading-s= message

--- a/app/views/shared/_error_summary.html.haml
+++ b/app/views/shared/_error_summary.html.haml
@@ -5,5 +5,4 @@
     %ul.govuk-list.govuk-error-summary__list
       - entity.errors.each do |attribute, error|
         %li
-          %a{href: "##{entity.model_name.element}_#{attribute}"}
-            = error
+          %a{href: "##{entity.model_name.element}_#{attribute}"}= error

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -21,6 +21,8 @@
               %li.govuk-header__navigation-item
                 = link_to 'Suppliers', admin_suppliers_path, {:class=>"govuk-header__link"}
               %li.govuk-header__navigation-item
+                = link_to 'Frameworks', admin_frameworks_path, {:class=>"govuk-header__link"}
+              %li.govuk-header__navigation-item
                 = link_to 'Notify downloads', admin_notify_downloads_path, {:class=>"govuk-header__link"}
               %li.govuk-header__navigation-item
                 = link_to 'Sign out', admin_sign_out_path, {:class=>"govuk-header__link"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,8 @@ Rails.application.routes.draw do
       resources :blobs, only: :create, controller: 'submission_file_blobs'
     end
 
+    resources :frameworks, only: :index
+
     namespace :events do
       post 'user_signed_in'
       post 'user_signed_out'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,7 @@ Rails.application.routes.draw do
       resources :submissions, only: %i[show]
     end
 
-    resources :frameworks, only: %i[index new create show]
+    resources :frameworks, only: %i[index new create show edit update]
 
     resources :notify_downloads, only: %i[index show]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,8 @@ Rails.application.routes.draw do
       resources :submissions, only: %i[show]
     end
 
+    resources :frameworks, only: %i[index]
+
     resources :notify_downloads, only: %i[index show]
 
     get '/sign_in', to: 'sessions#new', as: :sign_in

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,7 @@ Rails.application.routes.draw do
       resources :submissions, only: %i[show]
     end
 
-    resources :frameworks, only: %i[index]
+    resources :frameworks, only: %i[index new create show]
 
     resources :notify_downloads, only: %i[index show]
 

--- a/db/migrate/20190410103248_add_fdl_publishing_columns.rb
+++ b/db/migrate/20190410103248_add_fdl_publishing_columns.rb
@@ -1,0 +1,14 @@
+class AddFdlPublishingColumns < ActiveRecord::Migration[5.2]
+  def change
+    add_column :frameworks, :definition_source, :text
+    add_column :frameworks, :published, :boolean, default: false
+
+    # While published defaults to false for all new frameworks,
+    # we want all existing frameworks to appear published
+    ActiveRecord::Base.connection.execute(
+      <<~PostgreSQL
+        UPDATE frameworks SET published = true
+      PostgreSQL
+    )
+  end
+end

--- a/db/migrate/20190410103248_add_framework_definition_source.rb
+++ b/db/migrate/20190410103248_add_framework_definition_source.rb
@@ -1,0 +1,5 @@
+class AddFrameworkDefinitionSource < ActiveRecord::Migration[5.2]
+  def change
+    add_column :frameworks, :definition_source, :text
+  end
+end

--- a/db/migrate/20190410103248_add_framework_definition_source.rb
+++ b/db/migrate/20190410103248_add_framework_definition_source.rb
@@ -1,5 +1,0 @@
-class AddFrameworkDefinitionSource < ActiveRecord::Migration[5.2]
-  def change
-    add_column :frameworks, :definition_source, :text
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_14_145427) do
+ActiveRecord::Schema.define(version: 2019_04_10_103248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 2019_03_14_145427) do
     t.string "name"
     t.string "short_name", null: false
     t.integer "coda_reference"
+    t.text "definition_source"
     t.index ["short_name"], name: "index_frameworks_on_short_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(version: 2019_04_10_103248) do
     t.string "short_name", null: false
     t.integer "coda_reference"
     t.text "definition_source"
+    t.boolean "published", default: false
     t.index ["short_name"], name: "index_frameworks_on_short_name", unique: true
   end
 

--- a/spec/factories/framework.rb
+++ b/spec/factories/framework.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     sequence(:short_name) { |n| "FM#{n + 1000}" }
     sequence(:name) { |n| "G Cloud #{n}" }
 
+    published true
+
     transient do
       lot_count 0
     end

--- a/spec/features/admin_can_add_a_framework_spec.rb
+++ b/spec/features/admin_can_add_a_framework_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin can add a framework' do
+  before do
+    # Given that I am logged in as an admin
+    sign_in_as_admin
+  end
+
+  context 'we have a valid framework source' do
+    let(:valid_source) do
+      <<~FDL
+        Framework RM6060 {
+          Name 'Fake framework'
+          ManagementCharge 0.5% of 'Supplier Price'
+           InvoiceFields {
+            InvoiceValue from 'Supplier Price'
+          }
+        }
+      FDL
+    end
+
+    scenario 'there are no existing frameworks' do
+      # And there are no existing frameworks
+      # When I visit the frameworks page
+      visit admin_frameworks_path
+      # Then I should see no frameworks
+      expect(page).to have_text('No frameworks')
+
+      # And I click 'new framework'
+      click_link 'New Framework'
+      # Then I should see a "new framework" page
+      expect(page).to have_text('New framework')
+
+      # When I paste a valid framework
+      fill_in 'Definition', with: valid_source
+      # And I click "Save definition"
+      click_button 'Save definition'
+      # Then I should see "framework saved successfully"
+      expect(page).to have_text('Definition saved successfully')
+
+      save_and_open_page
+      # And I should see my FDL
+      expect(page).to have_content('Framework RM6060 {')
+    end
+  end
+end

--- a/spec/features/admin_can_add_a_framework_spec.rb
+++ b/spec/features/admin_can_add_a_framework_spec.rb
@@ -19,28 +19,74 @@ RSpec.feature 'Admin can add a framework' do
       FDL
     end
 
-    scenario 'there are no existing frameworks' do
-      # And there are no existing frameworks
+    context 'there are no existing frameworks' do
+      scenario 'everything is fine' do
+        # And there are no existing frameworks
+        # When I visit the frameworks page
+        visit admin_frameworks_path
+        # Then I should see no frameworks
+        expect(page).to have_text('No frameworks')
+
+        # And I click 'new framework'
+        click_link 'New Framework'
+        # Then I should see a "new framework" page
+        expect(page).to have_text('New framework')
+
+        # When I paste a valid framework
+        fill_in 'Definition', with: valid_source
+        # And I click "Save definition"
+        click_button 'Save definition'
+        # Then I should see "framework saved successfully"
+        expect(page).to have_text('Definition saved successfully')
+
+        # And I should see my FDL
+        expect(page).to have_content('Framework RM6060 {')
+      end
+    end
+
+    context 'there is an existing framework with the same name' do
+      let!(:existing_framework) { create :framework, short_name: 'RM6060', definition_source: valid_source }
+
+      scenario 'it rejects the new framework' do
+        # When I visit the frameworks page
+        visit admin_frameworks_path
+        # And I click 'new framework'
+        click_link 'New Framework'
+
+        # When I paste the valid framework with the same name
+        fill_in 'Definition', with: valid_source
+        # And I click "Save definition"
+        click_button 'Save definition'
+
+        # Then I should see that the framework already exists"
+        expect(page).to have_text('Short name has already been taken')
+        # And I should see my FDL
+        expect(page).to have_content('Framework RM6060 {')
+      end
+    end
+  end
+
+  context 'we have an invalid framework source' do
+    let(:invalid_source) { 'Frameworxk RM6060 {       }' }
+
+    scenario 'the framework source is rejected' do
       # When I visit the frameworks page
       visit admin_frameworks_path
-      # Then I should see no frameworks
-      expect(page).to have_text('No frameworks')
 
       # And I click 'new framework'
       click_link 'New Framework'
       # Then I should see a "new framework" page
       expect(page).to have_text('New framework')
 
-      # When I paste a valid framework
-      fill_in 'Definition', with: valid_source
+      # When I paste an ivalid framework
+      fill_in 'Definition', with: invalid_source
       # And I click "Save definition"
       click_button 'Save definition'
-      # Then I should see "framework saved successfully"
-      expect(page).to have_text('Definition saved successfully')
+      # Then I should see "failed to match sequence"
+      expect(page).to have_text('Failed to match sequence')
 
-      save_and_open_page
       # And I should see my FDL
-      expect(page).to have_content('Framework RM6060 {')
+      expect(page).to have_content('Frameworxk RM6060 {')
     end
   end
 end

--- a/spec/features/admin_can_add_a_framework_spec.rb
+++ b/spec/features/admin_can_add_a_framework_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Admin can add a framework' do
         # Then I should see that the framework already exists"
         expect(page).to have_text('Short name has already been taken')
         # And I should see my FDL
-        expect(page).to have_content('Framework RM6060 {')
+        expect(find_field('Definition source').value).to include('Framework RM6060 {')
       end
     end
   end
@@ -86,7 +86,7 @@ RSpec.feature 'Admin can add a framework' do
       expect(page).to have_text('Failed to match sequence')
 
       # And I should see my FDL
-      expect(page).to have_content('Frameworxk RM6060 {')
+      expect(find_field('Definition source').value).to include('Frameworxk RM6060 {')
     end
   end
 end

--- a/spec/features/admin_can_edit_a_framework_spec.rb
+++ b/spec/features/admin_can_edit_a_framework_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Admin can edit a framework' do
         # When I click on the existing framework
         click_link('Framework to be changed')
         # Then I should see the framework
-        expect(find_field('Definition source', disabled: true).value).to include('Framework RM999 {')
+        expect(page).to have_content('Framework RM999 {')
         # When I click on Edit definition
         click_link('Edit definition')
         # Then I should see an edit page for the framework definition

--- a/spec/features/admin_can_edit_a_framework_spec.rb
+++ b/spec/features/admin_can_edit_a_framework_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin can edit a framework' do
+  let(:existing_source) do
+    <<~FDL
+      Framework RM999 {
+        Name 'Framework to be changed'
+        ManagementCharge 0.5% of 'Supplier Price'
+         InvoiceFields {
+          InvoiceValue from 'Supplier Price'
+        }
+      }
+    FDL
+  end
+
+  before do
+    # Given that I am logged in as an admin
+    sign_in_as_admin
+    # And there is an existing framework
+    create(:framework, short_name: 'RM999', name: 'Framework to be changed', definition_source: existing_source)
+  end
+
+  context 'we have valid framework source' do
+    let(:edited_source) do
+      <<~FDL
+        Framework RM999 {
+          Name 'Vehicle Leasing'
+          ManagementCharge 0.5% of 'Supplier Price'
+           InvoiceFields {
+            InvoiceValue from 'Supplier Price'
+          }
+        }
+      FDL
+    end
+
+    context 'there is an existing framework' do
+      scenario 'everything is fine' do
+        # When I visit the frameworks page
+        visit admin_frameworks_path
+        # Then I should see a list of frameworks
+        expect(page).to have_content('Framework to be changed')
+        # When I click on the existing framework
+        click_link('Framework to be changed')
+        # Then I should see the framework
+        expect(find_field('Definition source', disabled: true).value).to include('Framework RM999 {')
+        # When I click on Edit definition
+        click_link('Edit definition')
+        # Then I should see an edit page for the framework definition
+        expect(page).to have_content('Edit framework definition')
+        # When I change the framework definition
+        fill_in 'Definition source', with: edited_source
+        # And I click "Save definition"
+        click_button('Save definition')
+        # Then I should see "framework saved successfully"
+        expect(page).to have_content('Framework saved successfully')
+        # And I should see the framework
+        expect(page).to have_content('Vehicle Leasing')
+      end
+    end
+  end
+
+  context 'we have invalid framework source' do
+    let(:incorrectly_edited_source) do
+      <<~FDL
+        Framewoxk RM999 {
+          Name 'Vehicle Leasing'
+
+           InvoiceFields {
+            InvoiceValue from 'Supplier Price'
+          }
+        }
+      FDL
+    end
+
+    context 'there is an existing framework' do
+      scenario 'the existing framework is not updated' do
+        # When I visit the frameworks page
+        visit admin_frameworks_path
+        # Then I should see a list of frameworks
+        expect(page).to have_content('Framework to be changed')
+        # When I click on the existing framework
+        click_link('Framework to be changed')
+        # And I click on Edit definition
+        click_link('Edit definition')
+        # When I change the framework definition
+        fill_in 'Definition source', with: incorrectly_edited_source
+        # And I click "Save definition"
+        click_button('Save definition')
+        # Then I should not see "framework saved successfully"
+        expect(page).not_to have_content('Framework saved successfully')
+        # And I should see the error message
+        expect(page).to have_content('Failed to match sequence')
+        # And I should see the unedited original framework
+        expect(page).to have_content('Framework to be changed')
+      end
+    end
+  end
+end

--- a/spec/features/admin_can_list_frameworks_spec.rb
+++ b/spec/features/admin_can_list_frameworks_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.feature 'Admin can list frameworks' do
-
   before do
     # Given that I am logged in as an admin
     sign_in_as_admin
@@ -23,4 +22,3 @@ RSpec.feature 'Admin can list frameworks' do
     expect(page).to have_text('Published', count: 2)
   end
 end
-

--- a/spec/features/admin_can_list_frameworks_spec.rb
+++ b/spec/features/admin_can_list_frameworks_spec.rb
@@ -6,10 +6,12 @@ RSpec.feature 'Admin can list frameworks' do
     sign_in_as_admin
   end
 
-  scenario 'There are some frameworks' do
-    # And there are some frameworks
+  scenario 'There are some published and unpublished frameworks' do
+    # And there are some published frameworks
     FactoryBot.create(:framework, name: 'Laundry Framework 1', short_name: 'RM1234')
     FactoryBot.create(:framework, name: 'Vehicle Purchase Framework 1', short_name: 'RM5678')
+    # And there are some unpublished frameworks
+    FactoryBot.create(:framework, published: false, name: 'Vehicle Purchase Framework 2', short_name: 'RM5679')
 
     # When I click the "frameworks" link from the main admin page
     visit admin_root_path
@@ -19,6 +21,7 @@ RSpec.feature 'Admin can list frameworks' do
     expect(page).to have_text('Laundry Framework 1')
     expect(page).to have_text('Vehicle Purchase Framework 1')
     # And the frameworks' statuses
-    expect(page).to have_text('Published', count: 2)
+    expect(page).to have_selector('td', text: 'Published', count: 2)
+    expect(page).to have_selector('td', text: 'New', count: 1)
   end
 end

--- a/spec/features/admin_can_list_frameworks_spec.rb
+++ b/spec/features/admin_can_list_frameworks_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin can list frameworks' do
+
+  before do
+    # Given that I am logged in as an admin
+    sign_in_as_admin
+  end
+
+  scenario 'There are some frameworks' do
+    # And there are some frameworks
+    FactoryBot.create(:framework, name: 'Laundry Framework 1', short_name: 'RM1234')
+    FactoryBot.create(:framework, name: 'Vehicle Purchase Framework 1', short_name: 'RM5678')
+
+    # When I click the "frameworks" link from the main admin page
+    visit admin_root_path
+    click_link 'Frameworks'
+
+    # Then I should see a list of frameworks
+    expect(page).to have_text('Laundry Framework 1')
+    expect(page).to have_text('Vehicle Purchase Framework 1')
+    # And the frameworks' statuses
+    expect(page).to have_text('Published', count: 2)
+  end
+end
+

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -26,4 +26,50 @@ RSpec.describe Framework do
       end
     end
   end
+
+  describe '.new_from_fdl' do
+    subject(:framework) { Framework.new_from_fdl(definition_source) }
+
+    before { framework.validate }
+
+    context 'with some valid FDL' do
+      let(:definition_source) do
+        <<~FDL
+          Framework RM999 {
+            Name 'Parsed correctly'
+            ManagementCharge 0.5% of 'Supplier Price'
+             InvoiceFields {
+              InvoiceValue from 'Supplier Price'
+            }
+          }
+        FDL
+      end
+
+      it { is_expected.to be_valid }
+      it { is_expected.not_to be_persisted }
+      it 'has a name' do
+        expect(framework.name).to eql('Parsed correctly')
+      end
+    end
+
+    context 'with some invalid FDL' do
+      let(:definition_source) do
+        <<~FDL
+          Framework RM999 {
+            xName 'Parsed incorrectly'
+            ManagementCharge 0.5% of 'Supplier Price'
+             InvoiceFields {
+              InvoiceValue from 'Supplier Price'
+            }
+          }
+        FDL
+      end
+
+      it { is_expected.not_to be_valid }
+      it { is_expected.not_to be_persisted }
+      it 'has the parse error as an error on definition_source' do
+        expect(framework.errors[:definition_source].first).to match('Failed to match sequence')
+      end
+    end
+  end
 end

--- a/spec/requests/v1/frameworks_spec.rb
+++ b/spec/requests/v1/frameworks_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe '/v1' do
+  before do
+    create(:framework)
+    create(:framework)
+  end
+
+  describe 'GET /v1/frameworks' do
+    subject(:data) { json['data'] }
+
+    it 'returns a list of all the frameworks without authentication' do
+      get '/v1/frameworks'
+
+      expect(response).to be_successful
+      expect(data.size).to eq(2)
+      expect(data.first).to have_attributes(:short_name, :name)
+    end
+  end
+end

--- a/spec/requests/v1/frameworks_spec.rb
+++ b/spec/requests/v1/frameworks_spec.rb
@@ -2,14 +2,15 @@ require 'rails_helper'
 
 RSpec.describe '/v1' do
   before do
-    create(:framework)
-    create(:framework)
+    create(:framework, published: true)
+    create(:framework, published: true)
+    create(:framework, published: false)
   end
 
   describe 'GET /v1/frameworks' do
     subject(:data) { json['data'] }
 
-    it 'returns a list of all the frameworks without authentication' do
+    it 'returns a list of all published frameworks without authentication' do
       get '/v1/frameworks'
 
       expect(response).to be_successful

--- a/spec/validators/fdl_validator_spec.rb
+++ b/spec/validators/fdl_validator_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe FdlValidator do
+  let(:test_class) do
+    Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+      extend ActiveModel::Naming
+
+      def self.name
+        'Framework'
+      end
+
+      attribute :fdl, :string
+      validates :fdl, fdl: true
+    end
+  end
+
+  subject(:instance) { test_class.new }
+
+  before do
+    instance.fdl = source
+    instance.validate
+  end
+
+  context 'FDL is valid' do
+    let(:source) do
+      <<~FDL
+        Framework RM6060 {
+          Name 'Fake framework'
+          ManagementCharge 0.5% of 'Supplier Price'
+           InvoiceFields {
+            InvoiceValue from 'Supplier Price'
+          }
+        }
+      FDL
+    end
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'FDL is invalid' do
+    let(:source) { 'Fxramework RM1234 {}' }
+
+    it { is_expected.not_to be_valid }
+    it 'has the ASCII tree of the failure' do
+      expect(instance.errors[:fdl].first).to match(/Failed to match sequence/)
+    end
+  end
+end


### PR DESCRIPTION
# [Adding and editing FDL](https://trello.com/c/V33kbSd8/960-adding-and-editing-fdl)

Add an `admin/frameworks_controller` to handle the features `features/admin_can_add_a_framework_spec.rb` and `features/admin_can_edit_a_framework_spec.rb`. This controller mostly just calls the two new `Framework` methods `Framework.new_from_fdl(definition_source)` and `Framework.update_from_fdl(definition_source)`.

There's now:

- A 'list frameworks' page at `/admin/frameworks` (all frameworks are currently set to an imaginary state of "Published")
- Some CRU (no D) around frameworks in the usual places

## Things not done

- no protection around editing frameworks with agreements (so be very careful)
- no templates
- no lot seeding (although you can add the optional lots)

## Deviation from design

We did have (and there is history for) the FDL errors shown in a `flash[:fdl_failure]` via `views/admin/shared/_alert.html.haml`. This corresponded well to the Figma [design](https://www.figma.com/proto/JbUKCvCtcFteaOT8AfCkCxHn/fdl-tooling?node-id=3%3A3632&scaling=min-zoom&redirected=1).  However, it wasn't consistent with the rest of the app with respect to ActiveRecord model errors. Add an `FdlValidator` for that, but accept that we have to parse the source twice; once for validation and once to extract details for saving to the `frameworks` table.

Also, this will look different (see 'New framework' below) in our implementation, but consistent with the rest of the app.

## New dependencies

* `launchy` – for test-time assistance with Capybara's `save_and_open_page`
* `prism.js` – for syntax highlighting on `frameworks#show`. This uses the `language-ruby` class, which is not entirely ideal but saves a lot of time. If we really can justify the benefit of making our own `language-fdl` theme then we should. But we probably can't.

## Screenshots

### Listing frameworks

![image](https://user-images.githubusercontent.com/194511/56292587-5a659d00-611f-11e9-87ac-9c1de9562f03.png)

### New framework

![image](https://user-images.githubusercontent.com/194511/56292820-c6480580-611f-11e9-8697-6177801260ca.png)


### Showing a definition

![image](https://user-images.githubusercontent.com/194511/56292511-3a35de00-611f-11e9-83bc-860df4b28bce.png)
