### PR TITLE
(chore) Fresh docker builds will provision node_module dependencies

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,6 +14,7 @@ services:
       - docker-compose.env
     volumes:
       - .:/srv/dss-api:cached
+      - node_modules:/srv/dss-api/node_modules:cached
     depends_on:
       - db-test
     command: ["bundle", "exec", "./bin/dsetup && spring server"]
@@ -36,3 +37,4 @@ networks:
 
 volumes:
   pg_test_data: {}
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     restart: on-failure
     volumes:
       - .:/srv/dss-api:cached
+      - node_modules:/srv/dss-api/node_modules:cached
     command: bash -c "rm -f tmp/pids/server.pid && rails s"
     container_name: "data-submission-service-api_web"
     networks:
@@ -68,6 +69,7 @@ services:
 
 volumes:
   pg_data: {}
+  node_modules:
 
 networks:
   public:


### PR DESCRIPTION
* Before this change starting the container from a clean state would result in asset pipeline errors generated by gov-uk frontend assets being unavilable.
* Eventually we tracked down that whilst the install process in the Dockerfile was installing the packages correctly and putting them within the image, they were being overwritten by the docker-compose volume configuration.
* The configuration of `.:/srv/dss-api` said, mount all the files from my local directory into the directory the Docker Image had prepared, in `/srv/dss-api` - this is very helpful in development since we don't want to rebuild the docker image every time we want to refresh the webpage or run the test suite.
* This change says that the `node_modules` directory should be mounted to a prepared Docker volume which stores the contents of the install `node_modules` as originally placed by the Docker image.
* Referring back to when I have had to do this before I found that this change had to go into docker-compose.test.yml too: https://github.com/DFE-Digital/teacher-vacancy-service/commit/76096a551d4ab706a0612928ba609b0d8ca8c9ca
* We're adding `:cached` as we don't expect these files to change often, which I have found to help with performance