### PR TITLE
(1132) Update documentation for grabbing a database dump

### DIFF
--- a/docs/get-prod-db-backup.md
+++ b/docs/get-prod-db-backup.md
@@ -17,29 +17,42 @@ https://docs.cloud.service.gov.uk/get_started.html
 Accessing the PostgreSQL database also requires the 'conduit' plugin for
 Cloudfoundry. You can install this using:
 
-`cf install-plugin conduit`
+    cf install-plugin conduit
 
 ## Create a backup (currently manual)
 
 Make sure you're in the production space (called 'prod')
 
-`cf target -s prod`
+    cf target -s prod
 
 Use conduit to make a dump of the production database
 
-`cf conduit ccs-rmi-api-prod -- pg_dump -F tar --file production-backup-YYYYMMDD.tar`
+    cf conduit ccs-rmi-api-prod -- pg_dump -F tar --file production-backup-YYYYMMDD.tar
 
 The `db:restore` rake tasks expects the file to be compressed, so let's do that
 
-`gzip production-backup-YYYYMMDD.tar`
+    gzip production-backup-YYYYMMDD.tar
 
 Finally move the file into the `backups` directory ready to be restored
 
 ## Restore the backup
 
-- Since AWS has a `root` Postgres role, you'll need to create one locally.
-  The first time you do this, create one with
-  `bash# psql postgres -c "CREATE ROLE root WITH SUPERUSER LOGIN;"`
-- `DISABLE_DATABASE_ENVIRONMENT_CHECK=1 be rake db:reset_to_production` will drop your db,
-  create a new one and restore from the gzipped backup
-- To restore from a specific backup, use `rake db:restore[path_to_gzipped_backup]`
+Launch a temporary instance of the `web` service, and get a shell on it.
+
+    docker-compose run --rm web bash
+
+On this container, install the Postgres client command-line tools, and then run
+a task to load the database backup into the development database.
+
+    apt-get install postgresql-client
+    ./bin/rails db:reset_to_production
+
+This task checks your current environment to make sure it matches the one the
+database was last used in. To disable this, set this variable before running the
+`db` task.
+
+    export DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+
+If you want to restore from a specific backup file, run the `db:restore` task:
+
+    ./bin/rails db:restore[path_to_gzipped_backup]

--- a/docs/get-prod-db-backup.md
+++ b/docs/get-prod-db-backup.md
@@ -1,54 +1,45 @@
 # Getting a local copy of the prod DB
 
-This is a fairly manual process with a tiny bit of rake help at the end. 
-Hopefully we'll automate daily backups. In the meantime, there's this. 
+This is a fairly manual process with a tiny bit of rake help at the end.
+Hopefully we'll automate daily backups. In the meantime, there's this.
+
+
+## Prerequisites
+
+### Cloudfoundry
+
+GPaaS is based on Cloudfoundry, so we use their command-tools in order to access
+the infrastructure.
+
+Install the command-tool by following their setup guide
+https://docs.cloud.service.gov.uk/get_started.html
+
+Accessing the PostgreSQL database also requires the 'conduit' plugin for
+Cloudfoundry. You can install this using:
+
+`cf install-plugin conduit`
 
 ## Create a backup (currently manual)
 
-SSH into bastion with 
+Make sure you're in the production space (called 'prod')
 
-`ssh ccs.production`
+`cf target -s prod`
 
-SSH into dss-infrastructure-production with something like
+Use conduit to make a dump of the production database
 
-`ssh ec2-user@<PublicDNS>`
-e.g.
-`ssh ec2-user@ec2-3-8-197-87.eu-west-2.compute.amazonaws.com`
+`cf conduit ccs-rmi-api-prod -- pg_dump -F tar --file production-backup-YYYYMMDD.tar`
 
-The Public DNS of the container instance can be found in
-```
-  Clusters >  dss-infrastructure-production > choose container (dss-infrastructure-production) >
-      ECS instances tab > lists 2 identical containers (pick either) > copy <Public DNS>
-```       
+The `db:restore` rake tasks expects the file to be compressed, so let's do that
 
-We now need 2 things:
-- RDS ENDPOINT: Find by going to RDS > Databases > dssinfrastructureproductionapi > Endpoint. 
-  Looks something like dssinfrastructureproductionapi.cwixmd5p744n.eu-west-2.rds.amazonaws.com
-- The postgres password, which we get from `echo $DATABASE_URL` on one of the docker instances
-  - `docker exec -it <container ID, e.g. 06f047454282 from docker ps, pick API production> /bin/bash`
-  - `echo $DATABASE_URL`
-  - Copy the password from the URL
-  - `exit` the docker container
+`gzip production-backup-YYYYMMDD.tar`
 
-Then:
-  - Choose a name for the backup that corresponds to the naming convention in the `rake db:restore` task,
-    e.g. `production-backup-20190130.tar`
-  - `docker run -i postgres /usr/bin/pg_dump -F tar -h <RDS ENDPOINT> -U root dss_api > production-backup-20190130.tar`
-  - paste the password
-  - gzip the tar file `gzip production-backup-20190130.tar`
-  - Copy the `.gz` file to bastion:
-    - `exit` from AWS
-    - `scp ec2-user@<PUBLIC_DNS_NAME>:production-backup-20190130.tar.gz .`
-    - `exit` from Bastion to your local machine
-    - assuming you're in your local API working dir, `mkdir backups`
-    - `scp ccs.production:production-backup-20190130.tar.gz backups`
-    - Don't forget to remove the backup from Bastion when you are done with it
-  
+Finally move the file into the `backups` directory ready to be restored
+
 ## Restore the backup
 
 - Since AWS has a `root` Postgres role, you'll need to create one locally.
-  The first time you do this, create one with 
+  The first time you do this, create one with
   `bash# psql postgres -c "CREATE ROLE root WITH SUPERUSER LOGIN;"`
-- `DISABLE_DATABASE_ENVIRONMENT_CHECK=1 be rake db:reset_to_production` will drop your db, 
+- `DISABLE_DATABASE_ENVIRONMENT_CHECK=1 be rake db:reset_to_production` will drop your db,
   create a new one and restore from the gzipped backup
 - To restore from a specific backup, use `rake db:restore[path_to_gzipped_backup]`


### PR DESCRIPTION
The process changed when we migrated the service to GPaaS, so let's update the documentation accordingly.