### PR TITLE
(1079) Admins can bulk add users

### DIFF
--- a/app/controllers/admin/supplier_bulk_imports_controller.rb
+++ b/app/controllers/admin/supplier_bulk_imports_controller.rb
@@ -21,6 +21,7 @@ class Admin::SupplierBulkImportsController < AdminController
   end
 
   def csv?
-    uploaded_file.content_type == 'text/csv'
+    File.extname(uploaded_file.original_filename) == '.csv' &&
+      ['text/csv', 'application/vnd.ms-excel'].include?(uploaded_file.content_type)
   end
 end

--- a/app/controllers/admin/user_bulk_imports_controller.rb
+++ b/app/controllers/admin/user_bulk_imports_controller.rb
@@ -10,7 +10,7 @@ class Admin::UserBulkImportsController < AdminController
     redirect_to new_admin_user_bulk_import_path, notice: 'Successfully imported users'
   rescue ActionController::ParameterMissing
     redirect_to new_admin_user_bulk_import_path, alert: 'Please choose a file to upload'
-  rescue ActiveRecord::RecordNotFound, ArgumentError => e
+  rescue ActiveRecord::RecordNotFound, ArgumentError, Import::Users::InvalidSalesforceId => e
     redirect_to new_admin_user_bulk_import_path, alert: e.message
   end
 

--- a/app/controllers/admin/user_bulk_imports_controller.rb
+++ b/app/controllers/admin/user_bulk_imports_controller.rb
@@ -21,6 +21,7 @@ class Admin::UserBulkImportsController < AdminController
   end
 
   def csv?
-    uploaded_file.content_type == 'text/csv'
+    File.extname(uploaded_file.original_filename) == '.csv' &&
+      ['text/csv', 'application/vnd.ms-excel'].include?(uploaded_file.content_type)
   end
 end

--- a/app/controllers/admin/user_bulk_imports_controller.rb
+++ b/app/controllers/admin/user_bulk_imports_controller.rb
@@ -1,0 +1,26 @@
+class Admin::UserBulkImportsController < AdminController
+  def new; end
+
+  def create
+    return redirect_to new_admin_user_bulk_import_path, alert: 'Uploaded file is not a CSV file' unless csv?
+
+    csv_path = uploaded_file.tempfile.path
+    Import::Users.new(csv_path, logger: Rails.logger).run
+
+    redirect_to new_admin_user_bulk_import_path, notice: 'Successfully imported users'
+  rescue ActionController::ParameterMissing
+    redirect_to new_admin_user_bulk_import_path, alert: 'Please choose a file to upload'
+  rescue ActiveRecord::RecordNotFound, ArgumentError => e
+    redirect_to new_admin_user_bulk_import_path, alert: e.message
+  end
+
+  private
+
+  def uploaded_file
+    params.require(:bulk_import).require(:csv_file)
+  end
+
+  def csv?
+    uploaded_file.content_type == 'text/csv'
+  end
+end

--- a/app/models/import/users.rb
+++ b/app/models/import/users.rb
@@ -25,6 +25,8 @@ require 'csv'
 # file into the container itself. Use the `docker cp` command to do this.
 module Import
   class Users
+    class InvalidSalesforceId < StandardError; end
+
     DEFAULT_WAIT = 0.2
     EXPECTED_HEADERS = %I[supplier_salesforce_id email name].freeze
 
@@ -38,6 +40,8 @@ module Import
     end
 
     def run
+      check_for_missing_salesforce_ids
+
       ActiveRecord::Base.transaction do
         @csv.each do |row_data|
           user = Row.new(row_data).import!
@@ -63,6 +67,17 @@ module Import
 
     def missing_headers
       EXPECTED_HEADERS - @csv.headers
+    end
+
+    def check_for_missing_salesforce_ids
+      supplier_salesforce_ids = Supplier.pluck(:salesforce_id, 1).to_h
+
+      @csv.each do |row_data|
+        salesforce_id = row_data[:supplier_salesforce_id]
+        next if supplier_salesforce_ids.key?(salesforce_id)
+
+        raise InvalidSalesforceId, "Could not find a supplier with salesforce_id '#{salesforce_id}'."
+      end
     end
   end
 end

--- a/app/models/import/users.rb
+++ b/app/models/import/users.rb
@@ -38,10 +38,12 @@ module Import
     end
 
     def run
-      @csv.each do |row_data|
-        user = Row.new(row_data).import!
-        log "User #{user.email} is associated with #{user.suppliers.map(&:name).to_sentence}"
-        wait
+      ActiveRecord::Base.transaction do
+        @csv.each do |row_data|
+          user = Row.new(row_data).import!
+          log "User #{user.email} is associated with #{user.suppliers.map(&:name).to_sentence}"
+          wait
+        end
       end
     end
 

--- a/app/views/admin/user_bulk_imports/new.html.haml
+++ b/app/views/admin/user_bulk_imports/new.html.haml
@@ -1,0 +1,23 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl Bulk import users
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = simple_form_for :bulk_import, url: admin_user_bulk_import_path do |form|
+      %fieldset.govuk-fieldset
+        %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
+          %h2.govuk-fieldset__heading
+            CSV
+
+        = form.input :csv_file, as: :file, label: 'Choose a CSV file to upload.', hide_optional: true
+        = form.button :submit, 'Upload'
+
+        %p
+          This file should contain the following columns:
+
+        %ul.govuk-list.govuk-list--bullet
+          %li name
+          %li email
+          %li supplier_salesforce_id
+

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -19,6 +19,8 @@
       %ul.govuk-page-actions--actions
         %li.govuk-page-actions--action
           = link_to 'Add a new user', new_admin_user_path
+        %li.govuk-page-actions--action
+          = link_to 'Bulk import users', new_admin_user_bulk_import_path
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,10 @@ Rails.application.routes.draw do
         get :confirm_delete
         get :confirm_reactivate
       end
+
+      collection do
+        resource :bulk_import, only: %i[new create], controller: 'user_bulk_imports', as: :user_bulk_import
+      end
     end
 
     resources :suppliers, only: %i[index show edit update] do

--- a/spec/features/admin_can_bulk_import_users_spec.rb
+++ b/spec/features/admin_can_bulk_import_users_spec.rb
@@ -24,7 +24,8 @@ RSpec.feature 'Admin can bulk import users' do
       expect(page).to have_text 'Bulk import users'
 
       attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'users.csv')
-      click_button 'Upload'
+
+      expect { click_button 'Upload' }.to change { User.count }
 
       expect(page).to have_text 'Successfully imported users'
 
@@ -39,14 +40,16 @@ RSpec.feature 'Admin can bulk import users' do
   end
 
   context 'with a CSV which references a salesforce_id that does not exist' do
-    before { jamila_company.update(salesforce_id: nil) }
+    before { seema_company.update(salesforce_id: nil) }
 
     scenario 'displays an error' do
       visit new_admin_user_bulk_import_path
       attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'users.csv')
-      click_button 'Upload'
 
-      expect(page).to have_text 'Couldn\'t find Supplier'
+      expect { click_button 'Upload' }.to_not change { User.count }
+
+      expect(page).to have_text 'Could not find a supplier with salesforce_id'
+      expect(page).to have_text seema_company_salesforce_id
     end
   end
 

--- a/spec/features/admin_can_bulk_import_users_spec.rb
+++ b/spec/features/admin_can_bulk_import_users_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin can bulk import users' do
+  let(:jamila_email) { 'jamila@aslan.tr' }
+  let(:seema_email) { 'seema@sash123.co.uk' }
+  let(:jamila_company_salesforce_id) { '0010N12004XKNGYQA5' }
+  let(:seema_company_salesforce_id) { '0010N45004XKN9yQAH' }
+
+  let!(:jamila_company) { FactoryBot.create(:supplier, salesforce_id: jamila_company_salesforce_id) }
+  let!(:seema_company) { FactoryBot.create(:supplier, salesforce_id: seema_company_salesforce_id) }
+
+  before do
+    stub_auth0_token_request
+    stub_auth0_create_user_request(jamila_email)
+    stub_auth0_create_user_request(seema_email)
+
+    sign_in_as_admin
+  end
+
+  context 'with a valid CSV' do
+    scenario 'creates users that do not exist' do
+      visit new_admin_user_bulk_import_path
+
+      expect(page).to have_text 'Bulk import users'
+
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'users.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Successfully imported users'
+
+      jamila_company_user = jamila_company.users.first
+      expect(jamila_company_user.name).to eql 'Jamila Aslan'
+      expect(jamila_company_user.email).to eql jamila_email
+
+      seema_company_user = seema_company.users.first
+      expect(seema_company_user.name).to eql 'Seema Clarke'
+      expect(seema_company_user.email).to eql seema_email
+    end
+  end
+
+  context 'with a CSV which references a salesforce_id that does not exist' do
+    before { jamila_company.update(salesforce_id: nil) }
+
+    scenario 'displays an error' do
+      visit new_admin_user_bulk_import_path
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'users.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Couldn\'t find Supplier'
+    end
+  end
+
+  context 'with a CSV with missing columns' do
+    scenario 'displays an error, showing which columns are missing' do
+      visit new_admin_user_bulk_import_path
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'users_bad_headers.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Missing headers in CSV file: supplier_salesforce_id'
+    end
+  end
+
+  context 'with a non-CSV file' do
+    scenario 'displays an error' do
+      visit new_admin_user_bulk_import_path
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'not-really-an.xls')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Uploaded file is not a CSV file'
+    end
+  end
+
+  context 'without attaching a file' do
+    scenario 'displays an error' do
+      visit new_admin_user_bulk_import_path
+      click_button 'Upload'
+
+      expect(page).to have_text 'Please choose a file to upload'
+    end
+  end
+end


### PR DESCRIPTION
Very similar to https://github.com/dxw/DataSubmissionServiceAPI/pull/437 but uses the already-built `Import::Users`class.

An additional check was added to not attempt to import any users when the CSV contains a salesforce_id that doesn't exist in the `Supplier` model, to prevent orphaned Auth0 users being created.

<img width="1056" alt="Screenshot 2019-05-22 at 12 09 22" src="https://user-images.githubusercontent.com/3166/58170098-74e4e600-7c8a-11e9-989d-2f290b35c6fa.png">