### PR TITLE
[1141] Allow multiple fields in depends_on clauses

### DIFF
--- a/app/models/framework/definition/ast/any.rb
+++ b/app/models/framework/definition/ast/any.rb
@@ -1,0 +1,23 @@
+class Framework
+  module Definition
+    module AST
+      Any = Class.new do
+        def downcase
+          self
+        end
+
+        def ==(_other)
+          true
+        end
+
+        def to_s
+          '*'
+        end
+
+        def inspect
+          '<Any>'
+        end
+      end.new
+    end
+  end
+end

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -13,6 +13,7 @@ class Framework
         rule(integer: sequence(:nil)) { nil } # .maybe produces { integer: [] } for empty
         rule(string: sequence(:nil))  { '' }  # Blank strings produce { string: [] }
 
+        rule(any_operator: simple(:a))                    { Any }
         rule(lookup_reference: simple(:r))                { LookupReference.new(r) }
 
         # Just stripping Parslet::Slice

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -70,14 +70,11 @@ class Framework
           end
         end
 
-        # dictionary key/value pairs
-        rule(key: simple(:key), value: simple(:value)) { { key => value } }
-
         # Transform a CST sequence like [{ key1 => value1}, { key2 => value2}] to a
         # real hash                      { key1 => value1, key2 => value2 }
         rule(dictionary: subtree(:dictionary)) do
           dictionary.each_with_object({}) do |kv, result|
-            result[kv.keys.first] = kv.values.first
+            result[kv[:key]] = kv[:value]
           end
         end
 

--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -121,8 +121,8 @@ class Framework
           field_def[:depends_on].present?
         end
 
-        def dependent_field
-          field_def[:depends_on][:dependent_field]
+        def dependent_fields
+          field_def[:depends_on][:dependent_fields]
         end
 
         def dependent_field_lookup_references

--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -122,7 +122,7 @@ class Framework
         end
 
         def dependent_fields
-          field_def[:depends_on][:dependent_fields]
+          [*field_def[:depends_on][:dependent_fields]]
         end
 
         def dependent_field_lookup_references
@@ -131,7 +131,8 @@ class Framework
 
         def dependent_field_inclusion_values
           field_def[:depends_on][:values].each_with_object({}) do |(field_value, lookup_name), result|
-            result[field_value.downcase] = lookups[lookup_name]
+            field_values = [*field_value].map(&:downcase)
+            result[field_values] = lookups[lookup_name]
           end
         end
 

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -27,7 +27,7 @@ class Framework
 
           def add_inclusion_validators(lookup_values)
             options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
-            options[:dependent_field_inclusion] =  { parent: field.dependent_field, in: { field.dependent_field => field.dependent_field_inclusion_values } } if field.dependent_field_inclusion?
+            options[:dependent_field_inclusion] =  { parent: field.dependent_fields, in: { field.dependent_fields => field.dependent_field_inclusion_values } } if field.dependent_field_inclusion?
           end
 
           def set_length_options!

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -27,7 +27,7 @@ class Framework
 
           def add_inclusion_validators(lookup_values)
             options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
-            options[:dependent_field_inclusion] =  { parent: field.dependent_fields, in: { field.dependent_fields => field.dependent_field_inclusion_values } } if field.dependent_field_inclusion?
+            options[:dependent_field_inclusion] =  { parent: field.dependent_fields, in: field.dependent_field_inclusion_values } if field.dependent_field_inclusion?
           end
 
           def set_length_options!

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -27,7 +27,7 @@ class Framework
 
           def add_inclusion_validators(lookup_values)
             options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
-            options[:dependent_field_inclusion] =  { parent: field.dependent_fields, in: field.dependent_field_inclusion_values } if field.dependent_field_inclusion?
+            options[:dependent_field_inclusion] =  { parents: field.dependent_fields, in: field.dependent_field_inclusion_values } if field.dependent_field_inclusion?
           end
 
           def set_length_options!

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -30,11 +30,10 @@ class Framework
             fields = ast.field_defs(entry_type).map { |field_def| AST::Field.new(field_def, ast.lookups) }
             fields.each do |field|
               raise Transpiler::Error, field.error if field.error
+              next unless field.dependent_field_inclusion?
 
-              if field.dependent_field_inclusion?
-                raise_when_dependent_reference_invalid(field, entry_type)
-                raise_when_lookup_reference_invalid(field)
-              end
+              raise_when_dependent_reference_invalid(field, entry_type)
+              raise_when_lookup_reference_invalid(field)
             end
           end
         end

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -40,11 +40,13 @@ class Framework
         end
 
         def raise_when_dependent_reference_invalid(field, entry_type)
-          valid_reference = ast.field_defs(entry_type).find { |f| f[:from] == field.dependent_fields }
-          return if valid_reference
+          field.dependent_fields.each do |dependent_field|
+            valid_reference = ast.field_defs(entry_type).find { |f| f[:from] == dependent_field }
+            next if valid_reference
 
-          raise Transpiler::Error,
-                "'#{field.sheet_name}' depends on '#{field.dependent_fields}', which does not exist"
+            raise Transpiler::Error,
+                  "'#{field.sheet_name}' depends on '#{dependent_field}', which does not exist"
+          end
         end
 
         def raise_when_lookup_reference_invalid(field)

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -33,6 +33,7 @@ class Framework
               next unless field.dependent_field_inclusion?
 
               raise_when_dependent_reference_invalid(field, entry_type)
+              raise_when_dependent_reference_has_mismatched_arity(field)
               raise_when_lookup_reference_invalid(field)
             end
           end
@@ -46,6 +47,23 @@ class Framework
             raise Transpiler::Error,
                   "'#{field.sheet_name}' depends on '#{dependent_field}', which does not exist"
           end
+        end
+
+        def raise_when_dependent_reference_has_mismatched_arity(field)
+          num_dependent_fields = field.dependent_fields.size
+
+          field.dependent_field_inclusion_values.each_key do |key|
+            next if key.size == num_dependent_fields
+
+            raise Transpiler::Error,
+                  "'#{field.sheet_name}' depends on #{num_dependent_fields} fields " \
+                  "#{format_string_list(field.dependent_fields)} but contains a match on " \
+                  "#{key.size} values #{format_string_list(key)}"
+          end
+        end
+
+        def format_string_list(array)
+          '(' + array.map { |value| "'#{value}'" }.join(', ') + ')'
         end
 
         def raise_when_lookup_reference_invalid(field)

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -40,11 +40,11 @@ class Framework
         end
 
         def raise_when_dependent_reference_invalid(field, entry_type)
-          valid_reference = ast.field_defs(entry_type).find { |f| f[:from] == field.dependent_field }
+          valid_reference = ast.field_defs(entry_type).find { |f| f[:from] == field.dependent_fields }
           return if valid_reference
 
           raise Transpiler::Error,
-                "'#{field.sheet_name}' depends on '#{field.dependent_field}', which does not exist"
+                "'#{field.sheet_name}' depends on '#{field.dependent_fields}', which does not exist"
         end
 
         def raise_when_lookup_reference_invalid(field)

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -57,13 +57,14 @@ class Framework
 
             raise Transpiler::Error,
                   "'#{field.sheet_name}' depends on #{num_dependent_fields} fields " \
-                  "#{format_string_list(field.dependent_fields)} but contains a match on " \
-                  "#{key.size} values #{format_string_list(key)}"
+                  "#{format_list(field.dependent_fields)} but contains a match on " \
+                  "#{key.size} values #{format_list(key)}"
           end
         end
 
-        def format_string_list(array)
-          '(' + array.map { |value| "'#{value}'" }.join(', ') + ')'
+        def format_list(array)
+          values = array.map { |value| value.is_a?(String) ? "'#{value}'" : value }
+          '(' + values.join(', ') + ')'
         end
 
         def raise_when_lookup_reference_invalid(field)

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -50,14 +50,22 @@ class Framework
 
       rule(:lots_block)           { str('Lots') >> space >> dictionary.as(:lots) }
 
-      rule(:depends_on)           { (spaced(str('depends_on')) >> spaced(string).as(:dependent_field) >> dictionary.as(:values)).as(:depends_on) }
+      rule(:depends_on)           { (spaced(str('depends_on')) >> dependent_fields.as(:dependent_fields) >> multi_key_dictionary.as(:values)).as(:depends_on) }
+      rule(:dependent_fields)     { dependent_field >> (spaced(str(',')) >> dependent_field).repeat }
+      rule(:dependent_field)      { spaced(string) }
 
       rule(:metadata)             { framework_name >> management_charge }
 
-      rule(:map)                  { allowable_key.as(:key) >> spaced(str('->')) >> allowable_value.as(:value) >> space? }
       rule(:allowable_key)        { string | pascal_case_identifier }
       rule(:allowable_value)      { percentage | lookup_reference | string }
-      rule(:dictionary)           { braced(map.repeat(1).as(:dictionary)) }
+      rule(:dictionary)           { braced(map_with(allowable_key).repeat(1).as(:dictionary)) }
+
+      rule(:allowable_keys)       { allowable_key >> (spaced(str(',')) >> allowable_key).repeat }
+      rule(:multi_key_dictionary) { braced(map_with(allowable_keys).repeat(1).as(:dictionary)) }
+
+      def map_with(key)
+        key.as(:key) >> spaced(str('->')) >> allowable_value.as(:value) >> space?
+      end
 
       rule(:string) do
         str("'") >> (

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -60,8 +60,10 @@ class Framework
       rule(:allowable_value)      { percentage | lookup_reference | string }
       rule(:dictionary)           { braced(map_with(allowable_key).repeat(1).as(:dictionary)) }
 
-      rule(:allowable_keys)       { allowable_key >> (spaced(str(',')) >> allowable_key).repeat }
-      rule(:multi_key_dictionary) { braced(map_with(allowable_keys).repeat(1).as(:dictionary)) }
+      rule(:allowable_multi_keys) { allowable_multi_key >> (spaced(str(',')) >> allowable_multi_key).repeat }
+      rule(:allowable_multi_key)  { allowable_key | any_operator }
+      rule(:any_operator)         { str('*').as(:any_operator) }
+      rule(:multi_key_dictionary) { braced(map_with(allowable_multi_keys).repeat(1).as(:dictionary)) }
 
       def map_with(key)
         key.as(:key) >> spaced(str('->')) >> allowable_value.as(:value) >> space?

--- a/app/validators/dependent_field_inclusion_validator.rb
+++ b/app/validators/dependent_field_inclusion_validator.rb
@@ -3,12 +3,11 @@ class DependentFieldInclusionValidator < ActiveModel::EachValidator
     parent_field_name = options[:parent]
     parent_field_value = record.attributes[parent_field_name]
 
-    parent_field_name_lookup = parent_field_name&.downcase
     parent_field_value_lookup = parent_field_value&.downcase
 
     mapping = options[:in].deep_transform_keys { |key| key.to_s.downcase }
 
-    valid_values = mapping.dig(parent_field_name_lookup, parent_field_value_lookup)&.map(&:downcase) || []
+    valid_values = mapping[parent_field_value_lookup]&.map(&:downcase) || []
     return if value&.downcase&.in?(valid_values)
 
     record.errors.add(

--- a/app/validators/dependent_field_inclusion_validator.rb
+++ b/app/validators/dependent_field_inclusion_validator.rb
@@ -1,14 +1,10 @@
 class DependentFieldInclusionValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    parent_field_names = options[:parents]
-    parent_field_values = parent_field_names.map { |name| record.attributes[name] }
-
+    parent_field_values = get_parent_field_values(record)
     parent_field_value_lookup = parent_field_values.map { |v| v&.downcase }
 
-    mapping = options[:in].deep_transform_keys { |key| key.map(&:downcase) }
-
-    valid_values = mapping[parent_field_value_lookup]&.map(&:downcase) || []
-    return if value&.downcase&.in?(valid_values)
+    valid_values = get_valid_values(parent_field_value_lookup)
+    return if valid_values.include?(value&.downcase)
 
     record.errors.add(
       attribute,
@@ -18,5 +14,23 @@ class DependentFieldInclusionValidator < ActiveModel::EachValidator
       parent_field_name: parent_field_names.join(', '),
       parent_field_value: parent_field_values.join(', ')
     )
+  end
+
+  private
+
+  def parent_field_names
+    options[:parents]
+  end
+
+  def get_parent_field_values(record)
+    parent_field_names.map { |name| record.attributes[name] }
+  end
+
+  def get_valid_values(lookup_key)
+    mapping = options[:in].deep_transform_keys { |key| key.map(&:downcase) }
+    matching_key = mapping.keys.find { |key| key == lookup_key }
+    matching_values = matching_key ? mapping[matching_key] : []
+
+    matching_values.map(&:downcase)
   end
 end

--- a/app/validators/dependent_field_inclusion_validator.rb
+++ b/app/validators/dependent_field_inclusion_validator.rb
@@ -1,11 +1,11 @@
 class DependentFieldInclusionValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    parent_field_name = options[:parent]
-    parent_field_value = record.attributes[parent_field_name]
+    parent_field_names = options[:parents]
+    parent_field_values = parent_field_names.map { |name| record.attributes[name] }
 
-    parent_field_value_lookup = parent_field_value&.downcase
+    parent_field_value_lookup = parent_field_values.map { |v| v&.downcase }
 
-    mapping = options[:in].deep_transform_keys { |key| key.to_s.downcase }
+    mapping = options[:in].deep_transform_keys { |key| key.map(&:downcase) }
 
     valid_values = mapping[parent_field_value_lookup]&.map(&:downcase) || []
     return if value&.downcase&.in?(valid_values)
@@ -15,8 +15,8 @@ class DependentFieldInclusionValidator < ActiveModel::EachValidator
       :invalid_dependent_field,
       value: value,
       attr: attribute,
-      parent_field_name: parent_field_name,
-      parent_field_value: parent_field_value
+      parent_field_name: parent_field_names.join(', '),
+      parent_field_value: parent_field_values.join(', ')
     )
   end
 end

--- a/spec/models/framework/definition/ast/field_spec.rb
+++ b/spec/models/framework/definition/ast/field_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Framework::Definition::AST::Field do
 
       it 'expands the Lot Segments out to their literal values' do
         expect(field.dependent_field_inclusion_values).to eq(
-          '2' => ['Car Derived Van', 'LCV', 'MPV', 'Pickup'],
-          '3' => ['HGV'],
+          ['2'] => ['Car Derived Van', 'LCV', 'MPV', 'Pickup'],
+          ['3'] => ['HGV'],
         )
       end
     end

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -345,16 +345,13 @@ RSpec.describe Framework::Definition::Generator do
         subject(:invoice_class) { definition::Invoice }
         let(:mappings) do
           {
-            'Lot Number' =>
-             {
-               '1' => invoice_class.lookups['Lot1Segment'],
-               '2' => invoice_class.lookups['Lot2Segment'],
-               '3' => invoice_class.lookups['Lot3Segment'],
-               '4' => invoice_class.lookups['Lot4Segment'],
-               '5' => invoice_class.lookups['Lot5Segment'],
-               '6' => invoice_class.lookups['Lot6Segment'],
-               '7' => invoice_class.lookups['Lot7Segment']
-             }
+            '1' => invoice_class.lookups['Lot1Segment'],
+            '2' => invoice_class.lookups['Lot2Segment'],
+            '3' => invoice_class.lookups['Lot3Segment'],
+            '4' => invoice_class.lookups['Lot4Segment'],
+            '5' => invoice_class.lookups['Lot5Segment'],
+            '6' => invoice_class.lookups['Lot6Segment'],
+            '7' => invoice_class.lookups['Lot7Segment']
           }
         end
 
@@ -538,9 +535,7 @@ RSpec.describe Framework::Definition::Generator do
             dependent_field_inclusion: {
               parent: 'Service Type',
               in: {
-                'Service Type' => {
-                  'core' => %w[Hi], 'non-core' => %w[There], 'mixture' => %w[Hi There]
-                }
+                'core' => %w[Hi], 'non-core' => %w[There], 'mixture' => %w[Hi There]
               }
             }
           )
@@ -550,11 +545,7 @@ RSpec.describe Framework::Definition::Generator do
           is_expected.to have_field('Going to Additional1').validated_by(
             dependent_field_inclusion: {
               parent: 'Product Class',
-              in: {
-                'Product Class' => {
-                  '1' => ['Hi'], '2' => ['There']
-                }
-              }
+              in: { '1' => ['Hi'], '2' => ['There'] }
             }
           )
         }

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -552,6 +552,38 @@ RSpec.describe Framework::Definition::Generator do
       end
     end
 
+    context 'mismatched depends_on fields and values' do
+      let(:source) do
+        <<~FDL
+          Framework RM3786 {
+            Name 'General Legal Advice Services'
+            ManagementCharge 1.5%
+            Lots { '99' -> 'Fake' }
+            InvoiceFields {
+              ProductClass from 'Product Class'
+              ProductDescription from 'Description'
+              ProductGroup from 'Product Group' depends_on 'Product Class', 'Description' {
+                'a', 'b', 'c' -> ProductGroup
+              }
+              InvoiceValue from 'Supplier Price'
+            }
+            Lookups {
+              ProductGroup [
+                'Core'
+              ]
+            }
+          }
+        FDL
+      end
+
+      it 'has the error' do
+        expect(generator.error).to eql(
+          "'Product Group' depends on 2 fields ('Product Class', 'Description') " \
+          "but contains a match on 3 values ('a', 'b', 'c')"
+        )
+      end
+    end
+
     context 'invalid depends_on fields' do
       let(:source) do
         <<~FDL

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -497,6 +497,7 @@ RSpec.describe Framework::Definition::Generator do
               String Additional1 from 'Going to Additional1' depends_on 'Service Type', 'Product Class' {
                 'Core', '1' -> SomeLookup
                 'Mixture', '2' -> SomeOtherLookup
+                'Non-core', * -> SomeCombinationOfLookups
               }
             }
 
@@ -545,7 +546,11 @@ RSpec.describe Framework::Definition::Generator do
           is_expected.to have_field('Going to Additional1').validated_by(
             dependent_field_inclusion: {
               parents: ['Service Type', 'Product Class'],
-              in: { ['core', '1'] => ['Hi'], ['mixture', '2'] => ['There'] }
+              in: {
+                ['core', '1'] => ['Hi'],
+                ['mixture', '2'] => ['There'],
+                ['non-core', Framework::Definition::AST::Any] => ['Hi', 'There']
+              }
             }
           )
         }
@@ -563,7 +568,7 @@ RSpec.describe Framework::Definition::Generator do
               ProductClass from 'Product Class'
               ProductDescription from 'Description'
               ProductGroup from 'Product Group' depends_on 'Product Class', 'Description' {
-                'a', 'b', 'c' -> ProductGroup
+                'a', *, 'c' -> ProductGroup
               }
               InvoiceValue from 'Supplier Price'
             }
@@ -579,7 +584,7 @@ RSpec.describe Framework::Definition::Generator do
       it 'has the error' do
         expect(generator.error).to eql(
           "'Product Group' depends on 2 fields ('Product Class', 'Description') " \
-          "but contains a match on 3 values ('a', 'b', 'c')"
+          "but contains a match on 3 values ('a', *, 'c')"
         )
       end
     end

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -345,19 +345,19 @@ RSpec.describe Framework::Definition::Generator do
         subject(:invoice_class) { definition::Invoice }
         let(:mappings) do
           {
-            '1' => invoice_class.lookups['Lot1Segment'],
-            '2' => invoice_class.lookups['Lot2Segment'],
-            '3' => invoice_class.lookups['Lot3Segment'],
-            '4' => invoice_class.lookups['Lot4Segment'],
-            '5' => invoice_class.lookups['Lot5Segment'],
-            '6' => invoice_class.lookups['Lot6Segment'],
-            '7' => invoice_class.lookups['Lot7Segment']
+            ['1'] => invoice_class.lookups['Lot1Segment'],
+            ['2'] => invoice_class.lookups['Lot2Segment'],
+            ['3'] => invoice_class.lookups['Lot3Segment'],
+            ['4'] => invoice_class.lookups['Lot4Segment'],
+            ['5'] => invoice_class.lookups['Lot5Segment'],
+            ['6'] => invoice_class.lookups['Lot6Segment'],
+            ['7'] => invoice_class.lookups['Lot7Segment']
           }
         end
 
         it {
           is_expected.to have_field('Vehicle Segment')
-            .validated_by(dependent_field_inclusion: { parent: 'Lot Number', in: mappings })
+            .validated_by(dependent_field_inclusion: { parents: ['Lot Number'], in: mappings })
         }
 
         it {
@@ -494,9 +494,9 @@ RSpec.describe Framework::Definition::Generator do
               }
               InvoiceValue from 'Supplier Price'
               ProductClass from 'Product Class'
-              String Additional1 from 'Going to Additional1' depends_on 'Product Class' {
-                '1' -> SomeLookup
-                '2' -> SomeOtherLookup
+              String Additional1 from 'Going to Additional1' depends_on 'Service Type', 'Product Class' {
+                'Core', '1' -> SomeLookup
+                'Mixture', '2' -> SomeOtherLookup
               }
             }
 
@@ -533,9 +533,9 @@ RSpec.describe Framework::Definition::Generator do
         it {
           is_expected.to have_field('Primary Specialism').validated_by(
             dependent_field_inclusion: {
-              parent: 'Service Type',
+              parents: ['Service Type'],
               in: {
-                'core' => %w[Hi], 'non-core' => %w[There], 'mixture' => %w[Hi There]
+                ['core'] => %w[Hi], ['non-core'] => %w[There], ['mixture'] => %w[Hi There]
               }
             }
           )
@@ -544,8 +544,8 @@ RSpec.describe Framework::Definition::Generator do
         it {
           is_expected.to have_field('Going to Additional1').validated_by(
             dependent_field_inclusion: {
-              parent: 'Product Class',
-              in: { '1' => ['Hi'], '2' => ['There'] }
+              parents: ['Service Type', 'Product Class'],
+              in: { ['core', '1'] => ['Hi'], ['mixture', '2'] => ['There'] }
             }
           )
         }

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -207,11 +207,46 @@ RSpec.describe Framework::Definition::Parser do
           field: 'ProductGroup',
           from: { string: 'Vehicle Segment' },
           depends_on: {
-            dependent_field: { string: 'Lot Number' },
+            dependent_fields: { string: 'Lot Number' },
             values: {
               dictionary: [
                 { key: { string: '1' }, value: { lookup_reference: 'Lot1Segment' } },
                 { key: { string: '2' }, value: { lookup_reference: 'Lot2Segment' } }
+              ]
+            }
+          }
+        )
+      }
+    end
+
+    context 'with multi-field dependencies' do
+      let(:source) do
+        <<~FDL
+          ProductGroup from 'Vehicle Segment' depends_on 'Lot Number', 'Category', 'Model' {
+            '1', 'Cars', 'Golf' -> Lot1Segment
+          }
+        FDL
+      end
+      it {
+        is_expected.to parse(source).as(
+          field: 'ProductGroup',
+          from: { string: 'Vehicle Segment' },
+          depends_on: {
+            dependent_fields: [
+              { string: 'Lot Number' },
+              { string: 'Category' },
+              { string: 'Model' },
+            ],
+            values: {
+              dictionary: [
+                {
+                  key: [
+                    { string: '1' },
+                    { string: 'Cars' },
+                    { string: 'Golf' },
+                  ],
+                  value: { lookup_reference: 'Lot1Segment' }
+                },
               ]
             }
           }
@@ -247,7 +282,7 @@ RSpec.describe Framework::Definition::Parser do
           field: 'Additional1',
           from: { string: 'Somewhere' },
           depends_on: {
-            dependent_field: { string: 'Something Else' },
+            dependent_fields: { string: 'Something Else' },
             values: {
               dictionary: [
                 { key: { string: '1' }, value: { lookup_reference: 'SomeValues1' } },

--- a/spec/validators/dependent_field_inclusion_validator_spec.rb
+++ b/spec/validators/dependent_field_inclusion_validator_spec.rb
@@ -10,11 +10,9 @@ RSpec.describe DependentFieldInclusionValidator do
       end
 
       mapping = {
-        'Service Type' => {
-          'core'     => ['Corporate Finance'],
-          'Non-core' => ['Equity Capital Markets'],
-          'MIXTURE'  => ['Asset Finance']
-        }
+        'core'     => ['Corporate Finance'],
+        'Non-core' => ['Equity Capital Markets'],
+        'MIXTURE'  => ['Asset Finance']
       }
 
       field 'Service Type', :string

--- a/spec/validators/dependent_field_inclusion_validator_spec.rb
+++ b/spec/validators/dependent_field_inclusion_validator_spec.rb
@@ -9,14 +9,16 @@ RSpec.describe DependentFieldInclusionValidator do
         'Validator'
       end
 
-      mapping = {
-        'core'     => ['Corporate Finance'],
-        'Non-core' => ['Equity Capital Markets'],
-        'MIXTURE'  => ['Asset Finance']
-      }
-
       field 'Service Type', :string
-      field 'Primary Specialism', :string, dependent_field_inclusion: { parent: 'Service Type', in: mapping }
+
+      field 'Primary Specialism', :string, dependent_field_inclusion: {
+        parents: ['Service Type'],
+        in: {
+          ['core']     => ['Corporate Finance'],
+          ['Non-core'] => ['Equity Capital Markets'],
+          ['MIXTURE']  => ['Asset Finance']
+        }
+      }
     end
   end
 
@@ -93,5 +95,99 @@ RSpec.describe DependentFieldInclusionValidator do
     let(:data) { { 'Primary Specialism' => 'something else' } }
 
     it { is_expected.to_not be_valid }
+  end
+
+  context 'with multiple parent fields' do
+    let(:entry_data_class) do
+      Class.new(Framework::EntryData) do
+        extend ActiveModel::Naming
+
+        def self.name
+          'Validator'
+        end
+
+        field 'Service Type', :string
+        field 'Primary Specialism', :string
+
+        field 'Quantity', :string, dependent_field_inclusion: {
+          parents: ['Service Type', 'Primary Specialism'],
+          in: {
+            ['core', 'corporate finance'] => ['one'],
+            ['Non-core', 'equity capital markets'] => ['two'],
+            ['MIXTURE', 'asset finance'] => ['three']
+          }
+        }
+      end
+    end
+
+    context 'the dependent field corresponds to the parent fields case-insensitively' do
+      let(:data) do
+        {
+          'Service Type' => 'Core',
+          'Primary Specialism' => 'CorPoRate FiNaNce',
+          'Quantity' => 'ONE'
+        }
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'the dependent field does not correspond to the parent field' do
+      let(:data) do
+        {
+          'Service Type' => 'Core',
+          'Primary Specialism' => 'CorPoRate FiNaNce',
+          'Quantity' => 'two'
+        }
+      end
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'the dependent field value is missing' do
+      let(:data) do
+        {
+          'Service Type' => 'Core',
+          'Primary Specialism' => 'CorPoRate FiNaNce',
+          'Quantity' => nil
+        }
+      end
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'the dependent field is missing' do
+      let(:data) do
+        {
+          'Service Type' => 'Core',
+          'Primary Specialism' => 'CorPoRate FiNaNce'
+        }
+      end
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'the parent field has a value not present in our mapping' do
+      let(:data) do
+        {
+          'Service Type' => 'Core',
+          'Primary Specialism' => 'Agriculture',
+          'Quantity' => 'ONE'
+        }
+      end
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'a parent field is missing entirely' do
+      let(:data) do
+        {
+          'Primary Specialism' => 'CorPoRate FiNaNce',
+          'Quantity' => 'ONE'
+        }
+      end
+
+      it { is_expected.to_not be_valid }
+    end
   end
 end

--- a/spec/validators/dependent_field_inclusion_validator_spec.rb
+++ b/spec/validators/dependent_field_inclusion_validator_spec.rb
@@ -113,8 +113,7 @@ RSpec.describe DependentFieldInclusionValidator do
           parents: ['Service Type', 'Primary Specialism'],
           in: {
             ['core', 'corporate finance'] => ['one'],
-            ['Non-core', 'equity capital markets'] => ['two'],
-            ['MIXTURE', 'asset finance'] => ['three']
+            ['other', Framework::Definition::AST::Any] => ['two']
           }
         }
       end
@@ -188,6 +187,53 @@ RSpec.describe DependentFieldInclusionValidator do
       end
 
       it { is_expected.to_not be_valid }
+    end
+
+    context 'the dependent field corresponds to a wildcard match' do
+      let(:data) do
+        {
+          'Service Type' => 'Other',
+          'Primary Specialism' => 'Absolutely Anything',
+          'Quantity' => 'two'
+        }
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'the dependent field does not correspond to a wildcard match' do
+      let(:data) do
+        {
+          'Service Type' => 'Other',
+          'Primary Specialism' => 'Absolutely Anything',
+          'Quantity' => 'one'
+        }
+      end
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'the wildcard field value is missing' do
+      let(:data) do
+        {
+          'Service Type' => 'Other',
+          'Primary Specialism' => nil,
+          'Quantity' => 'two'
+        }
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'the wildcard field is missing entirely' do
+      let(:data) do
+        {
+          'Service Type' => 'Other',
+          'Quantity' => 'two'
+        }
+      end
+
+      it { is_expected.to be_valid }
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR:

This PR adds the ability to have multiple fields in a `depends_on` clause in FDL. This is, this is now allowed:

        InvoiceFields {
          A from 'field a'
          B from 'field b'
          C from 'field c' depends_on 'field a', 'field b' {
            'one', 'apple' -> Set1
            'two', 'orange' -> Set2
          }
        }

The semantics are that for each row, the values of `field a` and `field b` will be extracted and used to look up a single row in the match table. Here, this says that if `field a` has value `one` _and_ `field b` has value `apple`, then use `Set1` as the valid values for `field c`. If `field a` is `two` _and_ `field b` is `orange`, then use `Set2`.

It is an error to use a different number of matching values than there are dependent fields. For example, these matches are both errors:

        InvoiceFields {
          A from 'field a'
          B from 'field b'
          C from 'field c' depends_on 'field a', 'field b' {
            'one', 'too', 'many' -> Set1
            'too few' -> Set2
          }
        }

All the values that were previously legal as match values in `depends_on` are still legal, but now you can use lists of them, separated by commas. There is no limitation on the number of dependent fields.