### PR TITLE
Ensure deleted Sidekiq::Cron jobs are purged

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,5 @@
 Sidekiq.configure_server do |_config|
   Sidekiq.options[:poll_interval] = 5
   schedule_file = 'config/sidekiq_schedule.yml'
-  Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+  Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file)
 end


### PR DESCRIPTION
Using the `load_from_hash!` bang method causes any scheduled jobs that
have been removed to be purged from Redis.

A previous commit removed QueueSizeMetricJob. However, we used
`load_from_hash` previously, which meant this task wasn't purged when we
deployed, causing many failing jobs to get created, which were retried
endlessly.

Although I have removed the job configuration manually from Redis, this
change ensures that it doesn't catch anyone else out in the future!