### PR TITLE
[1131] Task to synchronise user information against that mastered in auth0

### DIFF
--- a/lib/sync_users_with_auth0.rb
+++ b/lib/sync_users_with_auth0.rb
@@ -2,7 +2,10 @@ class SyncUsersWithAuth0
   def self.run!
     client = Auth0Api.new.client
     User.active.each do |user|
-      auth_id = client.get_users(q: "email:#{user.email}").first.fetch('user_id')
+      response = client.get_users(q: "email:#{user.email}")
+      return Rails.logger.info("Email: #{user.email} could not be found in Auth0") if response.empty?
+
+      auth_id = response.first.fetch('user_id')
       user.update(auth_id: auth_id) if user.auth_id != auth_id
     end
   end

--- a/lib/sync_users_with_auth0.rb
+++ b/lib/sync_users_with_auth0.rb
@@ -1,7 +1,11 @@
+require 'auth0'
+
 class SyncUsersWithAuth0
   def self.run!(dry: false)
     client = Auth0Api.new.client
     User.active.each do |user|
+      delay_request unless Rails.env.test?
+
       response = client.get_users(q: "email:#{user.email}")
       return Rails.logger.info("Email: #{user.email} could not be found in Auth0") if response.empty?
 
@@ -15,5 +19,9 @@ class SyncUsersWithAuth0
         end
       end
     end
+  end
+
+  def self.delay_request
+    sleep 0.1
   end
 end

--- a/lib/sync_users_with_auth0.rb
+++ b/lib/sync_users_with_auth0.rb
@@ -7,7 +7,11 @@ class SyncUsersWithAuth0
         delay_request unless Rails.env.test?
 
         response = auth0_client.get_users(q: "email:#{user.email}")
-        return Rails.logger.info("Email: #{user.email} could not be found in Auth0") if response.empty?
+
+        if response.empty?
+          Rails.logger.info("Email: #{user.email} could not be found in Auth0")
+          next
+        end
 
         update_user(user: user, response: response, dry: dry)
       end

--- a/lib/sync_users_with_auth0.rb
+++ b/lib/sync_users_with_auth0.rb
@@ -35,6 +35,7 @@ class SyncUsersWithAuth0
         Rails.logger.info("Would have updated (#{user.email}) to (#{auth_id}).")
       else
         user.update(auth_id: auth_id)
+        Rails.logger.info("Updated (#{user.email}) to (#{auth_id}).")
       end
     end
   end

--- a/lib/sync_users_with_auth0.rb
+++ b/lib/sync_users_with_auth0.rb
@@ -1,0 +1,9 @@
+class SyncUsersWithAuth0
+  def self.run!
+    client = Auth0Api.new.client
+    User.active.each do |user|
+      auth_id = client.get_users(q: "email:#{user.email}").first.fetch('user_id')
+      user.update(auth_id: auth_id) if user.auth_id != auth_id
+    end
+  end
+end

--- a/lib/sync_users_with_auth0.rb
+++ b/lib/sync_users_with_auth0.rb
@@ -1,12 +1,19 @@
 class SyncUsersWithAuth0
-  def self.run!
+  def self.run!(dry: false)
     client = Auth0Api.new.client
     User.active.each do |user|
       response = client.get_users(q: "email:#{user.email}")
       return Rails.logger.info("Email: #{user.email} could not be found in Auth0") if response.empty?
 
       auth_id = response.first.fetch('user_id')
-      user.update(auth_id: auth_id) if user.auth_id != auth_id
+
+      if user.auth_id != auth_id
+        if dry
+          Rails.logger.info("Would have updated (#{user.email}) to (#{auth_id}).")
+        else
+          user.update(auth_id: auth_id)
+        end
+      end
     end
   end
 end

--- a/spec/lib/sync_users_with_auth0_spec.rb
+++ b/spec/lib/sync_users_with_auth0_spec.rb
@@ -40,8 +40,23 @@ RSpec.describe SyncUsersWithAuth0 do
       end
     end
 
-    context 'when the user email cannot be found' do
-      it 'logs a warning to the developer'
+    context 'when the user email cannot be found in auth0' do
+      it 'logs a warning to the developer' do
+        user_that_only_exists_in_the_api = create(:user)
+
+        stub_auth0_get_users_request(
+          email: user_that_only_exists_in_the_api.email,
+          auth_id: user_that_only_exists_in_the_api.auth_id,
+          user_already_exists: false
+        )
+
+        expect(Rails.logger).to receive(:info)
+          .with("Email: #{user_that_only_exists_in_the_api.email} could not be found in Auth0")
+
+        described_class.run!
+
+        expect(user.changed?).to eq(false)
+      end
     end
 
     context 'when called with the dry-run true' do

--- a/spec/lib/sync_users_with_auth0_spec.rb
+++ b/spec/lib/sync_users_with_auth0_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe SyncUsersWithAuth0 do
         user_already_exists: true
       )
 
+      expect(Rails.logger).to receive(:info)
+        .with("Updated (#{user.email}) to (auth0|the-new-value).")
+
       described_class.run!
 
       expect(user.reload.auth_id).to eq('auth0|the-new-value')

--- a/spec/lib/sync_users_with_auth0_spec.rb
+++ b/spec/lib/sync_users_with_auth0_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+require 'sync_users_with_auth0'
+
+RSpec.describe SyncUsersWithAuth0 do
+  before(:each) do
+    stub_auth0_token_request
+  end
+
+  describe '.run!' do
+    it 'updates local user record auth_id fields with the auth0 value' do
+      known_out_of_sync_user_email = 'email@example.com'
+      user = create(:user, email: known_out_of_sync_user_email, auth_id: 'auth0|an-old-value')
+
+      stub_auth0_get_users_request(
+        email: known_out_of_sync_user_email,
+        auth_id: 'auth0|the-new-value',
+        user_already_exists: true
+      )
+
+      described_class.run!
+
+      expect(user.reload.auth_id).to eq('auth0|the-new-value')
+    end
+
+    context 'when the auth_id matches' do
+      it 'does not change the user record' do
+        email = 'email@example.com'
+        user = create(:user, email: email, auth_id: 'auth0|an-old-value')
+
+        stub_auth0_get_users_request(
+          email: email,
+          auth_id: 'auth0|the-old-value',
+          user_already_exists: true
+        )
+
+        described_class.run!
+
+        expect(user.changed?).to eq(false)
+        expect(user.reload.auth_id).to eq('auth0|the-old-value')
+      end
+    end
+
+    context 'when the user email cannot be found' do
+      it 'logs a warning to the developer'
+    end
+
+    context 'when called with the dry-run true' do
+      it 'does not perform the update, but logs that it would have tried' do
+      end
+    end
+  end
+end

--- a/spec/support/auth0_helpers.rb
+++ b/spec/support/auth0_helpers.rb
@@ -20,4 +20,16 @@ module Auth0Helpers
       .with(body: hash_including(email: email))
       .to_return(status: 500, body: '')
   end
+
+  def stub_auth0_get_users_request(email:, auth_id:, user_already_exists: false)
+    stubbed_response = if user_already_exists
+                         [{ email: email, user_id: auth_id }]
+                       else
+                         []
+                       end
+
+    stub_request(:get, 'https://testdomain/api/v2/users')
+      .with(query: hash_including(q: "email:#{email}"))
+      .to_return(status: 200, body: stubbed_response.to_json)
+  end
 end


### PR DESCRIPTION
* When any user is removed and re-added from auth0 directly as opposed to the built-in admin functionality, the API's User table is not updated with the new `auth_id` value which is crucial for each user to retrieve their data from the API.
* This could also conceivably happen during any network error between the API and Auth0, or if there is any other error upstream of the initial create request made from the admin area.
* It is important to note that Auth0 is the canonical store for the correct `auth_id` values.
* This new class can be used directly from the console to reconcile all users held locally against those in the respective Auth0 application. It can be used to resync all users, and be reused again in future if any of the above happens again. If this happens often we imagine we could use it as the basis of a new automated task to reduce the time needed to run it.
* As it's quite a risky procedure, it can be ran in dry mode to see what impact would be had if it was run there and then.


