### PR TITLE
Set RAILS_MAX_THREADS to 15 and add DATABASE_POOL_SIZE

### DIFF
--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -21,6 +21,7 @@ applications:
       - AZURE
     env:
       RAILS_ENV: production
-      RAILS_MAX_THREADS: 5
+      RAILS_MAX_THREADS: 15
+      DATABASE_POOL_SIZE: 15
       SUBMIT_INVOICES: 'true'
       NEW_INGEST: 'true'


### PR DESCRIPTION
During peak periods we can see around 30 to 40 concurrent connections.
Set the RAILS_MAX_THREADS to 15 so that our 3 running instances have
enough capacity.

Add a DATABASE_POOL_SIZE and set it to the same value so that each
thread can have a database connection.

This will stop occurences of

```
Failsafe from rollbar-gem. ActiveRecord::ConnectionTimeoutError: "could not obtain a connection from the pool within 5.000 seconds (waited 5.000 seconds); all pooled connections were in use" in /home/vcap/deps/0/vendor_bundle/ruby/2.5.0/gems/activerecord-5.2.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:201:in `block in wait_poll': build_item in exception_data
```

which can lead to

```
JSONAPI::Consumer::Errors::ServerError: Internal server error
```

from the frontend app.