### PR TITLE
Independently set Sidekiq's concurrency

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,1 +1,1 @@
-concurrency: <%= ENV['DATABASE_POOL_SIZE'] %>
+concurrency: <%= ENV['SIDEKIQ_CONCURRENCY'] || ENV['DATABASE_POOL_SIZE'] %>

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -25,6 +25,8 @@ section of the Auth0 dashboard. The application ID for local development is
 locally!
 - SIDEKIQ_USERNAME/SIDEKIQ_PASSWORD – Credentials to protect access to the
 Sidekiq administrative interface
+- SIDEKIQ_CONCURRENCY - Used to set the number of jobs that Sidekiq will attempt
+to work on at once. If not set, falls back to DATABASE_POOL_SIZE.
 - SUBMIT_INVOICES – Used as a feature-switch to enable/disable Workday
 integration, which will make API calls to generate invoices for completed
 submissions


### PR DESCRIPTION
Introduce the `SIDEKIQ_CONCURRENCY` environment variable that can be optionally used to control the number of jobs that workers will pick up per-instance.

If this isn't set, it'll fallback to using the `DATABASE_POOL_SIZE` value, as before.