### PR TITLE
(chore) Reference how to do deployments in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,8 @@ There are Rake tasks to report the status of monthly tasks:
 There are some handy methods available in the Rails console for debugging
 submissions and reporting on the state of the monthly tasks. See
 [lib/console_helpers.rb](lib/console_helpers.rb) for more details.
+
+
+## Deployments
+
+Documentation on how deployments are managed for the RMI service as a whole are documented within the [service manual](https://crown-commercial-service.github.io/ReportMI-service-manual/#/deployments).


### PR DESCRIPTION
Depends on: https://github.com/Crown-Commercial-Service/ReportMI-service-manual/pull/43

## Changes in this PR:

* Before this change only the frontend application had documentation in its repository: https://github.com/dxw/DataSubmissionService, the API did not, and doesn't include any clear reference to the process.
* Instead of duplicating the documentation into both repositories, which risks becoming out of sync, including a link to the service manual will hopefully be clearer and less fragile.
* Changing language from "release" to "deployment" since from the perspective of a wider and higher level service manual the term "release" may be more ambiguous 