### PR TITLE
(1040) New ingest can be enabled with an environment variable

### DIFF
--- a/app/controllers/v1/submission_entries_controller.rb
+++ b/app/controllers/v1/submission_entries_controller.rb
@@ -19,7 +19,10 @@ class V1::SubmissionEntriesController < APIController
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def bulk
+    return render plain: 'success', status: :created if ENV['NEW_INGEST'] == 'true'
+
     entries = []
 
     params[:_jsonapi][:data].each do |entry_params|
@@ -39,6 +42,7 @@ class V1::SubmissionEntriesController < APIController
 
     render plain: 'success', status: :created
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/app/controllers/v1/submission_file_blobs_controller.rb
+++ b/app/controllers/v1/submission_file_blobs_controller.rb
@@ -7,6 +7,8 @@ class V1::SubmissionFileBlobsController < APIController
     submission_file = SubmissionFile.find(params[:file_id])
     submission_file.file_blob = ActiveStorage::Blob.new(file_blob_params)
 
+    SubmissionIngestionJob.perform_later(submission_file) if ENV['NEW_INGEST'] == 'true'
+
     render jsonapi: submission_file,
            status: :created,
            fields: { submission_files: %i[submission_id rows filename] }

--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -39,6 +39,8 @@ class V1::SubmissionsController < APIController
   end
 
   def validate
+    return head :no_content if ENV['NEW_INGEST'] == 'true'
+
     submission = Submission.find(params[:id])
     SubmissionValidationJob.perform_later(submission)
 

--- a/app/jobs/submission_ingestion_job.rb
+++ b/app/jobs/submission_ingestion_job.rb
@@ -1,0 +1,6 @@
+class SubmissionIngestionJob < ApplicationJob
+  def perform(submission_file)
+    orchestrator = Ingest::Orchestrator.new(submission_file)
+    orchestrator.perform
+  end
+end

--- a/spec/requests/v1/submission_entries_spec.rb
+++ b/spec/requests/v1/submission_entries_spec.rb
@@ -210,4 +210,17 @@ RSpec.describe '/v1' do
       end
     end
   end
+
+  context 'with new ingest enabled' do
+    describe 'POST multiple entries' do
+      it 'ignores the entries, but responds positively' do
+        ClimateControl.modify NEW_INGEST: 'true' do
+          post "/v1/submissions/#{submission.id}/entries/bulk", params: valid_bulk_params.to_json, headers: json_headers
+
+          expect(response).to have_http_status(:created)
+          expect(submission.entries.count).to eq 0
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/v1/submission_file_blobs_spec.rb
+++ b/spec/requests/v1/submission_file_blobs_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe '/v1' do
       expect(file_attachment.content_type).to eq('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
       expect(file_attachment.byte_size).to eq(234936)
       expect(file_attachment.checksum).to eq('r1gZERPTNkeuHwKyI9qUPQ==')
+
+      expect(SubmissionIngestionJob).not_to have_been_enqueued
+    end
+
+    context 'with new ingest enabled' do
+      it 'enqueues an ingest background job' do
+        ClimateControl.modify NEW_INGEST: 'true' do
+          post(
+            v1_file_blobs_path(submission_file.id),
+            params: params.to_json,
+            headers: json_headers.merge('X-Auth-Id' => user.auth_id)
+          )
+
+          expect(SubmissionIngestionJob).to have_been_enqueued
+        end
+      end
     end
   end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -218,5 +218,16 @@ RSpec.describe '/v1' do
       expect(response).to have_http_status(:no_content)
       expect(SubmissionValidationJob).to have_been_enqueued.with(submission)
     end
+
+    it 'ignores the request, if new ingest is enabled' do
+      ClimateControl.modify NEW_INGEST: 'true' do
+        submission = FactoryBot.create(:submission_with_pending_entries)
+
+        post "/v1/submissions/#{submission.id}/validate", headers: { 'X-Auth-Id' => user.auth_id }
+
+        expect(response).to have_http_status(:no_content)
+        expect(SubmissionValidationJob).to_not have_been_enqueued
+      end
+    end
   end
 end


### PR DESCRIPTION
To allow us to test new ingest, add a `NEW_INGEST` environment variable.
If it's set to `true`:
 - Enqueues a new SubmissionIngestionJob after a file is uploaded
 - Ignores POST requests (from the lambdas) to:
   - /submission/:submission_id/entries/bulk
   - /submission/:submission_id/validate

NB: Once new ingest is live and fully replaces the existing solution, the conditionals will be removed and obsolete endpoints removed.