### PR TITLE
Improve experience of restoring and using a production database dump

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,8 +13,10 @@
 ActiveRecord::Schema.define(version: 2019_08_20_105032) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -9,13 +9,57 @@ namespace :db do
     Dir[PRODUCTION_BACKUP_TARS].sort.reverse.first
   end
 
+  def filter_toc(path)
+    # We filter the database dump, modifying its table of contents to remove
+    # elements that we do not wish to restore:
+    #
+    # - The PostGIS extension and the spatial_ref_sys table that it creates.
+    #   This extension exists in the production dump because it is always enabled
+    #   for GOV.UK Platform as a Service Postgres instances
+    #   (https://docs.cloud.service.gov.uk/deploying_services/postgresql/#add-or-remove-extensions-for-a-postgresql-service-instance).
+    #   However, we do not make use of it in our app, and if we kept it in the
+    #   dump then we would need to use a custom Postgres Docker image with the PostGIS
+    #   extension installed. So it's easier to just get rid of it.
+    #
+    # - The reassign_owned function and event trigger. If we do not get rid of
+    #   these, then something happens that causes migrations that alter columns
+    #   to fail in development, with an error like 'role
+    #   "rdsbroker_e8e8d7d2_5890_4f9d_8c9c_da43a9918e4c_manager" does not
+    #   exist'.
+    new_toc_lines = File.read(path).each_line.reject do |line|
+      line =~ /EXTENSION.*postgis|spatial_ref_sys|reassign_owned/
+    end
+
+    File.open(path, 'w') { |f| f << new_toc_lines.join("\n") }
+  end
+
   desc 'Restore from a backup'
   task :restore, %i[filename user] => :environment do |_task, args|
     filename = args[:filename] || find_latest_backup or
       raise ArgumentError, "[filename] required when no #{PRODUCTION_BACKUP_TARS} found"
 
     STDERR.puts("Restoring from #{filename}")
-    system 'pg_restore', '-d', database_url, filename
+
+    Tempfile.create do |toc_file|
+      sh "pg_restore --list #{filename} > #{toc_file.path}"
+
+      filter_toc(toc_file.path)
+
+      sh 'pg_restore', \
+         # Fail when first error is encountered, instead of reporting mutiple
+         # errors at the end
+         '--exit-on-error', \
+         '-d', database_url, \
+         # Only restore the objects specified by our filtered table of contents
+         '-L', toc_file.path, \
+         # Do not attempt to set object ownership, since the roles referred to
+         # by the dump will not exist locally
+         '--no-owner', \
+         # Do not attempt to set access privileges, since the roles referred to
+         # by the dump will not exist locally
+         '--no-privileges', \
+         filename
+    end
   end
 
   desc 'Wipe out your local DB and replace with latest from ./backups'


### PR DESCRIPTION
## Changes in this PR:

- Fix issues with production -> development database restore
- Commit `enable_extension` added by Rails when running migrations against a database restored from a production dump

_See commit messages for more details._