### PR TITLE
Allow FDL to validate blank Framework#name

### DIFF
--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -5,6 +5,7 @@ class Framework < ApplicationRecord
   has_many :agreements, dependent: :destroy
   has_many :suppliers, through: :agreements
 
+  validates :name, presence: true
   validates :short_name, presence: true, uniqueness: true
   validates :coda_reference, allow_nil: true, format: {
     with: /\A40\d{4}\z/,

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -9,8 +9,9 @@ class Framework
         rule(decimal: simple(:d))     { BigDecimal(d) }
         rule(integer: simple(:i))     { Integer(i) }
 
-        # Range simplifier
+        # Empty type simplifiers
         rule(integer: sequence(:nil)) { nil } # .maybe produces { integer: [] } for empty
+        rule(string: sequence(:nil))  { '' }  # Blank strings produce { string: [] }
 
         rule(lookup_reference: simple(:r))                { LookupReference.new(r) }
 

--- a/spec/models/framework/definition/language_spec.rb
+++ b/spec/models/framework/definition/language_spec.rb
@@ -492,6 +492,26 @@ RSpec.describe Framework::Definition::Language do
       end
     end
 
+    context 'Blank strings' do
+      let(:source) do
+        <<~FDL
+          Framework RMTEST {
+            Name ''
+            ManagementCharge 0%
+             InvoiceFields {
+              InvoiceValue from 'Supplier Price'
+            }
+          }
+        FDL
+      end
+
+      describe 'the name' do
+        subject(:name) { definition.framework_name }
+
+        it { is_expected.to be_blank }
+      end
+    end
+
     context 'our FDL isn\'t valid' do
       let(:source) { 'any old rubbish' }
 

--- a/spec/models/framework_lot_spec.rb
+++ b/spec/models/framework_lot_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FrameworkLot do
 
   describe 'validations' do
     subject do
-      framework = Framework.create!(short_name: 'cboard8')
+      framework = FactoryBot.create(:framework, short_name: 'cboard8')
       framework.lots.create!(number: '1a')
     end
 


### PR DESCRIPTION
- Empty strings should be correctly blank, not `{ :string => [] }`
  which is a Parslet "empty" artefact
- Empty framework names should not be allowed