### PR TITLE
Use an api specific AUTH0 user service

### DIFF
--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -12,7 +12,7 @@ applications:
       - ingest-bucket-CF_SPACE
       - ADMIN_EMAILS
       - API_SECRETBASE
-      - AUTH0
+      - API_AUTH0
       - GOOGLE_CLIENT
       - ROLLBAR
       - SIDEKIQ

--- a/CF/sidekiq-manifest-template.yml
+++ b/CF/sidekiq-manifest-template.yml
@@ -10,7 +10,7 @@ applications:
       - ingest-bucket-CF_SPACE
       - ADMIN_EMAILS
       - API_SECRETBASE
-      - AUTH0
+      - API_AUTH0
       - GOOGLE_CLIENT
       - ROLLBAR
       - SIDEKIQ


### PR DESCRIPTION
In production we have 2 different AUTH0 clients with different levels of
access.

Make the API use the one with the access the API needs.