### PR TITLE
Fix/known field missing should be transpiler error

### DIFF
--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -35,6 +35,10 @@ class Framework
           @lookups = lookups
         end
 
+        def error
+          "known field not found: '#{warehouse_name}'" if known? && DataWarehouse::KnownFields::ALL[warehouse_name].nil?
+        end
+
         def sheet_name
           field_def[:from]
         end

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -14,7 +14,7 @@ class Framework
         ast = @ast
         transpiler = self
 
-        check_management_charge_calculator_fields_are_not_optional(ast[:management_charge])
+        raise_when_management_field_optional(ast[:management_charge])
 
         Class.new(Framework::Definition::Base) do
           framework_name       ast[:framework_name]
@@ -83,19 +83,13 @@ class Framework
         end
       end
 
-      # rubocop:disable Metrics/AbcSize
-      def check_management_charge_calculator_fields_are_not_optional(info)
-        if info[:column_based] && ast.field_by_sheet_name(:invoice, info[:column_based][:column_name]).field_def[:optional]
-          raise Transpiler::Error,
-                'Management charge references ' \
-                "'#{info[:column_based][:column_name]}' so it cannot be optional"
-        elsif info[:flat_rate] && info[:flat_rate][:column].present? && ast.field_by_sheet_name(:invoice, info[:flat_rate][:column]).field_def[:optional]
-          raise Transpiler::Error,
-                'Management charge references ' \
-                "'#{info[:flat_rate][:column]}' so it cannot be optional"
+      def raise_when_management_field_optional(info)
+        optional_found = [info.dig(:column_based, :column_name), info.dig(:flat_rate, :column)].compact.find do |field_name|
+          ast.field_by_sheet_name(:invoice, field_name)&.optional?
         end
+
+        raise Transpiler::Error, "Management charge references '#{optional_found}' so it cannot be optional" if optional_found
       end
-      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -53,6 +53,8 @@ class Framework
 
           ast.field_defs(entry_type).each do |field_def|
             field = AST::Field.new(field_def, ast.lookups)
+            raise Transpiler::Error, field.error if field.error
+
             # Always use a case_insensitive_inclusion validator if
             # there's a lookup with the same name as the field
             lookup_values = ast.lookups[field.lookup_name]

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -580,6 +580,30 @@ RSpec.describe Framework::Definition::Generator do
           expect(generator.error).to eql('InvoiceFields is missing an InvoiceValue field')
         end
       end
+      context 'There is a bad reference to a known field' do
+        let(:source) do
+          <<~FDL
+            Framework RM1234 {
+              Name 'x'
+              ManagementCharge 0%
+              Lots { '99' -> 'fake' }
+
+              InvoiceFields {
+                InvoiceValue from 'x'
+                MisspelledField from 'somwhere'
+              }
+            }
+          FDL
+        end
+
+        example { expect(definition).to be_nil }
+        it      { is_expected.not_to be_success }
+        it      { is_expected.to be_error }
+
+        it 'has the error' do
+          expect(generator.error).to eql("known field not found: 'MisspelledField'")
+        end
+      end
     end
 
     context 'our FDL isn\'t valid' do


### PR DESCRIPTION
`DataWarehouse::KnownFields::NotFoundError` is not a `Transpiler::Error` so would cause crashing rather than validation failure when a known field was, well, unknown to `KnownFields`. This would cause a Rails Red Screen. Instead, make it fail validation, like so:

![image](https://user-images.githubusercontent.com/194511/59430320-e0c5f480-8dd9-11e9-805f-849e30626672.png)

Instead of slapping a `rescue` block in the middle of the `Transpiler`, add an `error` message method to `AST::Field`, and populate it if there is problem within a field. This means we can just add to that method rather than peppering `rescue` blocks throughout `transpiler.rb` when we find other semantic cases within a field that need an error.

While here, remove the Rubocop `AbcSize` disable when checking for invalid `optional` management charge references by making the method smaller and `find`ing on both places where it might occur.
