### PR TITLE
Explictly call Rails.logger on Framework#update/create_from_fdl

### DIFF
--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -22,7 +22,7 @@ class Framework < ApplicationRecord
 
   def self.new_from_fdl(definition_source)
     Framework.new(definition_source: definition_source).tap do |framework|
-      definition = Framework::Definition::Language.generate_framework_definition(definition_source, logger)
+      definition = Framework::Definition::Language.generate_framework_definition(definition_source, Rails.logger)
       framework.name       = definition.framework_name
       framework.short_name = definition.framework_short_name
     rescue Parslet::ParseFailed => e
@@ -35,7 +35,7 @@ class Framework < ApplicationRecord
 
   def update_from_fdl(definition_source)
     definition = begin
-                   Framework::Definition::Language.generate_framework_definition(definition_source, logger)
+                   Framework::Definition::Language.generate_framework_definition(definition_source, Rails.logger)
                  rescue Parslet::ParseFailed
                    return update(definition_source: definition_source)
                  end


### PR DESCRIPTION
In development, this `logger` variable resolves correctly; however on staging and above `logger` is nil. 

Explicitly set it to be Rails.logger so that on staging & above, a Framework parsing error will be shown to the user.

Related Rollbar errors: [https://rollbar.com/dxw/ccs-reportmi-api/items/90/](https://rollbar.com/dxw/ccs-reportmi-api/items/90/)
[https://rollbar.com/dxw/ccs-reportmi-api/items/91/](https://rollbar.com/dxw/ccs-reportmi-api/items/91/)