### PR TITLE
Release 79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [release-79] - 2019-06-19
+
+- Fix/known field missing should be transpiler error
+- Address CVE-2015-9284
+- Allow admins to generate tasks for suppliers
+- API expects a JSON Web Token for authentication
+
 ## [release-78] - 2019-06-10
 
 - Remove erroneous optional fields from RM3756's FDL
@@ -536,6 +543,7 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
+[release-79]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-78...release-79
 [release-78]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-77...release-78
 [release-77]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-76...release-77
 [release-76]: https://github.com/dxw/DataSubmissionServiceAPI/compare/release-75...release-76


### PR DESCRIPTION
- Fix/known field missing should be transpiler error
- Address CVE-2015-9284
- Allow admins to generate tasks for suppliers
- API expects a JSON Web Token for authentication