### PR TITLE
Feature/1147 deactivated users are reactivated via bulk upload

### DIFF
--- a/app/models/import/users/row.rb
+++ b/app/models/import/users/row.rb
@@ -10,7 +10,15 @@ module Import
       end
 
       def import!
-        user = existing_user.presence || create_user!
+        user = if existing_user.presence && !existing_user.active?
+                 ReactivateUser.new(user: existing_user).call
+                 existing_user
+               elsif existing_user.presence
+                 existing_user
+               else
+                 create_user!
+               end
+
         user.suppliers << supplier unless user.suppliers.include?(supplier)
         user
       end

--- a/spec/models/import/users/row_spec.rb
+++ b/spec/models/import/users/row_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Import::Users::Row do
       end
     end
 
-    context 'with a pre-existing user' do
+    context 'with a pre-existing active user' do
       let!(:existing_user) { FactoryBot.create(:user, email: email) }
 
       it 'associates the existing user with the supplier' do
@@ -45,6 +45,20 @@ RSpec.describe Import::Users::Row do
       it 'doesn’t make any Auth0 calls' do
         result
         expect(auth0_create_call).not_to have_been_requested
+      end
+    end
+
+    context 'with a pre-existing inactive user' do
+      let!(:existing_user) { FactoryBot.create(:user, :inactive, email: email) }
+
+      it 'associates the existing user with the supplier' do
+        expect(result).to eq existing_user.reload
+        expect(existing_user.suppliers).to contain_exactly(matching_supplier)
+      end
+
+      it 'creates that user in Auth0' do
+        result
+        expect(auth0_create_call).to have_been_requested
       end
     end
 

--- a/spec/models/import/users/row_spec.rb
+++ b/spec/models/import/users/row_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Import::Users::Row do
       end
 
       it 'doesn’t make any Auth0 calls' do
+        result
         expect(auth0_create_call).not_to have_been_requested
       end
     end


### PR DESCRIPTION
## Changes in this PR:

- bulk uploading users now accommodates email addresses that belong to existing users who have been previously deactivated
- activate another test nearby that I noticed wasn't running