### PR TITLE
Restore management charge calculation

### DIFF
--- a/app/models/ingest/loader.rb
+++ b/app/models/ingest/loader.rb
@@ -29,12 +29,16 @@ module Ingest
     def load_invoices
       return if @converter.invoices.row_count.zero?
 
+      Rails.logger.info "Loading #{@converter.invoices.row_count} invoice rows"
+
       sheet_definition = @definition.for_entry_type('invoice')
       load_data_from(@converter.invoices, sheet_definition)
     end
 
     def load_orders
       return if @converter.orders.row_count.zero?
+
+      Rails.logger.info "Loading #{@converter.orders.row_count} order rows"
 
       sheet_definition = @definition.for_entry_type('order')
       load_data_from(@converter.orders, sheet_definition)

--- a/app/models/ingest/orchestrator.rb
+++ b/app/models/ingest/orchestrator.rb
@@ -44,8 +44,10 @@ module Ingest
 
     def calculate_management_charge_if_valid
       if @submission.entries.errored.none?
+        Rails.logger.info 'All rows valid, calculating management charge'
         SubmissionManagementChargeCalculationJob.perform_later(@submission)
       else
+        Rails.logger.info 'Some rows had validation errors'
         @submission.ready_for_review!
       end
     end

--- a/app/models/ingest/orchestrator.rb
+++ b/app/models/ingest/orchestrator.rb
@@ -28,7 +28,7 @@ module Ingest
         loader = Ingest::Loader.new(converter, @submission_file)
         loader.perform
 
-        @submission.ready_for_review!
+        calculate_management_charge_if_valid
       end
     end
 
@@ -40,6 +40,14 @@ module Ingest
         @framework.short_name,
         'ingest'
       ]
+    end
+
+    def calculate_management_charge_if_valid
+      if @submission.entries.errored.none?
+        SubmissionManagementChargeCalculationJob.perform_later(@submission)
+      else
+        @submission.ready_for_review!
+      end
     end
   end
 end


### PR DESCRIPTION
The management charge calculation was previously triggered at the end of SubmissionValidationJob. As this is no longer running (new ingest validates as it goes), this was being skipped. This restores the functionality (enqueuing SubmissionChargeCalculationJob for valid submissions)