### PR TITLE
(1110) Don't create Auth0 user if they already exist

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
 
   def create_with_auth0
     return if active?
+    return if user_already_exists_in_auth0?
 
     auth0_response = auth0_client.create_user(
       name,
@@ -64,6 +65,16 @@ class User < ApplicationRecord
   end
 
   private
+
+  def user_already_exists_in_auth0?
+    auth0_response = auth0_client.get_users(q: "email:#{email}")
+    return false if auth0_response.empty?
+
+    user_id = auth0_response[0]['user_id']
+    update auth_id: user_id
+
+    true
+  end
 
   def auth0_client
     @auth0_client ||= Auth0Api.new.client


### PR DESCRIPTION
Previously, bulk importing users would rollback on failures, but the newly-created Auth0 users would still exist. On subsequent runs, those users on Auth0 would fail to create because they already exist.

This queries Auth0 first to check for an existing user. If it exists, we update the `User` with the `user_id` (aka auth_id) returned. If they don't exist, we create the user in Auth0 as before.