### PR TITLE
Ingest fetches files using ActiveStorage, for GPaaS compatibility

### DIFF
--- a/spec/models/ingest/submission_file_downloader_spec.rb
+++ b/spec/models/ingest/submission_file_downloader_spec.rb
@@ -7,36 +7,14 @@ RSpec.describe Ingest::SubmissionFileDownloader do
   subject(:downloader) { Ingest::SubmissionFileDownloader.new(file) }
 
   describe '.downloaded?' do
-    let(:thread) { double('thread') }
-    let(:thread_value) { double('thread_value') }
-
     it "is true when the submission's file was successfully downloaded" do
-      allow(thread_value).to receive(:success?).and_return(true)
-      allow(thread).to receive(:value).and_return(thread_value)
-      allow(Open3).to receive(:popen3).with(/curl/).and_yield(nil, [], [], thread)
-      allow(File).to receive(:exist?).with('/tmp/ca52d38f-00b2-457a-888c-14a878f29897.xls').and_return(true)
-
       result = downloader.perform
 
       expect(result).to be_downloaded
     end
 
     it "is false if the submission's file was not downloaded" do
-      allow(thread_value).to receive(:success?).and_return(true)
-      allow(thread).to receive(:value).and_return(thread_value)
-      allow(Open3).to receive(:popen3).with(/curl/).and_yield(nil, [], [], thread)
-      allow(File).to receive(:exist?).with('/tmp/ca52d38f-00b2-457a-888c-14a878f29897.xls').and_return(false)
-
-      result = downloader.perform
-
-      expect(result).to_not be_downloaded
-    end
-
-    it 'is false if a non-zero exit code was received' do
-      allow(thread_value).to receive(:success?).and_return(false)
-      allow(thread).to receive(:value).and_return(thread_value)
-      allow(Open3).to receive(:popen3).with(/curl/).and_yield(nil, [], [], thread)
-      allow(File).to receive(:exist?).with('/tmp/ca52d38f-00b2-457a-888c-14a878f29897.xls').and_return(false)
+      allow(file.file.blob).to receive(:download).and_raise(Aws::S3::Errors::ServiceError)
 
       result = downloader.perform
 


### PR DESCRIPTION
GPaaS doesn't allow files to be downloaded from a S3 bucket using a signed public URL, but instead needs to be fetched using the AWS S3 APIs.

NB: In Rails 5.2, an S3-specific exception is raised in the event of a failure fetching the file. This makes it hard to test, as this is provider-specific, and the test ActiveStorage provider does not have
this. Rails 6 will have ActiveStorage::FileNotFoundError.

For now, I've stubbed the ActiveStorage `download` method to raise the expected AWS exception.