### PR TITLE
(1078) Late notification CSV should only include users with overdue returns on at least one framework

### DIFF
--- a/app/models/task/overdue_user_notification_list.rb
+++ b/app/models/task/overdue_user_notification_list.rb
@@ -55,7 +55,7 @@ class Task
     end
 
     def frameworks
-      @frameworks ||= Framework.order(:short_name)
+      @frameworks ||= Framework.published.order(:short_name)
     end
 
     def frameworks_header

--- a/app/models/task/overdue_user_notification_list.rb
+++ b/app/models/task/overdue_user_notification_list.rb
@@ -34,8 +34,11 @@ class Task
     private
 
     def csv_line_for(user, supplier)
+      framework_presence = late_task_framework_presence(supplier)
+      return if framework_presence.all?('no')
+
       CSV.generate_line(
-        [user.email, due_date, user.name, supplier.name, reporting_month] + late_task_framework_presence(supplier)
+        [user.email, due_date, user.name, supplier.name, reporting_month] + framework_presence
       )
     end
 

--- a/spec/models/task/overdue_user_notification_list_spec.rb
+++ b/spec/models/task/overdue_user_notification_list_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Task::OverdueUserNotificationList do
 
       let(:alice)      { create :user, name: 'Alice Example', email: 'alice@example.com' }
       let(:bob)        { create :user, name: 'Bob Example', email: 'bob@example.com' }
+      let(:charley)    { create :user, name: 'Charley Goodsupplier', email: 'charley.goodsupplier@example.com' }
       let(:frank)      { create(:user, :inactive, name: 'Frank Inactive', email: 'frank.inactive@example.com') }
 
       before do
@@ -24,17 +25,20 @@ RSpec.describe Task::OverdueUserNotificationList do
 
         supplier_a = create(:supplier, name: 'Supplier A')
         supplier_b = create(:supplier, name: 'Supplier B')
+        supplier_c = create(:supplier, name: 'Supplier C')
 
         create :membership, user: alice, supplier: supplier_a
         create :membership, user: alice, supplier: supplier_b
         create :membership, user: bob, supplier: supplier_b
         create :membership, user: frank, supplier: supplier_b
+        create :membership, user: charley, supplier: supplier_c
 
         create :task, supplier: supplier_a, framework: framework1, period_month: 1
         create :task, supplier: supplier_a, framework: framework2, period_month: 1
         create :task, supplier: supplier_b, framework: framework1, period_month: 1
 
         create :task, :completed, supplier: supplier_a, framework: framework3
+        create :task, :completed, supplier: supplier_c, framework: framework1
 
         generator.generate
       end
@@ -56,6 +60,10 @@ RSpec.describe Task::OverdueUserNotificationList do
 
       it 'does not include inactive users' do
         expect(output.string).not_to include('Frank Inactive')
+      end
+
+      it 'does not include suppliers with no incomplete submissions' do
+        expect(output.string).not_to include('Charley Goodsupplier')
       end
     end
   end

--- a/spec/models/task/overdue_user_notification_list_spec.rb
+++ b/spec/models/task/overdue_user_notification_list_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Task::OverdueUserNotificationList do
         framework1 = create :framework, short_name: 'RM0001'
         framework2 = create :framework, short_name: 'RM0002'
         framework3 = create :framework, short_name: 'COMPLETE0001'
+        create :framework, short_name: 'NOTPUBLISHED0001', published: false
 
         supplier_a = create(:supplier, name: 'Supplier A')
         supplier_b = create(:supplier, name: 'Supplier B')
@@ -49,6 +50,10 @@ RSpec.describe Task::OverdueUserNotificationList do
         expect(lines.first).to eql(
           'email address,due_date,person_name,supplier_name,reporting_month,COMPLETE0001,RM0001,RM0002'
         )
+      end
+
+      it 'does not include columns for unpublished frameworks' do
+        expect(lines.first).not_to include('NOTPUBLISHED0001')
       end
 
       it 'has a line for each user and supplier, listing the frameworks they have late tasks for' do


### PR DESCRIPTION
Stop `OverdueUserNotificationList` including users whose suppliers have no frameworks with overdue tasks for the current reporting period.

Previously, we were getting reports of users receiving emails telling them they were overdue submitting returns, whilst missing the list of frameworks (because there were none).