### PR TITLE
(chore) API container can be connected to through Docker by other docker applications

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     container_name: "data-submission-service-api_web"
     networks:
       public:
+        aliases:
+          - api
       private:
   worker:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       - .:/srv/dss-api:cached
     command: bash -c "rm -f tmp/pids/server.pid && rails s"
     container_name: "data-submission-service-api_web"
+    networks:
+      public:
+      private:
   worker:
     build:
       context: .
@@ -41,16 +44,27 @@ services:
       - .:/srv/dss-api:cached
     command: bash -c "bundle exec sidekiq"
     container_name: "data-submission-service-api_worker"
+    networks:
+      private:
   db:
     image: postgres
     volumes:
       - pg_data:/var/lib/postgresql/data/:cached
     restart: on-failure
     container_name: "data-submission-service-api_db"
+    networks:
+      private:
   redis:
     image: redis
     container_name: "data-submission-service-api_redis"
     expose:
       - 6379
+    networks:
+      private:
+
 volumes:
   pg_data: {}
+
+networks:
+  public:
+  private:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
     container_name: "data-submission-service-api_db"
   redis:
     image: redis
+    container_name: "data-submission-service-api_redis"
     expose:
       - 6379
 volumes:


### PR DESCRIPTION
* Before this change containers that joined the `datasubmissionserviceapi_public` network could make connections to `curl web:3100`, since internally web is defined internally as the puma container.
* Externally this was a problem since the frontend (which also has its own `web` service) has to use `curl web:3100` which doesn't make immediate sense. This alias will allow that container to use curl `api:3100`.
* Connecting to the API in this way does create a coupling between the 2 sets of docker containers. To start the frontend, Docker will ask you to first start the API so that its public network becomes available for use. I would suggest that this explicit dependency, while not fantastic, is better than waiting for the frontend to create a request before it fails and to trust the the errors are handled in a meaningful way - which they aren't right now.