### PR TITLE
Load Redis URL to the ENV from VCAP_SERVICES

### DIFF
--- a/lib/vcap_parser.rb
+++ b/lib/vcap_parser.rb
@@ -13,6 +13,10 @@ class VcapParser
       vcap_json.fetch('aws-s3-bucket', [])
                .find { |aws_config| aws_config.fetch('name').match?(/^ingest-bucket-/) }
     )
+
+    load_redis_config(
+      vcap_json.fetch('redis', []).first
+    )
   end
 
   def self.load_ingest_bucket_config(ingest_bucket_config)
@@ -22,5 +26,11 @@ class VcapParser
     ENV['AWS_SECRET_ACCESS_KEY'] = ingest_bucket_config.fetch('credentials').fetch('aws_secret_access_key')
     ENV['AWS_S3_REGION'] = ENV['AWS_REGION'] = ingest_bucket_config.fetch('credentials').fetch('aws_region')
     ENV['AWS_S3_BUCKET'] = ingest_bucket_config.fetch('credentials').fetch('bucket_name')
+  end
+
+  def self.load_redis_config(redis_config)
+    return unless redis_config
+
+    ENV['REDIS_URL'] = redis_config.fetch('credentials').fetch('uri')
   end
 end

--- a/spec/lib/vcap_parser_spec.rb
+++ b/spec/lib/vcap_parser_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe VcapParser do
       end
     end
 
+    it 'loads redis URL to the ENV' do
+      vcap_json = '
+        {
+          "redis": [
+           {
+              "credentials": {
+                "uri": "rediss://x:REDACTED@HOST:6379"
+              }
+            }
+          ]
+        }
+      '
+      ClimateControl.modify VCAP_SERVICES: vcap_json do
+        VcapParser.load_service_environment_variables!
+        expect(ENV['REDIS_URL']).to eq('rediss://x:REDACTED@HOST:6379')
+      end
+    end
+
     it 'does not error if VCAP_SERVICES is not set' do
       ClimateControl.modify VCAP_SERVICES: nil do
         expect { VcapParser.load_service_environment_variables! }.to_not raise_error


### PR DESCRIPTION
To support Redis on GPAAS, we need to extract the URL of the redis instance, and load it to the ENV.