### PR TITLE
(981) Revert the "can't be blank" validation error change

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,6 @@ en:
   errors:
     format: "%{message}"
     messages:
-      blank: 'Enter your %{attribute}'
       taken: '%{attribute} has already been taken.'
       invalid_urn: 'is not a recognised URN'
       invalid_ingested_date: 'must be in the format dd/mm/yyyy'

--- a/spec/models/submission_entry_spec.rb
+++ b/spec/models/submission_entry_spec.rb
@@ -119,6 +119,28 @@ RSpec.describe SubmissionEntry do
       end
     end
 
+    context 'with a blank required string' do
+      let(:data_hash) { valid_data_hash.merge('Associated Service' => '') }
+
+      it 'transitions state to errored' do
+        expect(entry.reload).to be_errored
+      end
+
+      it 'sets the validation errors' do
+        expect(entry.validation_errors).to eq(
+          [
+            {
+              'message' => 'can\'t be blank',
+              'location' => {
+                'row' => entry.source['row'],
+                'column' => 'Associated Service',
+              },
+            }
+          ]
+        )
+      end
+    end
+
     context 'with a lot number the supplier does not have an agreement against' do
       let(:data_hash) { valid_data_hash.merge('Lot Number' => 'XXX') }
 


### PR DESCRIPTION
When we added form validation to the admin site, we changed the validation errors that are shown to end users as well. This reverts the change, so a field with a presence validation will get  "{foo} can't be
blank" message, rather than the "Enter your {foo}".