### PR TITLE
Remove gzip from db restore and improve the docs

### DIFF
--- a/docs/get-prod-db-backup.md
+++ b/docs/get-prod-db-backup.md
@@ -29,11 +29,12 @@ Use conduit to make a dump of the production database
 
     cf conduit ccs-rmi-api-prod -- pg_dump -F tar --file production-backup-YYYYMMDD.tar
 
-The `db:restore` rake tasks expects the file to be compressed, so let's do that
+At the time of writing, this command takes about 15 minutes to run. For most of
+that time the `production-backup.tar` file will not grow, remaining at around 20
+MB in size -- if you notice that, it does not mean the command has got stuck.
+The final file size will be around 2 GB.
 
-    gzip production-backup-YYYYMMDD.tar
-
-Finally move the file into the `backups` directory ready to be restored
+Finally move the file into the `backups` directory ready to be restored.
 
 ## Restore the backup
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,21 +1,21 @@
 namespace :db do
-  PRODUCTION_BACKUP_TAR_GZS = 'backups/production-backup-*.tar.gz'.freeze
+  PRODUCTION_BACKUP_TARS = 'backups/production-backup-*.tar'.freeze
 
   def database_url
     ENV.fetch('DATABASE_URL').split('?').first
   end
 
   def find_latest_backup
-    Dir[PRODUCTION_BACKUP_TAR_GZS].sort.reverse.first
+    Dir[PRODUCTION_BACKUP_TARS].sort.reverse.first
   end
 
-  desc 'Restore from a gzipped backup'
+  desc 'Restore from a backup'
   task :restore, %i[filename user] => :environment do |_task, args|
     filename = args[:filename] || find_latest_backup or
-      raise ArgumentError, "[filename] required when no #{PRODUCTION_BACKUP_TAR_GZS} found"
+      raise ArgumentError, "[filename] required when no #{PRODUCTION_BACKUP_TARS} found"
 
-    STDERR.puts("Unzipping / restoring from #{filename}")
-    system "gunzip -c #{filename} | pg_restore -d '#{database_url}'"
+    STDERR.puts("Restoring from #{filename}")
+    system 'pg_restore', '-d', database_url, filename
   end
 
   desc 'Wipe out your local DB and replace with latest from ./backups'


### PR DESCRIPTION
## Changes in this PR:

This makes a couple of usability improvements to the `db:restore` task and related documentation, based on the experience of some of us getting the application running.