### PR TITLE
Expose submission's file key and name to API

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -93,6 +93,14 @@ class Submission < ApplicationRecord
     Hash[sheet_names.map { |sheet_name| [sheet_name, errors_for(sheet_name)] }]
   end
 
+  def file_key
+    files.first&.file_key
+  end
+
+  def filename
+    files.first&.filename
+  end
+
   private
 
   def enqueue_reversal_invoice_creation_job(user)

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -11,4 +11,8 @@ class SubmissionFile < ApplicationRecord
   def temporary_download_url
     file.attachment.service_url if file.attached?
   end
+
+  def file_key
+    file.attachment.key.to_s if file.attached?
+  end
 end

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -32,6 +32,8 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
 
   attribute :submitted_at
 
+  attributes :file_key, :filename
+
   private
 
   def submission

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -235,4 +235,36 @@ RSpec.describe Submission do
       )
     end
   end
+
+  describe '#file_key' do
+    context 'when file exists' do
+      it 'returns the file key' do
+        submission = FactoryBot.create(:completed_submission)
+        expect(submission.file_key).to eq(submission.files.first.file.attachment.key)
+      end
+    end
+
+    context 'when file does not exist' do
+      it 'returns nil' do
+        submission = FactoryBot.create(:no_business_submission)
+        expect(submission.file_key).to eq(nil)
+      end
+    end
+  end
+
+  describe '#filename' do
+    context 'when file exists' do
+      it 'returns the file name' do
+        submission = FactoryBot.create(:completed_submission)
+        expect(submission.filename).to eq(submission.files.first.file.attachment.filename.to_s)
+      end
+    end
+
+    context 'when file does not exist' do
+      it 'returns nil' do
+        submission = FactoryBot.create(:no_business_submission)
+        expect(submission.filename).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/serializable/serializable_submission_spec.rb
+++ b/spec/serializable/serializable_submission_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SerializableSubmission do
   context 'given a submission with invoices and orders' do
-    let(:submission) { FactoryBot.create(:submission, invoice_entries: 2, order_entries: 3) }
+    let(:submission) { FactoryBot.create(:completed_submission) }
     let(:serialized_submission) { SerializableSubmission.new(object: submission) }
 
     it 'exposes a count of the number of invoice entries' do
@@ -10,25 +10,33 @@ RSpec.describe SerializableSubmission do
     end
 
     it 'exposes a count of the number of order entries' do
-      expect(serialized_submission.as_jsonapi[:attributes][:order_count]).to eq(3)
+      expect(serialized_submission.as_jsonapi[:attributes][:order_count]).to eq(1)
     end
 
     it 'exposes the total value of invoice entries' do
-      expect(serialized_submission.as_jsonapi[:attributes][:invoice_total_value]).to eq(0.0)
+      expect(serialized_submission.as_jsonapi[:attributes][:invoice_total_value]).to eq(20)
     end
 
     it 'exposes the total value of order entries' do
-      expect(serialized_submission.as_jsonapi[:attributes][:order_total_value]).to eq(0.0)
+      expect(serialized_submission.as_jsonapi[:attributes][:order_total_value]).to eq(3)
     end
 
     it 'exposes a report_no_business? boolean' do
-      expect(serialized_submission.as_jsonapi[:attributes][:report_no_business?]).to eq(true)
+      expect(serialized_submission.as_jsonapi[:attributes][:report_no_business?]).to eq(false)
     end
 
     it 'exposes a sheet_errors hash' do
       expect(serialized_submission.as_jsonapi[:attributes][:sheet_errors]).to eq(
         'InvoicesRaised' => [], 'OrdersReceived' => []
       )
+    end
+
+    it 'exposes the submissions file key' do
+      expect(serialized_submission.as_jsonapi[:attributes][:file_key]).to eq(submission.file_key)
+    end
+
+    it 'exposes the submissions file name' do
+      expect(serialized_submission.as_jsonapi[:attributes][:filename]).to eq(submission.filename)
     end
   end
 end


### PR DESCRIPTION
For GPAAS, we can no longer use a temporary file URL to share a submission file with a supplier. The frontend will therefore need to know the file key to be able to use the AWS API to retrieve the file and give it to the user.

I did a slight refactor of SerializableSubmission spec, so it uses a completed submission factory, rather than a no business submission so we can better test the file key param.