### PR TITLE
Add a Framework::Definition::Generator

### DIFF
--- a/app/models/framework/definition/ast/presenter.rb
+++ b/app/models/framework/definition/ast/presenter.rb
@@ -38,8 +38,7 @@ class Framework
         end
 
         def field_by_name(entry_type, name)
-          field_def = field_defs(entry_type).find { |f| f[:field] == name }
-          raise ArgumentError, "No #{entry_type} field '#{name}' found" unless field_def
+          field_def = field_defs(entry_type).find { |f| f[:field] == name } || return
 
           Field.new(field_def, lookups)
         end

--- a/app/models/framework/definition/generator.rb
+++ b/app/models/framework/definition/generator.rb
@@ -1,0 +1,52 @@
+class Framework
+  module Definition
+    ##
+    # Given FDL source, generate an anonymous class that is a framework's definition.
+    #
+    # +definition+ holds the finished class if generation was successful.
+    # If +definition+ is nil, +error+ holds either:
+    #   - a parse tree, or
+    #   - the first semantic error that the +Transpiler+ encountered.
+    #
+    # There are also +success?+ and +error?+ helper methods which
+    # implicitly attempt to create +definition+.
+    class Generator
+      attr_reader :source, :logger, :error
+
+      def initialize(source, logger = Logger.new(STDERR))
+        @source = source
+        @logger = logger
+      end
+
+      def error?
+        definition.nil?
+      end
+
+      def success?
+        !!definition
+      end
+
+      def definition
+        @definition ||= begin
+                          cst = parse(source, logger) || return
+                          ast = Framework::Definition::AST::Creator.new.apply(cst)
+
+                          Framework::Definition::Transpiler.new(ast).transpile
+                        rescue Transpiler::Error => e
+                          @error = e.message
+                          nil
+                        end
+      end
+
+      private
+
+      def parse(source, logger)
+        Framework::Definition::Parser.new.parse(source, reporter: Parslet::ErrorReporter::Deepest.new)
+      rescue Parslet::ParseFailed => e
+        @error = e.parse_failure_cause.ascii_tree
+        logger.error(@error)
+        false
+      end
+    end
+  end
+end

--- a/app/models/framework/definition/language.rb
+++ b/app/models/framework/definition/language.rb
@@ -2,20 +2,6 @@ class Framework
   module Definition
     class Language
       class << self
-        ##
-        # Generate an anonymous outer class with framework metadata
-        # and either one or two nested +EntryData+ classes with field definitions
-        # and validations for Invoices and Contracts.
-        #
-        # params
-        # +source+ Framework definition language content to parse
-        def generate_framework_definition(source, logger = Logger.new(STDERR))
-          cst = parse(source, logger)
-          ast = Framework::Definition::AST::Creator.new.apply(cst)
-
-          Framework::Definition::Transpiler.new(ast).transpile
-        end
-
         def [](framework_short_name)
           sanitized_short_name = framework_short_name.tr('/.', '_')
 
@@ -24,14 +10,8 @@ class Framework
           raise ArgumentError, "#{framework_short_name}.fdl does not exist in models/framework/definition" \
             unless File.exist?(fdl_filename)
 
-          generate_framework_definition(File.read(fdl_filename))
-        end
-
-        def parse(source, logger)
-          Framework::Definition::Parser.new.parse(source, reporter: Parslet::ErrorReporter::Deepest.new)
-        rescue Parslet::ParseFailed => e
-          logger.error(e.parse_failure_cause.ascii_tree)
-          raise
+          generator = Generator.new(File.read(fdl_filename))
+          generator.definition
         end
       end
     end

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -1,6 +1,8 @@
 class Framework
   module Definition
     class Transpiler
+      class Error < StandardError; end
+
       attr_reader :ast
 
       def initialize(ast)
@@ -36,14 +38,18 @@ class Framework
             ActiveModel::Name.new(self, nil, entry_type_capitalized)
           end
 
-          field_defs = ast.field_defs(entry_type)
-
           _total_value_field = ast.field_by_name(entry_type, "#{entry_type_capitalized}Value")
+          if _total_value_field.nil?
+            raise Transpiler::Error,
+                  "#{entry_type_capitalized}Fields is missing " \
+                  "an #{entry_type_capitalized}Value field"
+          end
+
           total_value_field _total_value_field.sheet_name
 
           lookups ast.lookups
 
-          field_defs.each do |field_def|
+          ast.field_defs(entry_type).each do |field_def|
             field = AST::Field.new(field_def, ast.lookups)
             # Always use a case_insensitive_inclusion validator if
             # there's a lookup with the same name as the field

--- a/app/validators/fdl_validator.rb
+++ b/app/validators/fdl_validator.rb
@@ -1,7 +1,6 @@
 class FdlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    Framework::Definition::Language.parse(value, Logger.new('/dev/null'))
-  rescue Parslet::ParseFailed => e
-    record.errors.add(attribute, :fdl, value: value, message: e.parse_failure_cause.ascii_tree)
+    generator = Framework::Definition::Generator.new(value, Logger.new('/dev/null'))
+    record.errors.add(attribute, :fdl, value: value, message: generator.error) if generator.error?
   end
 end

--- a/spec/features/admin_can_add_a_framework_spec.rb
+++ b/spec/features/admin_can_add_a_framework_spec.rb
@@ -66,6 +66,40 @@ RSpec.feature 'Admin can add a framework' do
     end
   end
 
+  context 'we have a syntactically valid framework source, but it is missing InvoiceValue' do
+    let(:invalid_source) do
+      <<~FDL
+        Framework RM6060 {
+          Name 'Fake framework'
+          ManagementCharge 0.5% of 'Supplier Price'
+           InvoiceFields {
+            String from 'Supplier Price'
+          }
+        }
+      FDL
+    end
+
+    scenario 'the framework source is rejected' do
+      # When I visit the frameworks page
+      visit admin_frameworks_path
+
+      # And I click 'new framework'
+      click_link 'New Framework'
+      # Then I should see a "new framework" page
+      expect(page).to have_text('New framework')
+
+      # When I paste an invalid framework
+      fill_in 'Definition', with: invalid_source
+      # And I click "Save definition"
+      click_button 'Save definition'
+      # Then I should see "InvoiceFields is missing an InvoiceValue field"
+      expect(page).to have_text('InvoiceFields is missing an InvoiceValue field')
+
+      # And I should see my FDL
+      expect(find_field('Definition source').value).to include('Framework RM6060 {')
+    end
+  end
+
   context 'we have an invalid framework source' do
     let(:invalid_source) { 'Frameworxk RM6060 {       }' }
 
@@ -78,7 +112,7 @@ RSpec.feature 'Admin can add a framework' do
       # Then I should see a "new framework" page
       expect(page).to have_text('New framework')
 
-      # When I paste an ivalid framework
+      # When I paste an invalid framework
       fill_in 'Definition', with: invalid_source
       # And I click "Save definition"
       click_button 'Save definition'

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe Framework::Definition::Language do
+RSpec.describe Framework::Definition::Generator do
   describe '.generate_framework_definition' do
-    let(:logger)         { spy('Logger') }
-    subject(:definition) { Framework::Definition::Language.generate_framework_definition(source, logger) }
+    let(:logger)        { spy('Logger') }
+    subject(:generator) { Framework::Definition::Generator.new(source, logger) }
+
+    let!(:definition) { generator.definition }
 
     context 'Laundry framework language features (CM_OSG_05_3565)' do
       let(:source) do
@@ -512,12 +514,44 @@ RSpec.describe Framework::Definition::Language do
       end
     end
 
+    context 'our FDL\'s meaning is invalid' do
+      context 'There is no InvoiceValue for InvoiceFields' do
+        let(:source) do
+          <<~FDL
+            Framework RM1234 {
+              Name 'x'
+              ManagementCharge 0%
+
+              InvoiceFields {
+                String from 'x'
+              }
+            }
+          FDL
+        end
+
+        example { expect(definition).to be_nil }
+        it      { is_expected.not_to be_success }
+        it      { is_expected.to be_error }
+
+        it 'has the error' do
+          expect(generator.error).to eql('InvoiceFields is missing an InvoiceValue field')
+        end
+      end
+    end
+
     context 'our FDL isn\'t valid' do
       let(:source) { 'any old rubbish' }
 
-      it 'logs the error and re-raises' do
-        expect { definition }.to raise_error(Parslet::ParseFailed)
+      example { expect(definition).to be_nil }
+      it { is_expected.to be_error }
+      it { is_expected.not_to be_success }
+
+      it 'logs the error' do
         expect(logger).to have_received(:error).with(/Expected "Framework"/)
+      end
+
+      it 'has the parse failure' do
+        expect(generator.error).to match(/Failed to match sequence/)
       end
     end
   end

--- a/spec/validators/fdl_validator_spec.rb
+++ b/spec/validators/fdl_validator_spec.rb
@@ -40,11 +40,31 @@ RSpec.describe FdlValidator do
   end
 
   context 'FDL is invalid' do
-    let(:source) { 'Fxramework RM1234 {}' }
+    context 'syntactically' do
+      let(:source) { 'Fxramework RM1234 {}' }
 
-    it { is_expected.not_to be_valid }
-    it 'has the ASCII tree of the failure' do
-      expect(instance.errors[:fdl].first).to match(/Failed to match sequence/)
+      it { is_expected.not_to be_valid }
+      it 'has the ASCII tree of the failure' do
+        expect(instance.errors[:fdl].first).to match(/Failed to match sequence/)
+      end
+    end
+    context 'semantically' do
+      let(:source) do
+        <<~FDL
+          Framework RMNOINVOICEVALUE {
+            Name 'x'
+            ManagementCharge 0%
+             InvoiceFields {
+              String from 'Supplier Price'
+            }
+          }
+        FDL
+      end
+
+      it { is_expected.not_to be_valid }
+      it 'has the first semantic failure' do
+        expect(instance.errors[:fdl].first).to eql('InvoiceFields is missing an InvoiceValue field')
+      end
     end
   end
 end


### PR DESCRIPTION
Replaces a lot of `Framework::Definition::Language`. It's main purpose is to track the
last error in class generation. That can either be a parse error – a full
preformatted ASCII tree – or the last semantic error the `Transpiler`
encountered. At present, the only semantic error is the non-occurrence
of an `InvoiceValue` field in `InvoiceFields` or `ContractValue` in
`ContractFields`.

The generator takes some source and optionally a logger. You can ask it
if it was a `#success?` or an `#error?` and in the former case a `#definition`
will be available. In the case of an `#error?` it will be nil.