### PR TITLE
(970) Admins can bulk import suppliers

### DIFF
--- a/app/controllers/admin/supplier_bulk_imports_controller.rb
+++ b/app/controllers/admin/supplier_bulk_imports_controller.rb
@@ -10,7 +10,7 @@ class Admin::SupplierBulkImportsController < AdminController
     redirect_to new_admin_supplier_bulk_import_path, notice: 'Successfully imported suppliers'
   rescue ActionController::ParameterMissing
     redirect_to new_admin_supplier_bulk_import_path, alert: 'Please choose a file to upload'
-  rescue ArgumentError => e
+  rescue ActiveRecord::RecordNotFound, ArgumentError => e
     redirect_to new_admin_supplier_bulk_import_path, alert: e.message
   end
 

--- a/app/controllers/admin/supplier_bulk_imports_controller.rb
+++ b/app/controllers/admin/supplier_bulk_imports_controller.rb
@@ -1,0 +1,26 @@
+class Admin::SupplierBulkImportsController < AdminController
+  def new; end
+
+  def create
+    return redirect_to new_admin_supplier_bulk_import_path, alert: 'Uploaded file is not a CSV file' unless csv?
+
+    csv_path = uploaded_file.tempfile.path
+    Import::FrameworkSuppliers.new(csv_path, logger: Rails.logger).run
+
+    redirect_to new_admin_supplier_bulk_import_path, notice: 'Successfully imported suppliers'
+  rescue ActionController::ParameterMissing
+    redirect_to new_admin_supplier_bulk_import_path, alert: 'Please choose a file to upload'
+  rescue ArgumentError => e
+    redirect_to new_admin_supplier_bulk_import_path, alert: e.message
+  end
+
+  private
+
+  def uploaded_file
+    params.require(:bulk_import).require(:csv_file)
+  end
+
+  def csv?
+    uploaded_file.content_type == 'text/csv'
+  end
+end

--- a/app/models/import/framework_suppliers/row.rb
+++ b/app/models/import/framework_suppliers/row.rb
@@ -21,7 +21,7 @@ module Import
       private
 
       def framework
-        @framework ||= Framework.find_by!(short_name: framework_short_name)
+        @framework ||= Framework.published.find_by!(short_name: framework_short_name)
       end
 
       def framework_lot

--- a/app/views/admin/supplier_bulk_imports/new.html.haml
+++ b/app/views/admin/supplier_bulk_imports/new.html.haml
@@ -1,0 +1,25 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl Bulk import suppliers
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = simple_form_for :bulk_import, url: admin_supplier_bulk_import_path do |form|
+      %fieldset.govuk-fieldset
+        %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
+          %h2.govuk-fieldset__heading
+            CSV
+
+        = form.input :csv_file, as: :file, label: 'Choose a CSV file to upload.', hide_optional: true
+        = form.button :submit, 'Upload'
+
+        %p
+          This file should contain the following columns:
+
+        %ul.govuk-list.govuk-list--bullet
+          %li framework_short_name (e.g. RM1043.5)
+          %li lot_number
+          %li supplier_name
+          %li salesforce_id
+          %li coda_reference
+

--- a/app/views/admin/suppliers/index.html.haml
+++ b/app/views/admin/suppliers/index.html.haml
@@ -14,6 +14,11 @@
         %button.govuk-button Search
 
   .govuk-grid-column-one-third
+    %nav.govuk-page-actions{"aria-labelledby" => "page-actions-title"}
+      %h2#page-actions-title.govuk-heading-s{"aria-label" => "Page actions"} Actions
+      %ul.govuk-page-actions--actions
+        %li.govuk-page-actions--action
+          = link_to 'Bulk import suppliers', new_admin_supplier_bulk_import_path
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,10 @@ Rails.application.routes.draw do
         put :deactivate
       end
       resources :submissions, only: %i[show]
+
+      collection do
+        resource :bulk_import, only: %i[new create], controller: 'supplier_bulk_imports', as: :supplier_bulk_import
+      end
     end
 
     resources :tasks, only: [] do

--- a/spec/features/admin_can_bulk_import_suppliers_spec.rb
+++ b/spec/features/admin_can_bulk_import_suppliers_spec.rb
@@ -52,6 +52,18 @@ RSpec.feature 'Admin can bulk import suppliers' do
     end
   end
 
+  context 'with a CSV which references an unpublished framework' do
+    before { fm1234.update(published: false) }
+
+    scenario 'displays an error' do
+      visit new_admin_supplier_bulk_import_path
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'suppliers.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Couldn\'t find Framework'
+    end
+  end
+
   context 'with a CSV with missing columns' do
     scenario 'displays an error, showing which columns are missing' do
       visit new_admin_supplier_bulk_import_path

--- a/spec/features/admin_can_bulk_import_suppliers_spec.rb
+++ b/spec/features/admin_can_bulk_import_suppliers_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin can bulk import suppliers' do
+  let!(:fm1234) do
+    create(:framework, short_name: 'FM1234') do |framework|
+      create(:framework_lot, number: '1', framework: framework)
+      create(:framework_lot, number: '2a', framework: framework)
+      create(:framework_lot, number: '2b', framework: framework)
+    end
+  end
+
+  let!(:fm9999) do
+    create(:framework, short_name: 'FM9999iv') do |framework|
+      create(:framework_lot, number: '1', framework: framework)
+      create(:framework_lot, number: '2', framework: framework)
+      create(:framework_lot, number: '3', framework: framework)
+    end
+  end
+
+  before do
+    sign_in_as_admin
+  end
+
+  context 'with a valid CSV' do
+    scenario 'creates suppliers that do not exist' do
+      visit new_admin_supplier_bulk_import_path
+
+      expect(page).to have_text 'Bulk import suppliers'
+
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'suppliers.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Successfully imported suppliers'
+
+      aardvark = Supplier.find_by(name: 'Aardvark (UK) Ltd')
+      aardvark_fm1234_lots = aardvark.agreements.find_by(framework: fm1234).framework_lots.pluck(:number)
+      aardvark_fm9999_lots = aardvark.agreements.find_by(framework: fm9999).framework_lots.pluck(:number)
+
+      expect(aardvark.coda_reference).to eql 'C099999'
+      expect(aardvark.salesforce_id).to eql '001b000003FAKEFAKE'
+      expect(aardvark_fm1234_lots).to match_array %w[1 2b]
+      expect(aardvark_fm9999_lots).to match_array %w[3]
+
+      eyx_digital = Supplier.find_by(name: 'eyx Digital')
+      eyx_digital_fm1234 = eyx_digital.agreements.find_by(framework: fm1234)
+      eyx_digital_fm9999_lots = eyx_digital.agreements.find_by(framework: fm9999).framework_lots.pluck(:number)
+
+      expect(eyx_digital.coda_reference).to eql 'C088888'
+      expect(eyx_digital.salesforce_id).to eql '0010N00004FAKEFAKE'
+      expect(eyx_digital_fm1234).to be_nil
+      expect(eyx_digital_fm9999_lots).to match_array %w[2 3]
+    end
+  end
+
+  context 'with a CSV with missing columns' do
+    scenario 'displays an error, showing which columns are missing' do
+      visit new_admin_supplier_bulk_import_path
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'suppliers_with_missing_columns.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Missing headers in CSV file: framework_short_name'
+    end
+  end
+
+  context 'with a non-CSV file' do
+    scenario 'displays an error' do
+      visit new_admin_supplier_bulk_import_path
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'not-really-an.xls')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Uploaded file is not a CSV file'
+    end
+  end
+
+  context 'without attaching a file' do
+    scenario 'displays an error' do
+      visit new_admin_supplier_bulk_import_path
+      click_button 'Upload'
+
+      expect(page).to have_text 'Please choose a file to upload'
+    end
+  end
+end

--- a/spec/fixtures/suppliers.csv
+++ b/spec/fixtures/suppliers.csv
@@ -1,0 +1,6 @@
+framework_short_name,lot_number,salesforce_id,supplier_name,coda_reference
+FM1234,1,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999
+FM1234,2b,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999
+FM9999iv,3,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999
+FM9999iv,2,0010N00004FAKEFAKE,eyx Digital,C088888
+FM9999iv,3,0010N00004FAKEFAKE,eyx Digital,C088888

--- a/spec/fixtures/suppliers_with_missing_columns.csv
+++ b/spec/fixtures/suppliers_with_missing_columns.csv
@@ -1,0 +1,3 @@
+lot_number,salesforce_id,supplier_name,coda_reference
+1,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999
+2b,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999

--- a/spec/models/import/framework_suppliers/row_spec.rb
+++ b/spec/models/import/framework_suppliers/row_spec.rb
@@ -87,5 +87,13 @@ RSpec.describe Import::FrameworkSuppliers::Row do
         end
       end
     end
+
+    context 'with a framework that is not published' do
+      before { framework.update(published: false) }
+
+      it 'raises an ActiveRecord::RecordNotFound exception' do
+        expect { row.import! }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow admin users to upload a CSV file containing a list of suppliers alongside their frameworks and lots. We then use the existing `Import::FrameworkSuppliers` class to perform the import.

If any errors occur, an error is shown to the user, and the database is rolled back.

![Screenshot 2019-05-17 at 12 46 44](https://user-images.githubusercontent.com/3166/57925965-dc252380-78a1-11e9-95da-33b3633a1a7b.png)

NB: This page can be accessed from the 'Suppliers' menu item, and then clicking on the 'Bulk import suppliers' action.