### PR TITLE
Use ROLLBAR_ENV instead of INFRASTRUCTURE_ENVIRONMENT

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -66,7 +66,7 @@ Rollbar.configure do |config|
   # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
   # setup for Heroku. See:
   # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
-  config.environment = ENV['INFRASTRUCTURE_ENVIRONMENT'].presence || Rails.env
+  config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
 
   config.anonymize_user_ip = true
 end


### PR DESCRIPTION
We use ROLLBAR_ENV to determine the environment for Rollbar in the
application and we should be consistent.

We will need to add ROLLBAR_ENV to the tfvars for the api in at least staging.
The PaaS already has this set for all environmets and apps.