### PR TITLE
Update bundler -> 2.0 / run brakeman externally

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -466,4 +466,4 @@ RUBY VERSION
    ruby 2.5.5p157
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -2,14 +2,7 @@ if Rails.env.development? || Rails.env.test?
   namespace :brakeman do
     desc 'Run Brakeman'
     task :run do
-      require 'brakeman'
-
-      Brakeman.run(
-        app_path: '.',
-        quiet: true,
-        pager: false,
-        print_report: true
-      )
+      system("bundle exec brakeman --quiet --no-pager #{Rails.root}")
     end
   end
 end


### PR DESCRIPTION
We were getting HAML errors; this is down to brakeman not being able
to keep track of every possible dependency and needing to be run in its
own process so as to not load the world (including HAML which is causing
the problem in this instance)

presidentbeef/brakeman#1044