### PR TITLE
Validate presence of salesforce_id on suppliers

### DIFF
--- a/app/controllers/admin/supplier_bulk_imports_controller.rb
+++ b/app/controllers/admin/supplier_bulk_imports_controller.rb
@@ -10,7 +10,7 @@ class Admin::SupplierBulkImportsController < AdminController
     redirect_to new_admin_supplier_bulk_import_path, notice: 'Successfully imported suppliers'
   rescue ActionController::ParameterMissing
     redirect_to new_admin_supplier_bulk_import_path, alert: 'Please choose a file to upload'
-  rescue ActiveRecord::RecordNotFound, ArgumentError => e
+  rescue ActiveRecord::RecordNotFound, ArgumentError, ActiveRecord::RecordInvalid => e
     redirect_to new_admin_supplier_bulk_import_path, alert: e.message
   end
 

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -10,6 +10,7 @@ class Supplier < ApplicationRecord
   has_many :active_users, -> { active }, through: :memberships, class_name: 'User', source: :user
 
   validates :name, presence: true
+  validates :salesforce_id, presence: true
   validates :coda_reference, allow_blank: true, format: {
     with: /\AC0\d{4,5}\z/,
     message: 'must start with “C0” and have 4-5 additional numbers, for example: “C012345”'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
           attributes:
             name:
               blank: 'Enter a supplier name'
+            salesforce_id:
+              blank: 'Salesforce ID cannot be blank'
   errors:
     format: "%{message}"
     messages:

--- a/spec/features/admin_can_bulk_import_suppliers_spec.rb
+++ b/spec/features/admin_can_bulk_import_suppliers_spec.rb
@@ -74,6 +74,16 @@ RSpec.feature 'Admin can bulk import suppliers' do
     end
   end
 
+  context 'with a CSV with missing salesforce_id' do
+    scenario 'displays an error, showing which columns are missing' do
+      visit new_admin_supplier_bulk_import_path
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'suppliers_with_blank_salesforce_id.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Validation failed: Salesforce ID cannot be blank'
+    end
+  end
+
   context 'with a non-CSV file' do
     scenario 'displays an error' do
       visit new_admin_supplier_bulk_import_path

--- a/spec/features/admin_can_bulk_import_users_spec.rb
+++ b/spec/features/admin_can_bulk_import_users_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Admin can bulk import users' do
   end
 
   context 'with a CSV which references a salesforce_id that does not exist' do
-    before { seema_company.update(salesforce_id: nil) }
+    before { seema_company.update(salesforce_id: 'changed') }
 
     scenario 'displays an error' do
       visit new_admin_user_bulk_import_path

--- a/spec/fixtures/suppliers_with_blank_salesforce_id.csv
+++ b/spec/fixtures/suppliers_with_blank_salesforce_id.csv
@@ -1,0 +1,6 @@
+framework_short_name,lot_number,salesforce_id,supplier_name,coda_reference
+FM1234,1,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999
+FM1234,2b,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999
+FM9999iv,3,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999
+FM9999iv,2,0010N00004FAKEFAKE,eyx Digital,C088888
+FM9999iv,3,,eyx Digital,C088888


### PR DESCRIPTION
Now that admins can add suppliers, we need to ensure that suppliers always have a salesforce ID as it is used as a unique ID.

Also catch activerecord validation errors on bulk import.