### PR TITLE
Address CVE-2015-9284

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'auth0', require: false
 
 # Google Login
 gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'
 
 # Admin Frontend
 gem 'haml-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     options (2.3.2)
     parallel (1.12.1)
     parser (2.5.3.0)
@@ -456,6 +459,7 @@ DEPENDENCIES
   lograge
   lolsoap
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   parslet
   pg (>= 0.18, < 2.0)
   progress_bar

--- a/app/views/admin/sessions/new.html.haml
+++ b/app/views/admin/sessions/new.html.haml
@@ -5,7 +5,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = link_to 'Start now', auth_provider_path, class: 'govuk-button govuk-button--start', id: 'start-now'
+    = button_to 'Start now', auth_provider_path, class: 'govuk-button govuk-button--start', id: 'start-now'
     %h2.govuk-heading-m
       Before you start
     %p


### PR DESCRIPTION
Github recently raised a security notification for all projects relying on omniauth, but omniauth don't have a fix for this yet. (see https://github.com/omniauth/omniauth/pull/809)

I'm therefore leaning towards what @tekin has done with https://github.com/DFE-Digital/dfe-teachers-payment-service/pull/104 and locking down the get action anyway, using the `omniauth-rails_csrf_protection` gem.