### PR TITLE
(fix) Correct use of $@ in shell scripts

### DIFF
--- a/bin/drails
+++ b/bin/drails
@@ -1,3 +1,3 @@
 #!/bin/sh
 set +e
-docker-compose run --rm web rails $@
+docker-compose run --rm web rails "$@"

--- a/bin/drake
+++ b/bin/drake
@@ -1,3 +1,3 @@
 #!/bin/sh
 set +e
-docker-compose run --rm web rake $@
+docker-compose run --rm web rake "$@"

--- a/bin/dspec
+++ b/bin/dspec
@@ -4,8 +4,8 @@ set -e
 if [ $# -eq 0 ]
 then
   echo "No arguments supplied. Defaults to 'bundle exec rake default'"
-  docker exec -it data-submission-service-api_test bundle exec rake default $@
+  docker exec -it data-submission-service-api_test bundle exec rake default
 else
   echo "Testing: $@"
-  docker exec -it data-submission-service-api_test bundle exec rspec $@
+  docker exec -it data-submission-service-api_test bundle exec rspec "$@"
 fi


### PR DESCRIPTION
This puts the bash variable $@ in double quotes, so that shell words are
preserved correctly. For example, if one runs:

    ./bin/dspec -e 'name of test'

Then there are two argument strings passed to `dspec`: `-e`, and `name
of test`. The bash variable $@ contains these two strings. If it's used
unquoted, the effect is to insert them into a command as though they had
not been quoted originally, resulting in a command like this being run:

    docker exec ... rspec -e name of test

That means `rspec` is run with the arguments: `-e`, `name`, `of` and
`test`; `name` is used to match tests by name, and `of` and `test` are
assumed to be filenames, which results in an error.

Quoting the $@ variable effectively preserves the original quoting of
the shell words, so we get this instead:

    docker exec ... rspec -e 'name of test'

This means that invocations of these scripts that pass multi-word quoted
arguments pass those arguments through correctly.

I have also removed the variable $@ from a code path where the argument
array has been checked to be empty.