### PR TITLE
(1055) Definition invalid when management charge references optional field

### DIFF
--- a/app/models/framework/definition/RM3710.fdl
+++ b/app/models/framework/definition/RM3710.fdl
@@ -46,7 +46,7 @@ Framework RM3710 {
     optional Decimal Additional17 from 'Total Manufacturer Discount (%)'
     optional String from 'Cost Centre'
     optional String from 'Contract Number'
-    optional PromotionCode from 'Spend Code'
+    PromotionCode from 'Spend Code'
   }
 
   Lookups {

--- a/app/models/framework/definition/RM858.fdl
+++ b/app/models/framework/definition/RM858.fdl
@@ -23,7 +23,7 @@ Framework RM858 {
     InvoiceValue from 'Invoice Line Total Value ex VAT'
     optional VATIncluded from 'VAT Applicable'
     optional VATCharged from 'VAT Amount Charged'
-    optional PromotionCode from 'Spend Code'
+    PromotionCode from 'Spend Code'
     ProductGroup from 'Invoice Line Product / Service Grouping'
     optional ProductCode from 'CAP Code'
     optional ProductClass from 'Vehicle Make'

--- a/app/models/framework/definition/ast/presenter.rb
+++ b/app/models/framework/definition/ast/presenter.rb
@@ -42,6 +42,12 @@ class Framework
 
           Field.new(field_def, lookups)
         end
+
+        def field_by_sheet_name(entry_type, name)
+          field_def = field_defs(entry_type).find { |f| f[:from] == name } || return
+
+          Field.new(field_def, lookups)
+        end
       end
     end
   end

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -14,6 +14,8 @@ class Framework
         ast = @ast
         transpiler = self
 
+        check_management_charge_calculator_fields_are_not_optional(ast[:management_charge])
+
         Class.new(Framework::Definition::Base) do
           framework_name       ast[:framework_name]
           framework_short_name ast[:framework_short_name]
@@ -78,6 +80,20 @@ class Framework
           )
         end
       end
+
+      # rubocop:disable Metrics/AbcSize
+      def check_management_charge_calculator_fields_are_not_optional(info)
+        if info[:column_based] && ast.field_by_sheet_name(:invoice, info[:column_based][:column_name]).field_def[:optional]
+          raise Transpiler::Error,
+                'Management charge references ' \
+                "'#{info[:column_based][:column_name]}' so it cannot be optional"
+        elsif info[:flat_rate] && info[:flat_rate][:column].present? && ast.field_by_sheet_name(:invoice, info[:flat_rate][:column]).field_def[:optional]
+          raise Transpiler::Error,
+                'Management charge references ' \
+                "'#{info[:flat_rate][:column]}' so it cannot be optional"
+        end
+      end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end


### PR DESCRIPTION
If the field used for flat-rate or column-based management charge calculation is optional, then the user can submit rows within their return that will pass validation, but fail the management charge
calculation.

To prevent this we check that these fields are required within the transpiler, and raise a `Transpiler::Error` when this occurs.

![Screenshot 2019-05-24 at 12 59 58](https://user-images.githubusercontent.com/3166/58326167-ec01b200-7e23-11e9-8eef-da9913c18d79.png)

The existing `field_by_name` method uses the data warehouse field name, whereas the management charge calculation uses the sheet name, hence the need for adding `field_by_sheet_name` to the presenter.

Both RM3710 and RM858 failed this check, so they have been corrected.