### PR TITLE
Revert "Merge pull request #508 from dxw/security/update-nokogiri"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,9 +70,6 @@ gem 'http'
 # Used for FDL testing (see FDL::Validations::Test)
 gem 'hashdiff', require: false
 
-# Force nokogiri to non-vulnerable version
-gem 'nokogiri', '>= 1.10.4'
-
 group :development, :test do
   gem 'brakeman', require: false
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,7 +458,6 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   lolsoap
-  nokogiri (>= 1.10.4)
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   parslet
@@ -488,4 +487,4 @@ RUBY VERSION
    ruby 2.5.5p157
 
 BUNDLED WITH
-   2.0.2
+   2.0.1


### PR DESCRIPTION
## Changes in this PR:

This reverts commit ceb789d5a5b9028ef13cc101ca9f189aff7135cf, reversing
changes made to 57583bf3a00fb178c013a7538ee7712246730e36.

Whilst we have already merged a fix for this Nokogiri vulnerability https://github.com/dxw/DataSubmissionServiceAPI/pull/496 we attempted another change because the GitHub security advisory was still displaying on the repository page, and we had received another warning email. We also believe that the changes made in this change better protect the team from accidentally reverting back to a vulnerable version of Nokogiri due tot he explicit lock `'>= 1.10.4'`.

Updating the Nokogiri gem using bundler 2.0.2 was fine during the the build phase and so was merged. However, when CI came to deploy this change the Ruby on Rails buildpack was using bundler 2.0.1 which fails the deployment:
 
![Screenshot 2019-08-21 at 17 48 14](https://user-images.githubusercontent.com/912473/63451620-8c27a100-c43c-11e9-83c9-a24a6e9b5cff.png)

Whilst we need a more solid answer to how to upgrade bundler versions, we should for now unblock the deployment pipelines to enable us to continue delivering features and other security fixes.