### PR TITLE
(1053) Admin frameworks page is ordered by short_name

### DIFF
--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -3,7 +3,7 @@ class Admin::FrameworksController < AdminController
   before_action :prevent_change_to_published, only: %i[edit update_fdl publish]
 
   def index
-    @frameworks = Framework.all
+    @frameworks = Framework.order(:short_name).all
   end
 
   def new

--- a/app/views/admin/frameworks/index.html.haml
+++ b/app/views/admin/frameworks/index.html.haml
@@ -16,11 +16,13 @@
       %table.govuk-table{:class => 'govuk-!-margin-top-7'}
         %thead.govuk-table__head
           %tr.govuk-table__row
+            %th.govuk-table__header #
             %th.govuk-table__header Name
             %th.govuk-table__header Status
         %tbody.govuk-table__body
           - @frameworks.each do |framework|
             %tr.govuk-table__row
+              %td.govuk-table__cell= link_to framework.short_name, admin_framework_path(framework.id)
               %td.govuk-table__cell= link_to framework.name, admin_framework_path(framework.id)
               %td.govuk-table__cell= published_status(framework)
 

--- a/spec/features/admin_can_list_frameworks_spec.rb
+++ b/spec/features/admin_can_list_frameworks_spec.rb
@@ -17,11 +17,23 @@ RSpec.feature 'Admin can list frameworks' do
     visit admin_root_path
     click_link 'Frameworks'
 
-    # Then I should see a list of frameworks
-    expect(page).to have_text('Laundry Framework 1')
-    expect(page).to have_text('Vehicle Purchase Framework 1')
-    # And the frameworks' statuses
-    expect(page).to have_selector('td', text: 'Published', count: 2)
-    expect(page).to have_selector('td', text: 'New', count: 1)
+    # Then I should see a list of frameworks with their statuses
+    within 'tbody > tr:nth-child(1)' do
+      expect(page).to have_text('RM1234')
+      expect(page).to have_text('Laundry Framework 1')
+      expect(page).to have_text('Published')
+    end
+
+    within 'tbody > tr:nth-child(2)' do
+      expect(page).to have_text('RM5678')
+      expect(page).to have_text('Vehicle Purchase Framework 1')
+      expect(page).to have_text('Published')
+    end
+
+    within 'tbody > tr:nth-child(3)' do
+      expect(page).to have_text('RM5679')
+      expect(page).to have_text('Vehicle Purchase Framework 2')
+      expect(page).to have_text('New')
+    end
   end
 end


### PR DESCRIPTION
Add `short_name` to the frameworks list page, and order by it.

<img width="1060" alt="Screenshot 2019-05-10 at 13 32 22" src="https://user-images.githubusercontent.com/3166/57527624-103f9800-7328-11e9-8fcc-600d6f4a9ca9.png">
