### PR TITLE
Fix FDL double-sanitisation issue

### DIFF
--- a/app/models/framework/definition.rb
+++ b/app/models/framework/definition.rb
@@ -14,10 +14,7 @@ class Framework
           end
       end
 
-      def [](framework_short_name)
-        sanitized_framework_short_name = framework_short_name.tr('/.', '_')
-        cache[sanitized_framework_short_name]
-      end
+      delegate :[], to: :cache
     end
 
     ##

--- a/spec/fixtures/RM999_5.fdl
+++ b/spec/fixtures/RM999_5.fdl
@@ -1,0 +1,12 @@
+Framework RM999.5 {
+  Name 'Hi'
+  ManagementCharge 0.5%
+
+  Lots {
+    '1' -> 'Fake'
+  }
+
+  InvoiceFields {
+    InvoiceValue from 'Somewhere'
+  }
+}

--- a/spec/models/framework/definition_spec.rb
+++ b/spec/models/framework/definition_spec.rb
@@ -61,8 +61,22 @@ RSpec.describe Framework::Definition do
       context 'and it has full-stops in it' do
         let(:framework_short_name) { 'RM1043.5' }
 
-        it 'returns that framework' do
-          expect(definition.framework_short_name).to eql(framework_short_name)
+        context 'and the framework is on the filesystem' do
+          it 'returns that framework' do
+            expect(definition.framework_short_name).to eql(framework_short_name)
+          end
+        end
+
+        context 'and the framework is in the database' do
+          let(:framework_short_name) { 'RM999.5' }
+
+          before do
+            create :framework, :with_fdl, short_name: 'RM999.5', fdl_file: 'RM999_5.fdl'
+          end
+
+          it 'returns that framework' do
+            expect(definition.framework_short_name).to eql(framework_short_name)
+          end
         end
       end
     end


### PR DESCRIPTION
`Framework::Definition#[]` is responsible for getting a definition from
the cache. `Framework::Language#[]` is responsible for getting the source
from either the DB or the filesystem and transpiling it.

In the circumstance that a framework was in the database but had a
period in the `short_name`, a double sanitisation issue occurred, meaning
that `Language#[]` would try and look for (say) 'RM999_5' in the database
when 'RM999.5' was there, resulting in

```
Framework::Definition::MissingError: There is no framework definition for "RM999_5"
```

Take the responsibility for sanitisation away from `Definition` and leave
it with `Language` to avoid this.