### PR TITLE
Bump nokogiri to v1.10.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,9 @@ gem 'http'
 # Used for FDL testing (see FDL::Validations::Test)
 gem 'hashdiff', require: false
 
+# Force nokogiri to non-vulnerable version
+gem 'nokogiri', '>= 1.10.4'
+
 group :development, :test do
   gem 'brakeman', require: false
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   lolsoap
+  nokogiri (>= 1.10.4)
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   parslet
@@ -487,4 +488,4 @@ RUBY VERSION
    ruby 2.5.5p157
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
NB: Running `bundle update nokogiri` failed with "Bundler attempted to update nokogiri but its version stayed the same". 

I couldn't see any dependencies that were preventing this, so solved it by adding an explicit minimum version requirement for Nokogiri in the Gemfile.