### PR TITLE
(chore) Only build the docker image for the codebase once

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
       args:
         RAILS_ENV: "development"
+    image: local/data_submission_service_api_app
     ports: ["3000:3000"]
     environment:
       RAILS_ENV: "development"
@@ -27,6 +28,7 @@ services:
           - api
       private:
   worker:
+    image: local/data_submission_service_api_app
     build:
       context: .
       args:


### PR DESCRIPTION
* Before this change Sidekiq was instructed through the `build` command to find the Dockerfile and build a new image. As Sidekiq is `dependant` on `web`, web will always be built first leading to duplicate effort and time spent when starting up the service locally.
* We can use a `image` flag to store an image for reuse, calling it `app` rather than `web` since that might imply that it is connected to the `web` docker-compose service when in fact it's a generic build of the local directory for reuse by any docker service that wants it.
* `build` is still available to the Sidekiq service so it behaves conventionally with docker-compose, we should still be able to run `docker-compose build worker` in isolation if we want to however this shouldn't be a common operation.