### PR TITLE
Add /v1/frameworks to API

### DIFF
--- a/app/controllers/v1/frameworks_controller.rb
+++ b/app/controllers/v1/frameworks_controller.rb
@@ -1,0 +1,9 @@
+class V1::FrameworksController < APIController
+  skip_before_action :authenticate, :reject_without_user!
+
+  def index
+    frameworks = Framework.all.sort_by(&:short_name)
+
+    render jsonapi: frameworks
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,8 @@ Rails.application.routes.draw do
       resources :blobs, only: :create, controller: 'submission_file_blobs'
     end
 
+    resources :frameworks, only: :index
+
     namespace :events do
       post 'user_signed_in'
       post 'user_signed_out'

--- a/spec/requests/v1/frameworks_spec.rb
+++ b/spec/requests/v1/frameworks_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe '/v1' do
+  before do
+    create(:framework)
+    create(:framework)
+  end
+
+  describe 'GET /v1/frameworks' do
+    subject(:data) { json['data'] }
+
+    it 'returns a list of all the frameworks without authentication' do
+      get '/v1/frameworks'
+
+      expect(response).to be_successful
+      expect(data.size).to eq(2)
+      expect(data.first).to have_attributes(:short_name, :name)
+    end
+  end
+end


### PR DESCRIPTION
Add a frameworks index endpoint to the API which lists all frameworks in
jsonAPI format, with the frameworks' `name` and `short_name`

Frameworks are sorted by `:name`

This endpoint does not require authentication

This will be consumed on the public-facing supplier app.