### PR TITLE
Security/lock nokogiri to 1.10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY package.json yarn.lock $INSTALL_PATH/
 
 RUN yarn
 RUN gem update --system 3.0.0
-RUN gem install bundler
+RUN gem install bundler -v 2.0.1
 
 # bundle ruby gems based on the current environment, default to production
 RUN echo $RAILS_ENV

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,9 @@ gem 'http'
 # Used for FDL testing (see FDL::Validations::Test)
 gem 'hashdiff', require: false
 
+# Locking above vulnerable version https://nvd.nist.gov/vuln/detail/CVE-2019-5477
+gem 'nokogiri', '>= 1.10.4'
+
 group :development, :test do
   gem 'brakeman', require: false
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   lolsoap
+  nokogiri (>= 1.10.4)
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   parslet


### PR DESCRIPTION
## Changes in this PR:

- ensure we are using the same version of Bundler as used on the PaaS for now
- explicit lock on the Nokogiri gem to preserve the change made to the gemfile.lock by Dependabot and ensure we do not allow another gem to take us backwards 
- paired with https://github.com/dxw/DataSubmissionService/pull/278