### PR TITLE
1080 allow admins to generate tasks for suppliers

### DIFF
--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -1,0 +1,27 @@
+class Admin::TasksController < AdminController
+  before_action :find_supplier
+
+  def new
+    @task = @supplier.tasks.build
+  end
+
+  def create
+    @task = @supplier.tasks.build(task_params)
+    if @task.save
+      flash[:success] = 'Task added successfully.'
+      redirect_to admin_supplier_path(@supplier)
+    else
+      render action: :new
+    end
+  end
+
+  private
+
+  def find_supplier
+    @supplier = Supplier.find(params[:supplier_id])
+  end
+
+  def task_params
+    params.require(:task).permit(:period_year, :period_month, :framework_id)
+  end
+end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -18,6 +18,10 @@ class Framework < ApplicationRecord
 
   has_one_attached :template_file
 
+  def full_name
+    "#{short_name} #{name}"
+  end
+
   def definition
     @definition ||= Definition[short_name]
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -22,8 +22,14 @@ class Task < ApplicationRecord
   scope :incomplete, -> { where.not(status: 'completed') }
 
   validates :status, presence: true
+  validates :period_year, presence: true
+  validates :period_month,
+            presence: true,
+            uniqueness: { scope: %i[supplier_id framework_id period_year], message: 'This task already exists' }
+  validates :framework_id, presence: true
+  validates :due_on, presence: true
 
-  belongs_to :framework, optional: true
+  belongs_to :framework
   belongs_to :supplier
 
   has_many :submissions, dependent: :nullify

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -29,6 +29,8 @@ class Task < ApplicationRecord
   validates :framework_id, presence: true
   validates :due_on, presence: true
 
+  before_validation :set_due_on, on: :create
+
   belongs_to :framework
   belongs_to :supplier
 
@@ -73,5 +75,13 @@ class Task < ApplicationRecord
         submission.destroy
       end
     end
+  end
+
+  private
+
+  def set_due_on
+    return if period_year.blank? || period_month.blank?
+
+    self.due_on ||= Task::ReportingPeriod.new(period_year, period_month).due_date
   end
 end

--- a/app/models/task/generator.rb
+++ b/app/models/task/generator.rb
@@ -13,7 +13,7 @@ class Task
     delegate :info, :warn, to: :logger
 
     def generate!
-      info "Creating tasks for #{Date::MONTHNAMES[month]} #{year}, falling due on #{due_date}"
+      info "Creating tasks for #{Date::MONTHNAMES[month]} #{year}"
 
       agreements.find_each do |agreement|
         task_attributes = task_attributes_for_agreement(agreement)
@@ -38,13 +38,8 @@ class Task
         framework: agreement.framework,
         supplier: agreement.supplier,
         period_month: month,
-        period_year: year,
-        due_on: due_date
+        period_year: year
       }
-    end
-
-    def due_date
-      Task::ReportingPeriod.new(year, month).due_date
     end
   end
 end

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -32,6 +32,8 @@
         No tasks for
         = @supplier.name
 
+    = link_to "Add a missing task", new_admin_supplier_task_path(@supplier)
+
 .govuk-grid-row
   .govuk-grid-column-full
     %h2.govuk-heading-m{:class => 'govuk-!-margin-top-7'}
@@ -75,8 +77,7 @@
             - framework = agreement.framework
             %tr.govuk-table__row{:id => "framework-#{framework.id}" }
               %td.govuk-table__cell
-                = framework.short_name
-                = framework.name
+                = framework.full_name
               %td.govuk-table__cell
                 = agreement.active? ? 'Active' : 'Inactive'
               %td.govuk-table__cell

--- a/app/views/admin/tasks/new.html.haml
+++ b/app/views/admin/tasks/new.html.haml
@@ -1,0 +1,14 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = simple_form_for [:admin, @supplier, @task] do |form|
+      %fieldset.govuk-fieldset
+        %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
+          %h1.govuk-fieldset__heading
+            Add task to
+            = @supplier.name
+        = render partial: 'shared/error_summary', locals: { entity: @task } if @task.errors.present?
+
+        = form.input :framework_id, collection: @supplier.frameworks.collect {|x| [x.full_name, x.id]}, include_blank: false
+        = form.input :period_year, collection: [Date.today.year, Date.today.year-1], selected: Date.today.year
+        = form.input :period_month, collection: 1..12, selected: Date.today.month
+        = form.button :submit, value: 'Create task'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
         put :deactivate
       end
       resources :submissions, only: %i[show]
+      resources :tasks, only: %i[new create]
 
       collection do
         resource :bulk_import, only: %i[new create], controller: 'supplier_bulk_imports', as: :supplier_bulk_import

--- a/spec/features/admin_can_add_a_task_to_supplier_spec.rb
+++ b/spec/features/admin_can_add_a_task_to_supplier_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin users can' do
+  context 'when there is a supplier with tasks' do
+    before do
+      stub_govuk_bank_holidays_request
+      supplier = FactoryBot.create(:supplier, name: 'First Supplier')
+      framework1 = FactoryBot.create(:framework, name: 'Framework 1')
+      FactoryBot.create(:framework, name: 'Framework 2')
+      FactoryBot.create(:agreement, framework: framework1, supplier: supplier)
+      FactoryBot.create(:task, supplier: supplier, framework: framework1, period_month: 5, period_year: 2019)
+      sign_in_as_admin
+    end
+
+    scenario 'add another task' do
+      travel_to Date.new(2019, 6, 15) do
+        visit admin_suppliers_path
+        click_on 'First Supplier'
+        click_on 'Add a missing task'
+        select '6', from: 'Period month'
+        select '2019', from: 'Period year'
+        select 'Framework 1', from: 'Framework'
+        click_button 'Create task'
+        expect(page).to have_content 'Task added successfully'
+      end
+    end
+
+    scenario 'when task already exists' do
+      travel_to Date.new(2019, 6, 15) do
+        visit admin_suppliers_path
+        click_on 'First Supplier'
+        click_on 'Add a missing task'
+        select '5', from: 'Period month'
+        select '2019', from: 'Period year'
+        select 'Framework 1', from: 'Framework'
+        click_button 'Create task'
+        expect(page).to have_content 'This task already exists'
+      end
+    end
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -177,4 +177,17 @@ RSpec.describe Task do
       expect(Submission.exists?(correction_submission_in_review.id)).to be false
     end
   end
+
+  describe '#set_due_on' do
+    it 'sets a default due on date from month and date if not set yet' do
+      stub_govuk_bank_holidays_request
+      task = FactoryBot.create(:task, due_on: nil, period_month: 1, period_year: 2019)
+      expect(task.due_on).to eq(Date.new(2019, 2, 7))
+    end
+
+    it "doesn't overwrite a set due_on" do
+      task = FactoryBot.create(:task, due_on: Date.new(2019, 3, 9), period_month: 1, period_year: 2019)
+      expect(task.due_on).to eq(Date.new(2019, 3, 9))
+    end
+  end
 end


### PR DESCRIPTION
Admins can now go to a supplier and add new tasks.

If a task already exists for that supplier on the same framework and period, then they get an error.