### PR TITLE
(1075) Admins can see total and management charge

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -3,7 +3,6 @@
 @import "govuk-frontend/components/file-upload/file-upload";
 @import "govuk-frontend/components/skip-link/skip-link";
 @import "govuk-frontend/components/phase-banner/phase-banner";
-@import "govuk-frontend/components/table/table";
 @import "govuk-frontend/components/error-summary/error-summary";
 @import "govuk-frontend/components/select/select";
 @import "govuk-frontend/components/breadcrumbs/breadcrumbs";
@@ -26,3 +25,4 @@
 @import "search/search";
 @import "actions/all";
 @import "code/fdl";
+@import "table/table";

--- a/app/assets/stylesheets/components/table/_table.scss
+++ b/app/assets/stylesheets/components/table/_table.scss
@@ -1,0 +1,6 @@
+@import "govuk-frontend/components/table/table";
+
+.govuk-table__cell--numeric {
+  @include govuk-font($size: false);
+}
+

--- a/app/controllers/admin/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers_controller.rb
@@ -5,7 +5,7 @@ class Admin::SuppliersController < AdminController
 
   def show
     @supplier = Supplier.find(params[:id])
-    @tasks = @supplier.tasks.includes(:framework, :active_submission).order(due_on: :desc)
+    @tasks = @supplier.tasks.includes(:framework, active_submission: :files).order(due_on: :desc)
   end
 
   def edit

--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -1,19 +1,29 @@
 %tr.govuk-table__row
   %td.govuk-table__cell
     = task.framework.short_name
-  %td.govuk-table__cell
-    = task.period_date.to_s(:month_year)
+    %br/
+    %small
+      = task.period_date.to_s(:month_year)
   - if task.active_submission
+    %td.govuk-table__cell.govuk-table__cell--numeric
+      - unless task.active_submission.total_spend.zero?
+        = number_to_currency(task.active_submission.management_charge, unit: '£')
+        %br/
+        %small
+          from
+          = number_to_currency(task.active_submission.total_spend, unit: '£')
+          spend
     %td.govuk-table__cell
       = task.active_submission.created_at.to_s(:date_with_utc_time)
     %td.govuk-table__cell
       = task.active_submission.aasm_state.titlecase
     %td.govuk-table__cell
       - if task.active_submission.files.any? && task.active_submission.files.first.file.attached?
-        = link_to 'Download submission file', admin_task_active_submission_download_path(task)
+        = link_to 'Download', admin_task_active_submission_download_path(task)
     %td.govuk-table__cell
       = link_to 'View', admin_supplier_submission_path(task.supplier, task.active_submission) if task.active_submission.validation_failed?
   - else
+    %td.govuk-table__cell
     %td.govuk-table__cell
     %td.govuk-table__cell
       = task.status.titlecase

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -18,11 +18,11 @@
       %table.govuk-table
         %thead.govuk-table__head
           %tr.govuk-table__row
-            %th.govuk-table__header Framework
-            %th.govuk-table__header Month
+            %th.govuk-table__header Task
+            %th.govuk-table__header.govuk-table__header--numeric Management Charge
             %th.govuk-table__header Submitted
             %th.govuk-table__header Status
-            %th.govuk-table__header Submission file
+            %th.govuk-table__header Return
             %th.govuk-table__header Errors
         %tbody.govuk-table__body
           = render(collection: @tasks, partial: "task")

--- a/spec/features/view_supplier_details_spec.rb
+++ b/spec/features/view_supplier_details_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Viewing a supplier' do
     end
 
     visit admin_supplier_path(supplier)
-    click_link 'Download submission file'
+    click_link 'Download'
 
     expect(page.response_headers['Content-Disposition']).to match(/^attachment/)
     expect(page.response_headers['Content-Disposition']).to match(/RM0000 Test Supplier Ltd %28December 2018%29\.xlsx/)


### PR DESCRIPTION
Reorganise the admin supplier view page to make room for showing total spend and management charge against each task. This is necessary to fully test new frameworks with test submissions.

![Screenshot 2019-05-17 at 15 49 53](https://user-images.githubusercontent.com/3166/57936358-a8ef8e00-78bb-11e9-9763-6c323eabfcde.png)
