### PR TITLE
(fix) Starting the application on an existing database does not chang…

### DIFF
--- a/db/migrate/20190829153159_enable_citext_extension.rb
+++ b/db/migrate/20190829153159_enable_citext_extension.rb
@@ -1,0 +1,5 @@
+class EnableCitextExtension < ActiveRecord::Migration[5.2]
+  def change
+    enable_extension 'citext'
+  end
+end

--- a/db/migrate/20190829153212_enable_uuid_ossp_extension.rb
+++ b/db/migrate/20190829153212_enable_uuid_ossp_extension.rb
@@ -1,0 +1,5 @@
+class EnableUuidOsspExtension < ActiveRecord::Migration[5.2]
+  def change
+    enable_extension 'uuid-ossp'
+  end
+end


### PR DESCRIPTION
…e the schema

## Changes in this PR:

* These 2 extensions were added manually to the schema recently as they are always present on gpaas infrastructure https://github.com/dxw/DataSubmissionServiceAPI/commit/04f9d2d8afbee7cd343f57008f804d9538227647#diff-1acd2e7e27a227829d5d14a91c863bb6
* This works fine when `rake schema:load` is invoked during a normal database setup however there are many occasions where `rake db:migrate` is used instead. I have noticed when working locally and on CI that this can cause the schema.rb to change, removing the 2 lines detailing these extensions.
* Docker in development will migrate: https://github.com/dxw/DataSubmissionServiceAPI/blob/develop/docker-entrypoint.sh#L13
* Travis on CI will migrate https://github.com/dxw/DataSubmissionServiceAPI/blob/develop/.travis.yml#L36
* Migrations on real environments are manual processes where we run `rake db:migrate` on the console.
* Currently whenever we restarting our local environment with a new `bin/dstart` can result in unstaged change made to our schema.rb which risks being committed accidentally.
* This change ensures that changes added to the schema originally always persist.

CI: 
![Screenshot 2019-08-29 at 16 33 05](https://user-images.githubusercontent.com/912473/63956825-1eecbf00-ca7f-11e9-8600-1cf8eb55700b.png)

