### PR TITLE
Fix/error handling for connection problems with workday

### DIFF
--- a/app/models/workday/commercial_agreements.rb
+++ b/app/models/workday/commercial_agreements.rb
@@ -1,4 +1,5 @@
 module Workday
+  class ConnectionError < StandardError; end
   class CommercialAgreements
     def revenue_category_ids
       result = {}
@@ -27,14 +28,24 @@ module Workday
     end
 
     def commercial_agreement_xml
-      @commercial_agreement_xml ||= HTTP.basic_auth(
-        user: Workday.username,
-        pass: Workday.api_password
-      ).get(
-        'https://wd3-impl-services1.workday.com/ccx/service/customreport2/' +
-        Workday.tenant +
-        '/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category'
-      ).to_s
+      @commercial_agreement_xml ||= commercial_agreement.to_s
+    end
+
+    def commercial_agreement
+      @commercial_agreement ||= begin
+        result = HTTP.basic_auth(
+          user: Workday.username,
+          pass: Workday.api_password
+        ).get(
+          'https://wd3-impl-services1.workday.com/ccx/service/customreport2/' +
+          Workday.tenant +
+          '/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category'
+        )
+
+        raise Workday::ConnectionError if result.status == 500
+
+        result
+      end
     end
   end
 end

--- a/app/models/workday/commercial_agreements.rb
+++ b/app/models/workday/commercial_agreements.rb
@@ -1,38 +1,40 @@
-class Workday::CommercialAgreements
-  def revenue_category_ids
-    result = {}
-    report_entries.each do |report_entry|
-      framework_number = report_entry.at_xpath('wd:Framework_Number').text
-      revenue_category_wid_xml = report_entry.at_xpath('wd:Revenue_Category_ID/wd:ID[@wd:type="clRevenueCategory"]')
-      result[framework_number] = revenue_category_wid_xml.text if revenue_category_wid_xml
+module Workday
+  class CommercialAgreements
+    def revenue_category_ids
+      result = {}
+      report_entries.each do |report_entry|
+        framework_number = report_entry.at_xpath('wd:Framework_Number').text
+        revenue_category_wid_xml = report_entry.at_xpath('wd:Revenue_Category_ID/wd:ID[@wd:type="clRevenueCategory"]')
+        result[framework_number] = revenue_category_wid_xml.text if revenue_category_wid_xml
+      end
+      result
     end
-    result
-  end
 
-  def tax_code_ids
-    result = {}
-    report_entries.each do |report_entry|
-      framework_number = report_entry.at_xpath('wd:Framework_Number').text
-      tax_code_xml = report_entry.at_xpath('wd:Tax_Code_Reference/wd:ID[@wd:type="commercialAgreementTaxCode"]')
-      result[framework_number] = tax_code_xml.text if tax_code_xml
+    def tax_code_ids
+      result = {}
+      report_entries.each do |report_entry|
+        framework_number = report_entry.at_xpath('wd:Framework_Number').text
+        tax_code_xml = report_entry.at_xpath('wd:Tax_Code_Reference/wd:ID[@wd:type="commercialAgreementTaxCode"]')
+        result[framework_number] = tax_code_xml.text if tax_code_xml
+      end
+      result
     end
-    result
-  end
 
-  private
+    private
 
-  def report_entries
-    @report_entries ||= Nokogiri(commercial_agreement_xml).xpath('//wd:Report_Entry')
-  end
+    def report_entries
+      @report_entries ||= Nokogiri(commercial_agreement_xml).xpath('//wd:Report_Entry')
+    end
 
-  def commercial_agreement_xml
-    @commercial_agreement_xml ||= HTTP.basic_auth(
-      user: Workday.username,
-      pass: Workday.api_password
-    ).get(
-      'https://wd3-impl-services1.workday.com/ccx/service/customreport2/' +
-      Workday.tenant +
-      '/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category'
-    ).to_s
+    def commercial_agreement_xml
+      @commercial_agreement_xml ||= HTTP.basic_auth(
+        user: Workday.username,
+        pass: Workday.api_password
+      ).get(
+        'https://wd3-impl-services1.workday.com/ccx/service/customreport2/' +
+        Workday.tenant +
+        '/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category'
+      ).to_s
+    end
   end
 end

--- a/spec/models/workday/commercial_agreements_spec.rb
+++ b/spec/models/workday/commercial_agreements_spec.rb
@@ -24,5 +24,15 @@ RSpec.describe Workday::CommercialAgreements do
         'A206100' => 'GBC20'
       )
     end
+
+    context 'when the workday API returns a 500 status code' do
+      it 'raises an error' do
+        stub_request(:get, 'https://wd3-impl-services1.workday.com/ccx/service/customreport2/tenant/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category')
+          .with(headers: { 'Authorization' => 'Basic dXNlcjpwYXNzd29yZA==' })
+          .to_return(status: 500, body: '')
+
+        expect { subject.tax_code_ids }.to raise_error(Workday::ConnectionError)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR:
- model is testable as an isolated file through RSpec by changing the class/module hierarchy
- catch a 500 response from workday and raise this as an explicitly named error rather than an obscure error of: `Nokogiri::XML::XPath::SyntaxError (ERROR: Undefined namespace prefix: //wd:Report_Entry)` to bubble up

From a staging console we can see what the real behaviour of a 500 from the Workday API is and how that string is being sent to Nokogiri without checks:

![Screenshot 2019-08-07 at 16 41 45](https://user-images.githubusercontent.com/912473/62636984-7f7e5580-b932-11e9-9d26-bd963a5d479e.png)
