### PR TITLE
Catch more FDL semantic errors early

### DIFF
--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -125,6 +125,10 @@ class Framework
           field_def[:depends_on][:dependent_field]
         end
 
+        def dependent_field_lookup_references
+          field_def[:depends_on][:values].values
+        end
+
         def dependent_field_inclusion_values
           field_def[:depends_on][:values].each_with_object({}) do |(field_value, lookup_name), result|
             result[field_value.downcase] = lookups[lookup_name]

--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -36,7 +36,11 @@ class Framework
         end
 
         def error
-          "known field not found: '#{warehouse_name}'" if known? && DataWarehouse::KnownFields::ALL[warehouse_name].nil?
+          if known? && DataWarehouse::KnownFields::ALL[warehouse_name].nil?
+            "known field not found: '#{warehouse_name}'"
+          elsif additional? && lookups[lookup_name].nil? && PRIMITIVE_TYPES[source_type].nil?
+            "unknown type '#{lookup_name}' (neither primitive nor lookup) for #{warehouse_name}"
+          end
         end
 
         def sheet_name

--- a/app/models/framework/definition/ast/presenter.rb
+++ b/app/models/framework/definition/ast/presenter.rb
@@ -17,6 +17,10 @@ class Framework
           self.ast = ast
         end
 
+        def entry_types
+          %i[invoice contract].select { |fields_type| ast[:"#{fields_type}_fields"] }
+        end
+
         def field_defs(entry_type)
           fields_key = "#{entry_type}_fields".to_sym
           ast[fields_key]

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -1,0 +1,60 @@
+class Framework
+  module Definition
+    module AST
+      ##
+      # Given an AST::Presenter as @ast,
+      # throw the first semantic error we find via Transpiler::Error.
+      #
+      # Any error that isn't syntactic in nature is semantic. Things like:
+      #   - referencing a management charge field that doesn't exist
+      #   - referencing a management charge field that's erroneously optional
+      #   - referencing a dependent field that doesn't exist
+      #
+      # One method per type of check in #run
+      class SemanticChecker
+        attr_reader :ast
+
+        def initialize(ast)
+          @ast = ast
+        end
+
+        def run
+          raise_when_management_field_invalid(ast[:management_charge])
+          raise_when_field_invalid
+        end
+
+        private
+
+        def raise_when_field_invalid
+          ast.entry_types.each do |entry_type|
+            fields = ast.field_defs(entry_type).map { |field_def| AST::Field.new(field_def, ast.lookups) }
+            fields.each do |field|
+              raise Transpiler::Error, field.error if field.error
+
+              raise_when_dependent_reference_invalid(field, entry_type)
+            end
+          end
+        end
+
+        def raise_when_dependent_reference_invalid(field, entry_type)
+          return unless field.dependent_field_inclusion?
+
+          valid_reference = ast.field_defs(entry_type).find { |f| f[:from] == field.dependent_field }
+          return if valid_reference
+
+          raise Transpiler::Error,
+                "'#{field.sheet_name}' depends on '#{field.dependent_field}', which does not exist"
+        end
+
+        def raise_when_management_field_invalid(info)
+          referenced_field_name = [info.dig(:column_based, :column_name), info.dig(:flat_rate, :column)].compact.first(&:present?)
+          return if referenced_field_name.nil?
+
+          field = ast.field_by_sheet_name(:invoice, referenced_field_name)
+          raise Transpiler::Error, "Management charge references '#{referenced_field_name}' which does not exist" if field.nil?
+          raise Transpiler::Error, "Management charge references '#{referenced_field_name}' so it cannot be optional" if field.optional?
+        end
+      end
+    end
+  end
+end

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -622,6 +622,28 @@ RSpec.describe Framework::Definition::Generator do
       end
     end
 
+    context 'an unknown type is used on an additional field' do
+      let(:source) do
+        <<~FDL
+          Framework RM1234 {
+            Name 'x'
+            ManagementCharge 0%
+            Lots { '1' -> 'a' }
+
+            InvoiceFields {
+              InvoiceValue from 'x'
+              Dcemial Additional1 from 'somewhere'
+            }
+          }
+        FDL
+      end
+
+      it { is_expected.to be_error }
+      it 'tells us an unknown type has been used' do
+        expect(generator.error).to eql("unknown type 'Dcemial' (neither primitive nor lookup) for Additional1")
+      end
+    end
+
     context 'management charge references an optional field' do
       context 'with a flat-rate calculation' do
         let(:source) do

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -459,6 +459,28 @@ RSpec.describe Framework::Definition::Generator do
       end
     end
 
+    context 'Dependent field validation on a non-existent field' do
+      let(:source) do
+        <<~FDL
+          Framework RM3786 {
+            Name 'General Legal Advice Services'
+            ManagementCharge 1.5%
+            Lots { '99' -> 'Fake' }
+            InvoiceFields {
+              ProductDescription from 'Primary Specialism' depends_on 'Non-existent field' {
+                'Core' -> CoreSpecialisms
+              }
+              InvoiceValue from 'Supplier Price'
+            }
+          }
+        FDL
+      end
+
+      it 'has the error' do
+        expect(generator.error).to eql("'Primary Specialism' depends on 'Non-existent field', which does not exist")
+      end
+    end
+
     context 'Dependent field validation' do
       let(:source) do
         <<~FDL


### PR DESCRIPTION
# [Catch more FDL semantic errors early](https://trello.com/c/xOh0im1F/1105-catch-more-fdl-semantic-errors-early)

- **Disallow additional fields with bad types** - they would previously save and (would, I assume) blow up during ingest.
- **Disallow non-existent management charge fields** - Previously we were only checking if management charge fields were optional; extend this to fields that simply don't exist.
- **Disallow references to non-existent fields in `depends_on` clauses** - if a field in a `depends_on` doesn't exist, halt
- **Disallow references to non-existent lookups in `depends_on` blocks** - if any lookup is missing, halt

Also delete a few one-line specs; it's ok to test `error?`, `success?` and
`definition.nil?` once, but the setup takes a lot of time and we've added
a few new FDL specs lately, so speed up generator_spec by losing some
repetition.
