### PR TITLE
(1069) Make lots block in FDL mandatory

### DIFF
--- a/app/models/framework/definition/CM_OSG_05_3565.fdl
+++ b/app/models/framework/definition/CM_OSG_05_3565.fdl
@@ -2,6 +2,10 @@ Framework CM/OSG/05/3565 {
   Name 'Laundry Services - Wave 2'
   ManagementCharge 0.0%
 
+  Lots {
+    '1' -> 'Laundry Services - Wave 2'
+  }
+
   InvoiceFields {
     optional CustomerPostCode from 'Customer Postcode'
     CustomerName from 'Customer Organisation'

--- a/app/models/framework/definition/RM1031.fdl
+++ b/app/models/framework/definition/RM1031.fdl
@@ -3,6 +3,10 @@ Framework RM1031 {
 
   ManagementCharge 0.5%
 
+  Lots {
+    '1' -> 'Processing (collection, wash, finish and return) of linen items/linen hire items'
+  }
+
   InvoiceFields{
     CustomerName from 'Customer Organisation'
     optional CustomerPostCode from 'Customer PostCode'

--- a/app/models/framework/definition/RM1043_5.fdl
+++ b/app/models/framework/definition/RM1043_5.fdl
@@ -3,6 +3,13 @@ Framework RM1043.5 {
 
   ManagementCharge 1.0%
 
+  Lots {
+    '1' -> 'Digital outcomes'
+    '2' -> 'Digital specialists'
+    '3' -> 'User research studios'
+    '4' -> 'User research participants'
+  }
+
   InvoiceFields {
     SupplierReferenceNumber from 'Opportunity ID'
     CustomerName from 'Customer Organisation Name'

--- a/app/models/framework/definition/RM1043iii.fdl
+++ b/app/models/framework/definition/RM1043iii.fdl
@@ -3,6 +3,13 @@ Framework RM1043iii {
 
   ManagementCharge 1.0%
 
+  Lots {
+    '1' -> 'Outcomes'
+    '2' -> 'Specialists'
+    '3' -> 'User research studios'
+    '4' -> 'User research participants'
+  }
+
   InvoiceFields {
     SupplierReferenceNumber from 'SoW / Order Number'
     optional String from 'Buyer Cost Centre'

--- a/app/models/framework/definition/RM1043iv.fdl
+++ b/app/models/framework/definition/RM1043iv.fdl
@@ -3,6 +3,13 @@ Framework RM1043iv {
 
   ManagementCharge 1.0%
 
+  Lots {
+    '1' -> 'Outcomes'
+    '2' -> 'Specialists'
+    '3' -> 'User research studios'
+    '4' -> 'User research participants'
+  }
+
   InvoiceFields {
     SupplierReferenceNumber from 'SoW / Order Number'
     optional String from 'Buyer Cost Centre'

--- a/app/models/framework/definition/RM1070.fdl
+++ b/app/models/framework/definition/RM1070.fdl
@@ -3,6 +3,18 @@ Framework RM1070 {
 
   ManagementCharge 0.5%
 
+  Lots {
+    '1' -> 'Cars including 4x4 Variants'
+    '2' -> 'Light to Medium Commercial Vehicles up to but not including 7.5 tonnes (includin'
+    '3' -> 'Medium to Heavy Commercial Vehicles 7.5 tonnes and above'
+    '4' -> 'Motorcycles (including Quad Bikes and Scooters)'
+    '5' -> 'Buses and Coaches'
+    '6' -> 'Vehicles for Overseas'
+    '7' -> 'Blue Light Cars including 4x4 Variants'
+    '8' -> 'Blue Light, Light to Medium Commercial Vehicles'
+    '9' -> 'Blue Light Motorcycles (including Quad Bikes and Scooters)'
+  }
+
   InvoiceFields {
     LotNumber from 'Lot Number'
     optional CustomerPostCode from 'Customer PostCode'

--- a/app/models/framework/definition/RM1557_10.fdl
+++ b/app/models/framework/definition/RM1557_10.fdl
@@ -3,6 +3,12 @@ Framework RM1557.10 {
 
   ManagementCharge 0.75%
 
+  Lots {
+    '1' -> 'Cloud Hosting'
+    '2' -> 'Cloud Software'
+    '3' -> 'Cloud Support'
+  }
+
   InvoiceFields {
     SupplierReferenceNumber from 'Order Reference Number'
     CustomerURN from 'Customer Unique Reference Number (URN)'

--- a/app/models/framework/definition/RM1557ix.fdl
+++ b/app/models/framework/definition/RM1557ix.fdl
@@ -3,6 +3,12 @@ Framework RM1557ix {
 
   ManagementCharge 0.75%
 
+  Lots {
+    '1' -> 'Cloud Hosting'
+    '2' -> 'Cloud Software'
+    '3' -> 'Cloud Support'
+  }
+
   InvoiceFields {
     optional String from 'Buyer Cost Centre'
     SupplierReferenceNumber from 'Call Off Contract Reference'

--- a/app/models/framework/definition/RM1557vii.fdl
+++ b/app/models/framework/definition/RM1557vii.fdl
@@ -3,6 +3,13 @@ Framework RM1557vii {
 
   ManagementCharge 0.5%
 
+  Lots {
+    '1' -> 'Infrastructure as a Service (IaaS)'
+    '2' -> 'Platform as a Service (PaaS)'
+    '3' -> 'Software as a Service'
+    '4' -> 'Specialist Cloud Services'
+  }
+
   InvoiceFields {
     LotNumber from 'Lot Number'
     optional SupplierReferenceNumber from 'Supplier Order Number'

--- a/app/models/framework/definition/RM1557viii.fdl
+++ b/app/models/framework/definition/RM1557viii.fdl
@@ -3,6 +3,13 @@ Framework RM1557viii {
 
   ManagementCharge 0.5%
 
+  Lots {
+    '1' -> 'Infrastructure as a Service (IaaS)'
+    '2' -> 'Platform as a Service (PaaS)'
+    '3' -> 'Software as a Service'
+    '4' -> 'Specialist Cloud Services'
+  }
+
   InvoiceFields {
     optional String from 'Buyer Cost Centre'
     SupplierReferenceNumber from 'Call Off Contract Reference'

--- a/app/models/framework/definition/RM3710.fdl
+++ b/app/models/framework/definition/RM3710.fdl
@@ -8,6 +8,12 @@ Framework RM3710 {
     'Other Re-charges'             -> 0%
   }
 
+  Lots {
+    '1' -> 'Lease of passenger motor vehicles and light commercial vehicles up to 3.5 tonnes'
+    '2' -> 'Lease of commercial vehicles 3.5 tonnes and above, including buses, coaches, tra'
+    '3' -> 'Provision of Fleet Management Services, including the management, sourcing and s'
+  }
+
   InvoiceFields {
     LotNumber from 'Lot Number'
     CustomerURN from 'Customer URN'

--- a/app/models/framework/definition/RM3754.fdl
+++ b/app/models/framework/definition/RM3754.fdl
@@ -2,6 +2,10 @@ Framework RM3754 {
   Name 'Vehicle Telematics'
   ManagementCharge 0.5%
 
+  Lots {
+    '1' -> 'Vehicle Telematics'
+  }
+
   InvoiceFields {
     CustomerURN from 'Customer URN'
     optional CustomerPostCode from 'Customer PostCode'

--- a/app/models/framework/definition/RM3756.fdl
+++ b/app/models/framework/definition/RM3756.fdl
@@ -3,6 +3,11 @@ Framework RM3756 {
 
   ManagementCharge 1.5%
 
+  Lots {
+    '1' -> 'Rail Legal Services Tier 1'
+    '2' -> 'Rail Legal Services Tier 2'
+  }
+
   InvoiceFields {
     LotNumber from 'Tier Number'
     SupplierReferenceNumber from 'Supplier Reference Number'

--- a/app/models/framework/definition/RM3767.fdl
+++ b/app/models/framework/definition/RM3767.fdl
@@ -3,6 +3,11 @@ Framework RM3767 {
 
   ManagementCharge 1%
 
+  Lots {
+    '1' -> 'The supply and fit of tyres and associated services to the Police and emergency services'
+    '2' -> 'The supply and fit of tyres and associated services to central Government and the wider public sector'
+  }
+
   InvoiceFields {
     LotNumber from 'Lot Number'
     CustomerURN from 'Customer URN'
@@ -50,10 +55,5 @@ Framework RM3767 {
       'Mid-Range'
       'Budget'
     ]
-  }
-
-  Lots {
-    '1' -> 'The supply and fit of tyres and associated services to the Police and emergency services'
-    '2' -> 'The supply and fit of tyres and associated services to central Government and the wider public sector'
   }
 }

--- a/app/models/framework/definition/RM3772.fdl
+++ b/app/models/framework/definition/RM3772.fdl
@@ -1,7 +1,11 @@
 Framework RM3772 {
   Name 'Specialist Laundry Services (for Surgical Gowns, D'
 
-  ManagementCharge 0.5% 
+  ManagementCharge 0.5%
+
+  Lots {
+    '1' -> 'Processing of linen items and linen hire items'
+  }
 
   InvoiceFields {
     CustomerName from 'Customer Organisation'
@@ -24,7 +28,7 @@ Framework RM3772 {
     optional String from 'Cost Centre'
     optional String from 'Contract Number'
   }
-  
+
   ContractFields {
     optional CustomerName from 'Customer Organisation'
     optional CustomerPostCode from 'Customer PostCode'

--- a/app/models/framework/definition/RM3786.fdl
+++ b/app/models/framework/definition/RM3786.fdl
@@ -3,6 +3,11 @@ Framework RM3786 {
 
   ManagementCharge 1.5%
 
+  Lots {
+    '1' -> 'General Legal Services Tier 1'
+    '2' -> 'General Legal Services Tier 2'
+  }
+
   InvoiceFields {
     LotNumber from 'Tier Number'
     optional SupplierReferenceNumber from 'Supplier Reference Number'

--- a/app/models/framework/definition/RM3787.fdl
+++ b/app/models/framework/definition/RM3787.fdl
@@ -2,6 +2,10 @@ Framework RM3787 {
   Name 'Finance & Complex Legal Services'
   ManagementCharge 1.5%
 
+  Lots {
+    '1' -> 'Finance & Complex Legal Services'
+  }
+
   InvoiceFields {
     SupplierReferenceNumber from 'Supplier Reference Number'
     CustomerURN from 'Customer URN'

--- a/app/models/framework/definition/RM3788.fdl
+++ b/app/models/framework/definition/RM3788.fdl
@@ -3,6 +3,15 @@ Framework RM3788 {
 
   ManagementCharge 1.5%
 
+  Lots {
+    '1' -> 'Regional Legal Services'
+    '2a' -> 'Full Service Law Firms - England and Wales'
+    '2b' -> 'Full Service Law Firms - Scotland'
+    '2c' -> 'Full Service Law Firms - Northern Ireland'
+    '3' -> 'Property and Construction'
+    '4' -> 'Transport Rail'
+  }
+
   InvoiceFields {
     SupplierReferenceNumber from 'Supplier Reference Number'
     CustomerName from 'Customer Organisation Name'

--- a/app/models/framework/definition/RM3797.fdl
+++ b/app/models/framework/definition/RM3797.fdl
@@ -3,6 +3,10 @@ Framework RM3797 {
 
   ManagementCharge 1.0%
 
+  Lots {
+    '1' -> 'Journal Subscriptions (Print and Electronic)'
+  }
+
   InvoiceFields {
     CustomerURN from 'Customer URN'
     CustomerPostCode from 'Customer PostCode'

--- a/app/models/framework/definition/RM6060.fdl
+++ b/app/models/framework/definition/RM6060.fdl
@@ -3,6 +3,16 @@ Framework RM6060 {
 
    ManagementCharge 0.5% of 'Supplier Price'
 
+  Lots {
+    '1' -> 'Passenger Cars (including 4x4 variants)'
+    '2' -> 'Light to medium commercial vehicles (including car derived vans, 4x4 variants & minibuses) up to but not including 7.5 tonnes'
+    '3' -> 'Medium to heavy Commercial Vehicles 7.5 tonnes and above'
+    '4' -> 'Motorcycles (including scooters and quad bikes)'
+    '5' -> 'Buses and Coaches'
+    '6' -> 'Blue light vehicles (including passenger vehicles, 4x4 variants, all-terrain vehicles, motorcycles, scooters and quad bikes)'
+    '7' -> 'Blue light: light to medium commercial vehicles (including car derived vans, 4x4 variants & minibuses) up to but not including 7.5 tonnes'
+  }
+
    InvoiceFields {
     CustomerName from 'Customer Organisation Name'
     CustomerURN from 'Customer Unique Reference Number (URN)'

--- a/app/models/framework/definition/RM807.fdl
+++ b/app/models/framework/definition/RM807.fdl
@@ -3,6 +3,12 @@ Framework RM807 {
 
   ManagementCharge 0.5%
 
+  Lots {
+    '1' -> 'Passenger and Light Commercial Vehicles up to 3.5 tonnes'
+    '2' -> 'Light Commercial Vehicles up to 3.5 tonnes & Heavy Commercial Vehicles up'
+    '3' -> 'Passenger Vehicles, Light Commercial Vehicles up to3.5 tonnes & Heavy Comme to'
+  }
+
   InvoiceFields {
     LotNumber from 'Lot Number'
     optional CustomerPostCode from 'Customer PostCode'

--- a/app/models/framework/definition/RM849.fdl
+++ b/app/models/framework/definition/RM849.fdl
@@ -3,6 +3,13 @@ Framework RM849 {
 
   ManagementCharge 0.5%
 
+  Lots {
+    '1' -> 'Wash and Return'
+    '2' -> 'Linen Hire'
+    '3' -> 'Re-useable Theatre Drapes and Gowns'
+    '4' -> 'Mop Hire'
+  }
+
   InvoiceFields {
     LotNumber from 'Lot Number'
     optional SupplierReferenceNumber from 'Supplier Order Number'

--- a/app/models/framework/definition/RM858.fdl
+++ b/app/models/framework/definition/RM858.fdl
@@ -8,6 +8,17 @@ Framework RM858 {
     'Other Re-charges'     -> 0%
   }
 
+  Lots {
+    '1' -> 'Vehicle Lease - contract hire of passenger vehicles(inc 4x4s & mini buses)'
+    '2' -> 'Vehicle Lease-(contract hire of pass vehicles(inc 4x4 & mini buses) Light c'
+    '3' -> 'Vehicle Lease-contract hire of commercial vehicles 7.5 tonnes & above inc t'
+    '4' -> 'Vehicle Lease-contract hire of commercial vehicles 7.5 tonnes & above for a'
+    '5' -> 'Vehicle Lease-contract hire of buses & coaches excluding mini buses'
+    '6' -> 'Vehicle Lease-contract hire of motorcycles with the option to supply quad b'
+    '7' -> 'Vehicle Lease-single source supply of leased passenger vehicles & comm vehi'
+    '8' -> 'Vehicle Lease - fleet outsource  solution for the total mngmt & sourcing of'
+  }
+
   InvoiceFields {
     LotNumber from 'Lot Number'
     optional CustomerPostCode from 'Customer PostCode'

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -15,9 +15,9 @@ class Framework
       rule(:framework_block) do
         braced(
           spaced(metadata) >>
+          spaced(lots_block) >>
           spaced(fields_blocks) >>
-          spaced(lookups_block.as(:lookups)).maybe >>
-          spaced(lots_block).maybe
+          spaced(lookups_block.as(:lookups)).maybe
         )
       end
       rule(:framework_name)       { str('Name') >> spaced(string.as(:framework_name)) }

--- a/spec/features/admin_can_add_a_framework_spec.rb
+++ b/spec/features/admin_can_add_a_framework_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'Admin can add a framework' do
         Framework RM6060 {
           Name 'Fake framework'
           ManagementCharge 0.5% of 'Supplier Price'
+          Lots { '99' -> 'Fake' }
            InvoiceFields {
             InvoiceValue from 'Supplier Price'
           }
@@ -72,6 +73,7 @@ RSpec.feature 'Admin can add a framework' do
         Framework RM6060 {
           Name 'Fake framework'
           ManagementCharge 0.5% of 'Supplier Price'
+          Lots { '99' -> 'Fake' }
            InvoiceFields {
             String from 'Supplier Price'
           }

--- a/spec/features/admin_can_edit_a_framework_spec.rb
+++ b/spec/features/admin_can_edit_a_framework_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Admin can edit a framework' do
       Framework RM999 {
         Name 'Framework to be changed'
         ManagementCharge 0.5% of 'Supplier Price'
+        Lots { '99' -> 'Fake' }
          InvoiceFields {
           InvoiceValue from 'Supplier Price'
         }
@@ -31,6 +32,7 @@ RSpec.feature 'Admin can edit a framework' do
         Framework RM999 {
           Name 'Vehicle Leasing'
           ManagementCharge 0.5% of 'Supplier Price'
+          Lots { '99' -> 'Fake' }
            InvoiceFields {
             InvoiceValue from 'Supplier Price'
           }
@@ -100,6 +102,7 @@ RSpec.feature 'Admin can edit a framework' do
       <<~FDL
         Framewoxk RM999 {
           Name 'Vehicle Leasing'
+          Lots { '99' -> 'Fake' }
 
            InvoiceFields {
             InvoiceValue from 'Supplier Price'

--- a/spec/features/admin_can_publish_a_framework_spec.rb
+++ b/spec/features/admin_can_publish_a_framework_spec.rb
@@ -10,12 +10,12 @@ RSpec.feature 'Admin can edit a framework' do
       Framework RM999 {
         Name 'Framework to be published'
         ManagementCharge 0.5% of 'Supplier Price'
-         InvoiceFields {
-          InvoiceValue from 'Supplier Price'
-        }
         Lots {
           '1' -> 'Lot 1'
           '2' -> 'Second Lot'
+        }
+         InvoiceFields {
+          InvoiceValue from 'Supplier Price'
         }
       }
     FDL

--- a/spec/fixtures/rm3821.fdl
+++ b/spec/fixtures/rm3821.fdl
@@ -3,6 +3,23 @@ Framework RM3821 {
 
   ManagementCharge 1%
 
+  Lots {
+    '1a' -> 'Resource Planning and Management Solutions including Financial and Commercial'
+    '1b' -> 'Workflow and Case Management Solutions'
+    '1c' -> 'Data Collection, Storage and Management'
+    '1d' -> 'Data Intelligence and Analytics'
+    '2a' -> 'Business Applications'
+    '2b' -> 'Environmental and Planning'
+    '2c' -> 'Citizen Services'
+    '3a' -> 'Enterprise Applications for Health'
+    '3b' -> 'Health Information Management'
+    '3c' -> 'Community Health and Social Care'
+    '4a' -> 'Bluelight Operations'
+    '4b' -> 'Bluelight Data and Information Management'
+    '5a' -> 'Learning Applications and Platforms'
+    '5b' -> 'Academic Scheduling and Management Solutions'
+  }
+
   InvoiceFields {
     SupplierReferenceNumber from 'Order Reference Number'
     CustomerURN from 'Customer Unique Reference Number (URN)'
@@ -224,22 +241,5 @@ Framework RM3821 {
       'Skills and Quality'
       'Relationships and Engagement'
     ]
-  }
-
-  Lots {
-    '1a' -> 'Resource Planning and Management Solutions including Financial and Commercial'
-    '1b' -> 'Workflow and Case Management Solutions'
-    '1c' -> 'Data Collection, Storage and Management'
-    '1d' -> 'Data Intelligence and Analytics'
-    '2a' -> 'Business Applications'
-    '2b' -> 'Environmental and Planning'
-    '2c' -> 'Citizen Services'
-    '3a' -> 'Enterprise Applications for Health'
-    '3b' -> 'Health Information Management'
-    '3c' -> 'Community Health and Social Care'
-    '4a' -> 'Bluelight Operations'
-    '4b' -> 'Bluelight Data and Information Management'
-    '5a' -> 'Learning Applications and Platforms'
-    '5b' -> 'Academic Scheduling and Management Solutions'
   }
 }

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -222,6 +222,7 @@ RSpec.describe Framework::Definition::Generator do
             Framework RM6060 {
               Name 'Fake framework'
               ManagementCharge 0.5% of 'Supplier Price'
+              Lots { '99' -> 'Fake' }
 
               InvoiceFields {
                 InvoiceValue from 'Supplier Price'
@@ -248,6 +249,7 @@ RSpec.describe Framework::Definition::Generator do
                 CentralGovernment -> 0.5%
                 WiderPublicSector -> 1.2%
               }
+              Lots { '99' -> 'Fake' }
 
               InvoiceFields {
                 InvoiceValue from 'Supplier Price'
@@ -273,6 +275,8 @@ RSpec.describe Framework::Definition::Generator do
           Framework RM6060 {
             Name 'Fake framework'
             ManagementCharge 0.5%
+            Lots { '99' -> 'Fake' }
+
              InvoiceFields {
               InvoiceValue from 'Somewhere'
               String(..6) from 'Up to 6 chars'
@@ -391,6 +395,10 @@ RSpec.describe Framework::Definition::Generator do
             Name 'Fake framework'
             ManagementCharge 1%
 
+            Lots {
+              '99' -> 'Fake'
+            }
+
             InvoiceFields {
               InvoiceValue from 'Supplier Price'
             }
@@ -437,6 +445,7 @@ RSpec.describe Framework::Definition::Generator do
           Framework RM1043iii {
             Name 'DOS-like'
             ManagementCharge 1%
+            Lots { '99' -> 'Fake' }
 
             InvoiceFields {
               InvoiceValue from 'Supplier Price'
@@ -456,7 +465,7 @@ RSpec.describe Framework::Definition::Generator do
           Framework RM3786 {
             Name 'General Legal Advice Services'
             ManagementCharge 1.5%
-
+            Lots { '99' -> 'Fake' }
             InvoiceFields {
               ProductGroup from 'Service Type'
               ProductDescription from 'Primary Specialism' depends_on 'Service Type' {
@@ -532,6 +541,7 @@ RSpec.describe Framework::Definition::Generator do
           Framework RMTEST {
             Name ''
             ManagementCharge 0%
+            Lots { '99' -> 'Fake' }
              InvoiceFields {
               InvoiceValue from 'Supplier Price'
             }
@@ -553,6 +563,7 @@ RSpec.describe Framework::Definition::Generator do
             Framework RM1234 {
               Name 'x'
               ManagementCharge 0%
+              Lots { '99' -> 'fake' }
 
               InvoiceFields {
                 String from 'x'
@@ -593,8 +604,9 @@ RSpec.describe Framework::Definition::Generator do
           <<~FDL
             Framework RM5678 {
               Name 'x'
-
               ManagementCharge 0.5% of 'optionalfield'
+
+              Lots { '99' -> 'Fake' }
 
               InvoiceFields {
                 optional String from 'optionalfield'
@@ -626,6 +638,8 @@ RSpec.describe Framework::Definition::Generator do
                 'Damage'                       -> 0%
                 'Other Re-charges'             -> 0%
               }
+
+              Lots { '99' -> 'Fake' }
 
               InvoiceFields {
                 optional PromotionCode from 'Spend Code'

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Framework::Definition::Parser do
         Name 'Laundry Services - Wave 2'
         ManagementCharge 0%
 
+        Lots {
+          '1' -> 'Laundry Services'
+        }
+
         InvoiceFields {
           CustomerPostCode from 'Customer Postcode'
 

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe Framework do
           Framework RM999 {
             Name 'Parsed correctly'
             ManagementCharge 0.5% of 'Supplier Price'
+            Lots {
+              '1' -> 'Lot 1'
+              '2' -> 'Second Lot'
+            }
              InvoiceFields {
               InvoiceValue from 'Supplier Price'
             }
@@ -84,6 +88,7 @@ RSpec.describe Framework do
           Framework RM999 {
             Name 'Changed successfully'
             ManagementCharge 0.5% of 'Supplier Price'
+            Lots { '99' -> 'Fake' }
              InvoiceFields {
               InvoiceValue from 'Supplier Price'
             }
@@ -103,6 +108,7 @@ RSpec.describe Framework do
         <<~FDL
           Framework RM999 {
             xName 'Parsed incorrectly'
+            Lots { '99' -> 'Fake' }
             ManagementCharge 0.5% of 'Supplier Price'
              InvoiceFields {
               InvoiceValue from 'Supplier Price'
@@ -127,12 +133,12 @@ RSpec.describe Framework do
           Framework RM999 {
             Name 'Changed successfully'
             ManagementCharge 0.5% of 'Supplier Price'
-             InvoiceFields {
-              InvoiceValue from 'Supplier Price'
-            }
             Lots {
               '1' -> 'Lot 1'
               '2' -> 'Second Lot'
+            }
+            InvoiceFields {
+              InvoiceValue from 'Supplier Price'
             }
           }
         FDL
@@ -160,43 +166,6 @@ RSpec.describe Framework do
           it 'deletes that lot from the database' do
             expect { subject.load_lots! }.to change { subject.lots.count }.by(1)
             expect(subject.lots.find_by(number: '1', description: 'Lot 1')).to be_a(FrameworkLot)
-            expect(subject.lots.find_by(number: '3')).to eq(nil)
-          end
-        end
-
-        context 'that has agreements against it' do
-          let!(:agreement_framework_lot) { create(:agreement_framework_lot, framework_lot: framework_lot) }
-
-          it 'raises an error' do
-            expect { subject.load_lots! }.to raise_error(ActiveRecord::InvalidForeignKey)
-          end
-        end
-      end
-    end
-
-    context 'with an FDL without lots' do
-      let(:definition_source) do
-        <<~FDL
-          Framework RM999 {
-            Name 'Changed successfully'
-            ManagementCharge 0.5% of 'Supplier Price'
-             InvoiceFields {
-              InvoiceValue from 'Supplier Price'
-            }
-          }
-        FDL
-      end
-
-      it 'does nothing' do
-        expect { subject.load_lots! }.to_not change { subject.lots.count }
-      end
-
-      context 'when framework already has a lot' do
-        let!(:framework_lot) { create(:framework_lot, framework: framework, number: '3') }
-
-        context 'that has no agreements against it' do
-          it 'deletes that lot from the database' do
-            expect { subject.load_lots! }.to change { subject.lots.count }.by(-1)
             expect(subject.lots.find_by(number: '3')).to eq(nil)
           end
         end

--- a/spec/validators/fdl_validator_spec.rb
+++ b/spec/validators/fdl_validator_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe FdlValidator do
         Framework RM6060 {
           Name 'Fake framework'
           ManagementCharge 0.5% of 'Supplier Price'
+          Lots { '99' -> 'Fake' }
            InvoiceFields {
             InvoiceValue from 'Supplier Price'
           }
@@ -54,6 +55,7 @@ RSpec.describe FdlValidator do
           Framework RMNOINVOICEVALUE {
             Name 'x'
             ManagementCharge 0%
+            Lots { '99' -> 'Fake' }
              InvoiceFields {
               String from 'Supplier Price'
             }


### PR DESCRIPTION
When publishing a framework, we use the `Lots { ... }` block to generate FrameworkLots, so make this block mandatory.