### PR TITLE
(fix) Yarn setup when using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -qq -y build-essential libpq-dev nodejs lo
 RUN echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen en_GB.UTF-8 UTF-8 && update-locale en_GB.UTF-8 UTF-8
 ENV LANGUAGE=en_GB.UTF-8 LC_ALL=en_GB.UTF-8
 
-RUN YARN_VERSION=1.9.4 \
+RUN YARN_VERSION=1.17.3 \
   set -ex \
   && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && mkdir -p /opt/yarn \

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,11 @@ accessible-autocomplete@^1.6.2:
   dependencies:
     preact "^8.3.1"
 
+codemirror@^5.46.0:
+  version "5.48.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.48.2.tgz#a9dd3d426dea4cd59efd59cd98e20a9152a30922"
+  integrity sha512-i9VsmC8AfA5ji6EDIZ+aoSe4vt9FcwPLdHB1k1ItFbVyuOFRrcfvnoKqwZlC7EVA2UmTRiNEypE4Uo7YvzVY8Q==
+
 govuk-frontend@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-2.4.0.tgz#a4f32f09f2120166006f2d0c2aa32cccf75f95ef"


### PR DESCRIPTION
This PR makes a couple of commits to update the version of Yarn in use, and adds a missing dependency. These changes were enough to get the build to run for me.