### PR TITLE
(1044) Make admin submission file downloads compatible with GPaaS

### DIFF
--- a/app/controllers/admin/active_submission_controller.rb
+++ b/app/controllers/admin/active_submission_controller.rb
@@ -1,0 +1,29 @@
+class Admin::ActiveSubmissionController < AdminController
+  include ActionController::Live
+
+  def download
+    response.headers['Content-Type'] = attachment.content_type
+    response.headers['Content-Disposition'] = "attachment; #{attachment.filename.parameters}"
+
+    attachment.download do |chunk|
+      response.stream.write(chunk)
+    end
+  ensure
+    response.stream.close
+  end
+
+  private
+
+  def task
+    @task ||= Task.includes(:framework, :supplier, :active_submission).find(params[:task_id])
+  end
+
+  def attachment
+    @attachment ||= begin
+                      attachment = task.active_submission.files.first.file
+                      attachment.filename = "#{task.framework.short_name} #{task.supplier.name} "\
+                        "(#{task.period_date.to_s(:month_year)}).#{attachment.filename.extension}"
+                      attachment
+                    end
+  end
+end

--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -10,7 +10,7 @@
       = task.active_submission.aasm_state.titlecase
     %td.govuk-table__cell
       - if task.active_submission.files.any? && task.active_submission.files.first.file.attached?
-        = link_to 'Download submission file', rails_blob_url(task.active_submission.files.first.file)
+        = link_to 'Download submission file', admin_task_active_submission_download_path(task)
     %td.govuk-table__cell
       = link_to 'View', admin_supplier_submission_path(task.supplier, task.active_submission) if task.active_submission.validation_failed?
   - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,10 @@ Rails.application.routes.draw do
       resources :submissions, only: %i[show]
     end
 
+    resources :tasks, only: [] do
+      get 'active_submission/download'
+    end
+
     resources :frameworks, only: %i[index new create show edit update]
 
     resources :notify_downloads, only: %i[index show]


### PR DESCRIPTION
Previously, it was using a method that would redirect the user to a
generated temporary URL for the file in the S3 bucket. Since GPaaS
does not permit this, we need to fetch the file ourselves and stream it
back to the user.

As a bonus, the files are returned with filenames that are more useful
to admin users, who likely have many downloads from varying suppliers
and frameworks - e.g. "RM1234 Company Name Ltd (December 2018).xls".