### PR TITLE
[1131] Creating users in Auth0 no longer fails if the local user is missing

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -41,7 +41,7 @@ class Admin::UsersController < AdminController
 
   def destroy
     @user = User.find(params[:id])
-    @user.deactivate
+    DeactivateUser.new(user: @user).call
     flash[:alert] = 'User has been deactivated'
     redirect_to admin_users_path
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -25,11 +25,9 @@ class Admin::UsersController < AdminController
 
   def edit
     @user = User.find(params[:id])
-    @user.create_with_auth0
-  rescue Auth0::Exception => e
-    flash[:alert] = 'There was an error adding the user to Auth0. Please try again.'
-    Rails.logger.error("Error adding user #{@user.email} to Auth0 during User#edit, message: #{e.message}")
-  ensure
+    result = ReactivateUser.new(user: @user).call
+    flash[:alert] = I18n.t('error_adding_user_to_auth0') if result.failure?
+
     redirect_to admin_user_path(@user)
   end
 

--- a/app/models/import/users/row.rb
+++ b/app/models/import/users/row.rb
@@ -22,11 +22,9 @@ module Import
       end
 
       def create_user!
-        User.transaction do
-          user = User.create!(email: email, name: name)
-          user.create_with_auth0
-          user
-        end
+        user = User.new(email: email, name: name)
+        CreateUser.new(user: user).call
+        user
       end
     end
   end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,0 +1,9 @@
+Result = Struct.new(:success) do
+  def success?
+    success == true
+  end
+
+  def failure?
+    !success
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
 
   def create_with_auth0
     return if active?
+    return if user_already_exists_in_auth0?
 
     auth0_response = auth0_client.create_user(
       name,
@@ -67,5 +68,17 @@ class User < ApplicationRecord
 
   def auth0_client
     @auth0_client ||= Auth0Api.new.client
+  end
+
+  def user_already_exists_in_auth0?
+    auth0_response = auth0_client.get_users(q: "email:#{email}")
+    auth0_client.headers = auth0_client.headers.except(:params)
+
+    return false if auth0_response.empty?
+
+    user_id = auth0_response[0]['user_id']
+    update auth_id: user_id
+
+    true
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,20 +31,6 @@ class User < ApplicationRecord
     suppliers.count > 1
   end
 
-  def create_with_auth0
-    return if active?
-    return if user_already_exists_in_auth0?
-
-    auth0_response = auth0_client.create_user(
-      name,
-      email: email,
-      email_verified: true,
-      password: temporary_password,
-      connection: 'Username-Password-Authentication',
-    )
-    update auth_id: auth0_response.fetch('user_id')
-  end
-
   def delete_on_auth0
     auth0_client.delete_user(auth_id)
     update auth_id: nil
@@ -60,25 +46,9 @@ class User < ApplicationRecord
     delete_on_auth0
   end
 
-  def temporary_password
-    "#{SecureRandom.urlsafe_base64}aA1!"
-  end
-
   private
 
   def auth0_client
     @auth0_client ||= Auth0Api.new.client
-  end
-
-  def user_already_exists_in_auth0?
-    auth0_response = auth0_client.get_users(q: "email:#{email}")
-    auth0_client.headers = auth0_client.headers.except(:params)
-
-    return false if auth0_response.empty?
-
-    user_id = auth0_response[0]['user_id']
-    update auth_id: user_id
-
-    true
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,24 +31,7 @@ class User < ApplicationRecord
     suppliers.count > 1
   end
 
-  def delete_on_auth0
-    auth0_client.delete_user(auth_id)
-    update auth_id: nil
-  end
-
   def active?
     !auth_id.nil?
-  end
-
-  def deactivate
-    return unless active?
-
-    delete_on_auth0
-  end
-
-  private
-
-  def auth0_client
-    @auth0_client ||= Auth0Api.new.client
   end
 end

--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -1,0 +1,24 @@
+class CreateUser
+  attr_accessor :user
+
+  def initialize(user:)
+    self.user = user
+  end
+
+  def call
+    result = Result.new(true)
+
+    User.transaction do
+      user.save
+      begin
+        CreateUserInAuth0.new(user: user).call
+      rescue Auth0::Exception
+        result.success = false
+        Rails.logger.error("Error adding user #{user.email} to Auth0 during CreateUser")
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    result
+  end
+end

--- a/app/services/create_user_in_auth0.rb
+++ b/app/services/create_user_in_auth0.rb
@@ -1,0 +1,49 @@
+require './lib/auth0_api'
+
+class CreateUserInAuth0
+  attr_accessor :user
+
+  def initialize(user:)
+    self.user = user
+  end
+
+  def call
+    return if updated_existing_user!
+
+    auth0_response = auth0_client.create_user(
+      user.name,
+      email: user.email,
+      email_verified: true,
+      password: CreateUserInAuth0.temporary_password,
+      connection: 'Username-Password-Authentication',
+    )
+    user.update(auth_id: auth0_response.fetch('user_id'))
+  end
+
+  def self.temporary_password
+    "#{SecureRandom.urlsafe_base64}aA1!"
+  end
+
+  private
+
+  def auth0_client
+    @auth0_client ||= Auth0Api.new.client
+  end
+
+  def updated_existing_user!
+    return false if existing_user_id.blank?
+
+    user.update(auth_id: existing_user_id)
+    true
+  end
+
+  def existing_user_id
+    @existing_user_id ||= begin
+      auth0_response = auth0_client.get_users(q: "email:#{user.email}")
+      auth0_client.headers = auth0_client.headers.except(:params)
+      return nil if auth0_response.empty?
+
+      auth0_response[0].dig('user_id')
+    end
+  end
+end

--- a/app/services/create_user_in_auth0.rb
+++ b/app/services/create_user_in_auth0.rb
@@ -38,12 +38,6 @@ class CreateUserInAuth0
   end
 
   def existing_user_id
-    @existing_user_id ||= begin
-      auth0_response = auth0_client.get_users(q: "email:#{user.email}")
-      auth0_client.headers = auth0_client.headers.except(:params)
-      return nil if auth0_response.empty?
-
-      auth0_response[0].dig('user_id')
-    end
+    @existing_user_id ||= FindUserInAuth0.new(user: user).call
   end
 end

--- a/app/services/deactivate_user.rb
+++ b/app/services/deactivate_user.rb
@@ -1,0 +1,24 @@
+class DeactivateUser
+  attr_accessor :user
+
+  def initialize(user:)
+    self.user = user
+  end
+
+  def call
+    result = Result.new(true)
+
+    User.transaction do
+      begin
+        DeleteUserInAuth0.new(user: user).call
+      rescue Auth0::Exception
+        result.success = false
+        Rails.logger.error("Error adding user #{user.email} to Auth0 during DeactivateUser")
+        raise ActiveRecord::Rollback
+      end
+      user.update(auth_id: nil)
+    end
+
+    result
+  end
+end

--- a/app/services/delete_user_in_auth0.rb
+++ b/app/services/delete_user_in_auth0.rb
@@ -1,0 +1,19 @@
+class DeleteUserInAuth0
+  attr_accessor :user
+
+  def initialize(user:)
+    self.user = user
+  end
+
+  def call
+    return unless user.active?
+
+    auth0_client.delete_user(user.auth_id)
+  end
+
+  private
+
+  def auth0_client
+    @auth0_client ||= Auth0Api.new.client
+  end
+end

--- a/app/services/find_user_in_auth0.rb
+++ b/app/services/find_user_in_auth0.rb
@@ -1,0 +1,23 @@
+require './lib/auth0_api'
+
+class FindUserInAuth0
+  attr_accessor :user
+
+  def initialize(user:)
+    self.user = user
+  end
+
+  def call
+    auth0_response = auth0_client.get_users(q: "email:#{user.email}")
+    auth0_client.headers = auth0_client.headers.except(:params)
+    return nil if auth0_response.empty?
+
+    auth0_response[0].dig('user_id')
+  end
+
+  private
+
+  def auth0_client
+    @auth0_client ||= Auth0Api.new.client
+  end
+end

--- a/app/services/reactivate_user.rb
+++ b/app/services/reactivate_user.rb
@@ -1,0 +1,20 @@
+class ReactivateUser
+  attr_accessor :user
+
+  def initialize(user:)
+    self.user = user
+  end
+
+  def call
+    result = Result.new(true)
+
+    begin
+      CreateUserInAuth0.new(user: user).call
+    rescue Auth0::Exception
+      result.success = false
+      Rails.logger.error("Error adding user #{user.email} to Auth0 during ReactivateUser")
+    end
+
+    result
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,3 +30,4 @@ en:
       invalid_optional_ingested_date: 'must be in the format dd/mm/yyyy or left blank'
       invalid_lot_number: 'is not included in the supplier framework agreement'
       invalid_dependent_field: '"%{value}" is not a valid %{attr} for the given %{parent_field_name} of "%{parent_field_value}". Please refer to the lookups tab in the template.'
+      error_adding_user_to_auth0: 'There was an error adding the user to Auth0. Please try again.'

--- a/spec/features/adding_a_user_spec.rb
+++ b/spec/features/adding_a_user_spec.rb
@@ -6,6 +6,8 @@ RSpec.feature 'Adding a user' do
   before do
     allow(Rails.logger).to receive(:error)
     stub_auth0_token_request
+
+    stub_auth0_get_users_request(email: email)
     stub_auth0_create_user_request(email)
 
     sign_in_as_admin
@@ -34,6 +36,7 @@ RSpec.feature 'Adding a user' do
 
   scenario 'with Auth0 error' do
     email = 'bla@example.com'
+    stub_auth0_get_users_request(email: email)
     stub_auth0_create_user_request_failure(email)
 
     click_on 'Users'

--- a/spec/features/adding_a_user_spec.rb
+++ b/spec/features/adding_a_user_spec.rb
@@ -45,9 +45,9 @@ RSpec.feature 'Adding a user' do
     fill_in 'Email address', with: 'bla@example.com'
     click_button 'Add new user'
 
-    expect(page).to have_content('There was an error adding the user to Auth0.')
+    expect(page).to have_content(I18n.t('error_adding_user_to_auth0'))
     expect(User.find_by(email: email)).to be_nil
     expect(Rails.logger).to have_received(:error)
-      .with(/Error adding user bla@example.com to Auth0 during User#create/)
+      .with(/Error adding user bla@example.com to Auth0 during CreateUser/)
   end
 end

--- a/spec/features/admin_can_bulk_import_users_spec.rb
+++ b/spec/features/admin_can_bulk_import_users_spec.rb
@@ -11,6 +11,9 @@ RSpec.feature 'Admin can bulk import users' do
 
   before do
     stub_auth0_token_request
+
+    stub_auth0_get_users_request(email: jamila_email)
+    stub_auth0_get_users_request(email: seema_email)
     stub_auth0_create_user_request(jamila_email)
     stub_auth0_create_user_request(seema_email)
 

--- a/spec/features/reactivating_a_user_spec.rb
+++ b/spec/features/reactivating_a_user_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Reactivating a user' do
   before do
     allow(Rails.logger).to receive(:error)
     stub_auth0_token_request
+    stub_auth0_get_users_request(email: user.email)
     sign_in_as_admin
   end
 

--- a/spec/features/reactivating_a_user_spec.rb
+++ b/spec/features/reactivating_a_user_spec.rb
@@ -29,8 +29,8 @@ RSpec.feature 'Reactivating a user' do
     click_on 'Reactivate user'
     click_on 'Reactivate user'
 
-    expect(page).to have_content('There was an error adding the user to Auth0.')
+    expect(page).to have_content(I18n.t('error_adding_user_to_auth0'))
     expect(Rails.logger).to have_received(:error)
-      .with(/Error adding user #{user.email} to Auth0 during User#edit/)
+      .with(/Error adding user #{user.email} to Auth0 during ReactivateUser/)
   end
 end

--- a/spec/models/import/users/row_spec.rb
+++ b/spec/models/import/users/row_spec.rb
@@ -32,15 +32,6 @@ RSpec.describe Import::Users::Row do
       it 'associates the user with its supplier' do
         expect(result.suppliers).to contain_exactly(matching_supplier)
       end
-
-      context 'when Auth0 errors' do
-        let!(:auth0_create_call) { stub_auth0_create_user_request_failure(email) }
-
-        it 'does not save the user' do
-          expect { row.import! }.to raise_error(Auth0::ServerError)
-          expect(User.find_by(email: email)).to be_nil
-        end
-      end
     end
 
     context 'with a pre-existing user' do

--- a/spec/models/import/users/row_spec.rb
+++ b/spec/models/import/users/row_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Import::Users::Row do
     let(:salesforce_id) { 'SALESFORCE123' }
 
     let!(:matching_supplier) { FactoryBot.create(:supplier, salesforce_id: salesforce_id) }
+    let!(:auth0_check_exists_call) { stub_auth0_get_users_request(email: email) }
     let!(:auth0_create_call) { stub_auth0_create_user_request(email) }
 
     let(:row) { Import::Users::Row.new(email: email, name: name, supplier_salesforce_id: salesforce_id) }

--- a/spec/models/import/users_spec.rb
+++ b/spec/models/import/users_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Import::Users do
     let(:importer) { Import::Users.new(csv_path, wait_time: 0, logger: Logger.new('/dev/null')) }
 
     before do
+      stub_auth0_get_users_request(email: jamila_email)
       stub_auth0_create_user_request(jamila_email)
+      stub_auth0_get_users_request(email: seema_email)
       stub_auth0_create_user_request(seema_email)
       stub_auth0_token_request
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,52 +29,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#create_with_auth0' do
-    let(:user) { FactoryBot.create(:user, :inactive) }
-    let!(:auth0_check_user_exists) { stub_auth0_get_users_request(email: user.email) }
-    let!(:auth0_create_call) { stub_auth0_create_user_request(user.email) }
-
-    before(:each) do
-      stub_auth0_token_request
-    end
-
-    it 'submits to Auth0 and updates auth_id' do
-      user.create_with_auth0
-
-      expect(auth0_create_call).to have_been_requested
-      expect(user.auth_id).to eq("auth0|#{user.email}")
-    end
-
-    context 'with a user whose email address already exists in Auth0' do
-      let!(:auth0_check_user_exists) do
-        stub_auth0_get_users_request(
-          email: user.email,
-          auth_id: 'auth0|456',
-          user_already_exists: true
-        )
-      end
-
-      it 'updates auth_id from the current Auth0 user' do
-        user.create_with_auth0
-
-        expect(auth0_check_user_exists).to have_been_requested
-        expect(auth0_create_call).not_to have_been_requested
-        expect(user.auth_id).to eq('auth0|456')
-      end
-    end
-  end
-
-  describe '#temporary_password' do
-    it 'conforms to the Auth0 criteria' do
-      password = User.new.temporary_password
-
-      expect(password).to match(/[a-z]/)
-      expect(password).to match(/[A-Z]/)
-      expect(password).to match(/[0-9]/)
-      expect(password).to match(/[!@#$%^&*]/)
-    end
-  end
-
   describe '#active?' do
     subject { user.active? }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,15 +31,36 @@ RSpec.describe User, type: :model do
 
   describe '#create_with_auth0' do
     let(:user) { FactoryBot.create(:user, :inactive) }
+    let!(:auth0_check_user_exists) { stub_auth0_get_users_request(email: user.email) }
     let!(:auth0_create_call) { stub_auth0_create_user_request(user.email) }
 
-    before { stub_auth0_token_request }
+    before(:each) do
+      stub_auth0_token_request
+    end
 
     it 'submits to Auth0 and updates auth_id' do
       user.create_with_auth0
 
       expect(auth0_create_call).to have_been_requested
       expect(user.auth_id).to eq("auth0|#{user.email}")
+    end
+
+    context 'with a user whose email address already exists in Auth0' do
+      let!(:auth0_check_user_exists) do
+        stub_auth0_get_users_request(
+          email: user.email,
+          auth_id: 'auth0|456',
+          user_already_exists: true
+        )
+      end
+
+      it 'updates auth_id from the current Auth0 user' do
+        user.create_with_auth0
+
+        expect(auth0_check_user_exists).to have_been_requested
+        expect(auth0_create_call).not_to have_been_requested
+        expect(user.auth_id).to eq('auth0|456')
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,48 +45,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#delete_on_auth0' do
-    let(:user) { FactoryBot.create(:user) }
-    let!(:auth0_delete_call) { stub_auth0_delete_user_request(user) }
-
-    before { stub_auth0_token_request }
-
-    it 'deletes user on Auth0 and nils auth_id' do
-      user.delete_on_auth0
-
-      expect(auth0_delete_call).to have_been_requested
-      expect(user.auth_id).to eq(nil)
-    end
-  end
-
-  describe '#deactivate' do
-    let!(:auth0_delete_call) { stub_auth0_delete_user_request(user) }
-
-    before { stub_auth0_token_request }
-
-    context 'an active user' do
-      let(:user) { FactoryBot.create(:user) }
-
-      it 'deletes user on Auth0 and nils auth_id' do
-        user.deactivate
-
-        expect(auth0_delete_call).to have_been_requested
-        expect(user.auth_id).to eq(nil)
-      end
-    end
-
-    context 'an inactive user' do
-      let(:user) { FactoryBot.create(:user, :inactive) }
-
-      it 'does not do anything' do
-        user.deactivate
-
-        expect(auth0_delete_call).not_to have_been_requested
-        expect(user.auth_id).to eq(nil)
-      end
-    end
-  end
-
   describe '.search' do
     let!(:bob) { FactoryBot.create(:user, name: 'Bob Booker', email: 'bob@sheffield.com') }
     let!(:bobby) { FactoryBot.create(:user, name: 'Bobby Brown', email: 'bobby_b_66@hotmail.com') }

--- a/spec/services/create_user_in_auth0_spec.rb
+++ b/spec/services/create_user_in_auth0_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe CreateUserInAuth0 do
+  describe '#call' do
+    let(:user) { create(:user, :inactive) }
+
+    subject { described_class.new(user: user).call }
+
+    before(:each) do
+      stub_auth0_token_request
+    end
+
+    it 'creates the user in Auth0 and updates the local user auth_id' do
+      stub_auth0_get_users_request(email: user.email)
+      auth0_create_call = stub_auth0_create_user_request(user.email)
+
+      subject
+
+      expect(auth0_create_call).to have_been_requested
+      expect(user.auth_id).to eq("auth0|#{user.email}")
+    end
+
+    context 'when the user already has an auth_id' do
+      let(:user) { create(:user, auth_id: 'auth|old') }
+
+      context 'when the ID is different from Auth0' do
+        it 'updates the user with the version found in auth0' do
+          stub_auth0_get_users_request(
+            email: user.email,
+            auth_id: 'auth|new',
+            user_already_exists: true
+          )
+
+          subject
+
+          expect(user.auth_id).to eq('auth|new')
+        end
+      end
+
+      context 'when the auth_id is the same as Auth0 for that email' do
+        let(:user) { create(:user, auth_id: 'auth|old') }
+
+        it 'does not perform an update' do
+          stub_auth0_get_users_request(
+            email: user.email,
+            auth_id: 'auth|old',
+            user_already_exists: true
+          )
+
+          subject
+
+          expect(user.changed?).to eq(false)
+          expect(user.auth_id).to eq('auth|old')
+        end
+
+        it 'does not send a create request to Auth0' do
+          stub_auth0_get_users_request(
+            email: user.email,
+            auth_id: 'auth|old',
+            user_already_exists: true
+          )
+
+          auth0_create_call = stub_auth0_create_user_request(user.email)
+
+          subject
+
+          expect(auth0_create_call).not_to have_been_requested
+        end
+      end
+    end
+
+    context 'with a user whose email address already exists in Auth0' do
+      it 'updates auth_id from the current Auth0 user' do
+        auth0_check_user_exists = stub_auth0_get_users_request(
+          email: user.email,
+          auth_id: 'auth0|456',
+          user_already_exists: true
+        )
+        auth0_create_call = stub_auth0_create_user_request(user.email)
+
+        subject
+
+        expect(auth0_check_user_exists).to have_been_requested
+        expect(auth0_create_call).not_to have_been_requested
+        expect(user.auth_id).to eq('auth0|456')
+      end
+    end
+  end
+
+  describe '#temporary_password' do
+    it 'conforms to the Auth0 criteria' do
+      password = described_class.temporary_password
+
+      expect(password).to match(/[a-z]/)
+      expect(password).to match(/[A-Z]/)
+      expect(password).to match(/[0-9]/)
+      expect(password).to match(/[!@#$%^&*]/)
+    end
+  end
+end

--- a/spec/services/create_user_spec.rb
+++ b/spec/services/create_user_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe CreateUser do
+  let(:user) { build(:user, auth_id: nil) }
+  before(:each) do
+    stub_auth0_token_request
+    stub_auth0_get_users_request(email: user.email)
+  end
+
+  describe '#call' do
+    it 'returns a successful result' do
+      stub_auth0_create_user_request(user.email)
+
+      result = described_class.new(user: user).call
+
+      expect(result.success?).to eq(true)
+      expect(result.failure?).to eq(false)
+    end
+
+    context 'when Auth0 errors' do
+      before(:each) do
+        stub_auth0_create_user_request_failure(user.email)
+      end
+
+      it 'returns a failed result' do
+        result = described_class.new(user: user).call
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'does not save the user' do
+        described_class.new(user: user).call
+        expect(User.find_by(email: user.email)).to be_nil
+      end
+
+      it 'logs a failure message' do
+        expect(Rails.logger).to receive(:error)
+          .with("Error adding user #{user.email} to Auth0 during CreateUser")
+        described_class.new(user: user).call
+      end
+    end
+  end
+end

--- a/spec/services/deactivate_user_spec.rb
+++ b/spec/services/deactivate_user_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe DeactivateUser do
+  let(:user) { create(:user) }
+  before(:each) do
+    stub_auth0_token_request
+  end
+
+  describe '#call' do
+    it 'returns a successful result' do
+      stub_auth0_delete_user_request(user)
+
+      result = described_class.new(user: user).call
+
+      expect(result.success?).to eq(true)
+      expect(result.failure?).to eq(false)
+    end
+
+    context 'when Auth0 errors' do
+      before(:each) do
+        stub_auth0_delete_user_request_failure(user)
+      end
+
+      it 'returns a failed result' do
+        result = described_class.new(user: user).call
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'does not update the user' do
+        original_auth_id = user.auth_id
+        described_class.new(user: user).call
+        expect(user.auth_id).to eql(original_auth_id)
+      end
+
+      it 'logs a failure message' do
+        expect(Rails.logger).to receive(:error)
+          .with("Error adding user #{user.email} to Auth0 during DeactivateUser")
+        described_class.new(user: user).call
+      end
+    end
+  end
+end

--- a/spec/services/delete_user_in_auth0_spec.rb
+++ b/spec/services/delete_user_in_auth0_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe DeleteUserInAuth0 do
+  describe '#call' do
+    let(:user) { create(:user) }
+
+    subject { described_class.new(user: user).call }
+
+    before(:each) do
+      stub_auth0_token_request
+    end
+
+    it 'deletes the user in Auth0' do
+      auth0_delete_call = stub_auth0_delete_user_request(user)
+
+      subject
+
+      expect(auth0_delete_call).to have_been_requested
+    end
+
+    context 'an inactive user' do
+      let(:user) { create(:user, :inactive) }
+
+      it 'does not do anything' do
+        auth0_delete_call = stub_auth0_delete_user_request(user)
+
+        subject
+
+        expect(auth0_delete_call).not_to have_been_requested
+      end
+    end
+  end
+end

--- a/spec/services/find_user_in_auth0_spec.rb
+++ b/spec/services/find_user_in_auth0_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+require 'auth0'
+
+RSpec.describe FindUserInAuth0 do
+  describe '#call' do
+    let(:user) { create(:user, :inactive) }
+
+    subject { described_class.new(user: user).call }
+
+    before(:each) do
+      stub_auth0_token_request
+    end
+
+    it 'returns the auth_id for an existing user' do
+      stub_auth0_get_users_request(
+        email: user.email,
+        auth_id: 'auth|old',
+        user_already_exists: true
+      )
+
+      result = subject
+
+      expect(result).to eq('auth|old')
+    end
+
+    context 'when that email does not exist' do
+      it 'returns nil' do
+        stub_auth0_get_users_request(
+          email: user.email,
+          user_already_exists: false
+        )
+
+        result = subject
+
+        expect(result).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/services/reactivate_user_spec.rb
+++ b/spec/services/reactivate_user_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe ReactivateUser do
+  let(:user) { create(:user, auth_id: nil) }
+
+  before(:each) do
+    stub_auth0_token_request
+    stub_auth0_get_users_request(email: user.email)
+  end
+
+  describe '#call' do
+    it 'returns a successful result' do
+      stub_auth0_create_user_request(user.email)
+
+      result = described_class.new(user: user).call
+
+      expect(result.success?).to eq(true)
+      expect(result.failure?).to eq(false)
+    end
+
+    context 'when Auth0 errors' do
+      before(:each) do
+        stub_auth0_create_user_request_failure(user.email)
+      end
+
+      it 'returns a failed result' do
+        result = described_class.new(user: user).call
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'does not update the user' do
+        described_class.new(user: user).call
+        expect(user.changed?).to eq(false)
+      end
+
+      it 'logs a failure message' do
+        expect(Rails.logger).to receive(:error)
+          .with("Error adding user #{user.email} to Auth0 during ReactivateUser")
+        described_class.new(user: user).call
+      end
+    end
+  end
+end

--- a/spec/support/auth0_helpers.rb
+++ b/spec/support/auth0_helpers.rb
@@ -21,7 +21,7 @@ module Auth0Helpers
       .to_return(status: 500, body: '')
   end
 
-  def stub_auth0_get_users_request(email:, auth_id:, user_already_exists: false)
+  def stub_auth0_get_users_request(email:, auth_id: 'auth|123', user_already_exists: false)
     stubbed_response = if user_already_exists
                          [{ email: email, user_id: auth_id }]
                        else

--- a/spec/support/auth0_helpers.rb
+++ b/spec/support/auth0_helpers.rb
@@ -9,6 +9,11 @@ module Auth0Helpers
       .to_return(status: 200, body: '')
   end
 
+  def stub_auth0_delete_user_request_failure(user)
+    stub_request(:delete, "https://testdomain/api/v2/users/#{user.auth_id}")
+      .to_return(status: 500, body: '')
+  end
+
   def stub_auth0_create_user_request(email)
     stub_request(:post, 'https://testdomain/api/v2/users')
       .with(body: hash_including(email: email))


### PR DESCRIPTION
This pull request is hopefully fixed in the second commit https://github.com/dxw/DataSubmissionServiceAPI/commit/395d77122db097c679ecfa14d2bf41f2530ad0f7. I felt uncomfortable in how long it took me to be confident in what the system was doing given the way responsibilities were handled, especially the distinction between local users and user records in Auth0. I did a number of retrospective refactorings as I wasn't sure how deep the rabbit hole would go, it turned out to be manageable and I believe it's worth proposing here.

## Changes in this PR:
- creation of users with using the individual creation form, or the bulk upload feature will continue to work if any email address already exists in Auth0 but no longer exist locally. This was happening during a bulk upload where one record would fail and rollback. This meant the CSV used in the upload had to be edited to remove all those that had succeeded. 
- creating a user that exists locally and exists with Auth0 will continue to return a form error that "the user already exists with this email address"
- refactor external API logic away from the User model into service objects, and away from the logic responsible for representing the data of a user
- refactor business logic away from the User Controller into service objects, so exception handling, and knowledge of what methods need to be called and in what order can be deferred to dedicated objects that are reusable


