### PR TITLE
Prevent editing of published frameworks

### DIFF
--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -1,4 +1,6 @@
 class Admin::FrameworksController < AdminController
+  before_action :prevent_change_to_published, only: %i[edit update]
+
   def index
     @frameworks = Framework.all
   end
@@ -28,13 +30,9 @@ class Admin::FrameworksController < AdminController
     end
   end
 
-  def edit
-    @framework = Framework.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @framework = Framework.find(params[:id])
-
     if @framework.update_from_fdl(framework_params[:definition_source])
       flash[:success] = 'Framework saved successfully.'
       redirect_to admin_framework_path(@framework)
@@ -44,6 +42,12 @@ class Admin::FrameworksController < AdminController
   end
 
   private
+
+  def prevent_change_to_published
+    @framework = Framework.find(params[:id]).tap do |framework|
+      redirect_to admin_frameworks_path, alert: t('.cannot_change') if framework.published?
+    end
+  end
 
   def framework_params
     params.require(:framework).permit(:definition_source)

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -3,11 +3,12 @@
     %h1.govuk-heading-xl= "#{@framework.short_name} #{@framework.name}"
 
   .govuk-grid-column-one-third
-    %nav.govuk-page-actions{"aria-labelledby" => "page-actions-title"}
-      %h2#page-actions-title.govuk-heading-s{"aria-label" => "Page actions"} Actions
-      %ul.govuk-page-actions--actions
-        %li.govuk-page-actions--action
-          = link_to 'Edit definition', edit_admin_framework_path(@framework.id)
+    - unless @framework.published
+      %nav.govuk-page-actions{"aria-labelledby" => "page-actions-title"}
+        %h2#page-actions-title.govuk-heading-s{"aria-label" => "Page actions"} Actions
+        %ul.govuk-page-actions--actions
+          %li.govuk-page-actions--action
+            = link_to 'Edit definition', edit_admin_framework_path(@framework.id)
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,13 @@
 ---
 en:
+  admin:
+    frameworks:
+      cannot_change: &cannot_change 'This framework has been published and cannot be edited'
+      update:
+        cannot_change: *cannot_change
+      edit:
+        cannot_change: *cannot_change
+
   activerecord:
     attributes:
       user:

--- a/spec/features/admin_can_edit_a_framework_spec.rb
+++ b/spec/features/admin_can_edit_a_framework_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.feature 'Admin can edit a framework' do
+  let(:framework) do
+    create(:framework, published: published, short_name: 'RM999',
+      name: 'Framework to be changed', definition_source: existing_source)
+  end
+
   let(:existing_source) do
     <<~FDL
       Framework RM999 {
@@ -17,8 +22,7 @@ RSpec.feature 'Admin can edit a framework' do
     # Given that I am logged in as an admin
     sign_in_as_admin
     # And there is an existing framework
-    create(:framework, published: published, short_name: 'RM999',
-      name: 'Framework to be changed', definition_source: existing_source)
+    framework
   end
 
   context 'we have valid framework source' do
@@ -75,6 +79,18 @@ RSpec.feature 'Admin can edit a framework' do
         expect(page).to have_content('Framework RM999 {')
         # And I should not see 'Edit definition'
         expect(page).not_to have_content('Edit definition')
+      end
+
+      scenario 'an admin attempts to /edit manually' do
+        # When I try to edit the framework
+        visit edit_admin_framework_path(framework)
+
+        # Then I should be redirected to the list of frameworks
+        expect(page).to have_content('Frameworks')
+        expect(page).to have_content('New Framework')
+
+        # And I should see that I cannot edit the framework
+        expect(page).to have_content('This framework has been published and cannot be edited')
       end
     end
   end

--- a/spec/features/admin_can_edit_a_framework_spec.rb
+++ b/spec/features/admin_can_edit_a_framework_spec.rb
@@ -17,7 +17,8 @@ RSpec.feature 'Admin can edit a framework' do
     # Given that I am logged in as an admin
     sign_in_as_admin
     # And there is an existing framework
-    create(:framework, short_name: 'RM999', name: 'Framework to be changed', definition_source: existing_source)
+    create(:framework, published: published, short_name: 'RM999',
+      name: 'Framework to be changed', definition_source: existing_source)
   end
 
   context 'we have valid framework source' do
@@ -33,7 +34,9 @@ RSpec.feature 'Admin can edit a framework' do
       FDL
     end
 
-    context 'there is an existing framework' do
+    context 'there is an existing unpublished framework' do
+      let(:published) { false }
+
       scenario 'everything is fine' do
         # When I visit the frameworks page
         visit admin_frameworks_path
@@ -57,6 +60,23 @@ RSpec.feature 'Admin can edit a framework' do
         expect(page).to have_content('Vehicle Leasing')
       end
     end
+
+    context 'there is an existing published framework' do
+      let(:published) { true }
+
+      scenario 'no link exists to edit' do
+        # When I visit the frameworks page
+        visit admin_frameworks_path
+        # Then I should see a list of frameworks
+        expect(page).to have_content('Framework to be changed')
+        # When I click on the existing framework
+        click_link('Framework to be changed')
+        # Then I should see the framework
+        expect(page).to have_content('Framework RM999 {')
+        # And I should not see 'Edit definition'
+        expect(page).not_to have_content('Edit definition')
+      end
+    end
   end
 
   context 'we have invalid framework source' do
@@ -72,7 +92,9 @@ RSpec.feature 'Admin can edit a framework' do
       FDL
     end
 
-    context 'there is an existing framework' do
+    context 'there is an existing unpublished framework' do
+      let(:published) { false }
+
       scenario 'the existing framework is not updated' do
         # When I visit the frameworks page
         visit admin_frameworks_path


### PR DESCRIPTION
When updating or saving, disallow any changes to Frameworks that are
#published.

Update older specs to correctly use unpublished frameworks or avoid
creations.