### PR TITLE
(chore) Copy filesystem FDL into the database

### DIFF
--- a/db/migrate/20190814160454_import_framework_definitions.rb
+++ b/db/migrate/20190814160454_import_framework_definitions.rb
@@ -1,0 +1,13 @@
+class ImportFrameworkDefinitions < ActiveRecord::Migration[5.2]
+  def up
+    fdl_root = Rails.root.join('app', 'models', 'framework', 'definition')
+
+    Framework.where(definition_source: nil).each do |framework|
+      name   = framework.short_name.tr('./', '_')
+      path   = fdl_root.join("#{name}.fdl")
+      source = path.exist? ? path.read : nil
+
+      framework.update!(definition_source: source)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_15_174954) do
+ActiveRecord::Schema.define(version: 2019_08_14_160454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
This migration finds all the Frameworks that do not have a
definition_source in the database, and populates this field from the FDL
on disk.

I have verified that all Frameworks we currently have in production are
matched to a FDL in the filesystem, and all FDL currently in the
filesystem is imported by this migration.