### PR TITLE
Change Daily Warehouse Export to 22:30 London time

### DIFF
--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -7,6 +7,6 @@ monthly_tasks_generation:
   class: 'MonthlyTasksGenerationJob'
   queue: default
 daily_data_warehouse_export:
-  cron: '0 23 * * *'
+  cron: '30 22 * * * Europe/London'
   class: DataWarehouseExportJob
   queue: default


### PR DESCRIPTION
This was previously happening at 23:00 Server Time (UTC), which during British Summer Time resulted in it happening at midnight London time.

It has been requested that this happens at 22:30 London Time instead.