### PR TITLE
(1157) Use separate queue for ingest jobs

### DIFF
--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -37,7 +37,7 @@ SCRIPT_PATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 CF_API_ENDPOINT="https://api.london.cloud.service.gov.uk"
 
-while getopts "a:u:p:o:s:h" opt; do
+while getopts "a:u:p:o:s:h:f" opt; do
   case $opt in
     u)
       CF_USER=$OPTARG

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -25,8 +25,13 @@ fi
 MEMORY_LIMIT="512M"
 INSTANCE_COUNT="1"
 
-SIDEKIQ_MEMORY_LIMIT="512M"
-SIDEKIQ_INSTANCE_COUNT="1"
+SIDEKIQ_DEFAULT_INSTANCE_COUNT="1"
+SIDEKIQ_DEFAULT_CONCURRENCY="5"
+SIDEKIQ_DEFAULT_MEMORY_LIMIT="2048M"
+
+SIDEKIQ_INGEST_INSTANCE_COUNT="1"
+SIDEKIQ_INGEST_CONCURRENCY="2"
+SIDEKIQ_INGEST_MEMORY_LIMIT="8192M"
 
 SCRIPT_PATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
@@ -105,8 +110,14 @@ if [[ "$CF_SPACE" == "staging" || "$CF_SPACE" == "prod" ]]; then
 
   MEMORY_LIMIT="512M"
   INSTANCE_COUNT="3"
-  SIDEKIQ_MEMORY_LIMIT="16384M"
-  SIDEKIQ_INSTANCE_COUNT="3"
+
+  SIDEKIQ_DEFAULT_MEMORY_LIMIT="2048M"
+  SIDEKIQ_DEFAULT_INSTANCE_COUNT="1"
+  SIDEKIQ_DEFAULT_CONCURRENCY="5"
+
+  SIDEKIQ_INGEST_MEMORY_LIMIT="16384M"
+  SIDEKIQ_INGEST_INSTANCE_COUNT="1"
+  SIDEKIQ_INGEST_CONCURRENCY="3"
 fi
 
 cd "$SCRIPT_PATH" || exit
@@ -117,7 +128,8 @@ cf target -o "$CF_ORG" -s "$CF_SPACE"
 
 # generate manifest
 sed "s/CF_SPACE/$CF_SPACE/g" manifest-template.yml | sed "s/MEMORY_LIMIT/$MEMORY_LIMIT/g" | sed "s/INSTANCE_COUNT/$INSTANCE_COUNT/g" > "$CF_SPACE.manifest.yml"
-sed "s/CF_SPACE/$CF_SPACE/g" sidekiq-manifest-template.yml | sed "s/SIDEKIQ_MEMORY_LIMIT/$SIDEKIQ_MEMORY_LIMIT/g" | sed "s/SIDEKIQ_INSTANCE_COUNT/$SIDEKIQ_INSTANCE_COUNT/g" > "$CF_SPACE.sidekiq.manifest.yml"
+sed "s/CF_SPACE/$CF_SPACE/g" sidekiq-manifest-template.yml | sed "s/SIDEKIQ_MEMORY_LIMIT/$SIDEKIQ_DEFAULT_MEMORY_LIMIT/g" | sed "s/SIDEKIQ_INSTANCE_COUNT/$SIDEKIQ_DEFAULT_INSTANCE_COUNT/g" | sed "s/SIDEKIQ_QUEUE_NAME/default/g" | sed "s/SIDEKIQ_CONCURRENCY/$SIDEKIQ_DEFAULT_CONCURRENCY/g" > "$CF_SPACE.sidekiq.default.manifest.yml"
+sed "s/CF_SPACE/$CF_SPACE/g" sidekiq-manifest-template.yml | sed "s/SIDEKIQ_MEMORY_LIMIT/$SIDEKIQ_INGEST_MEMORY_LIMIT/g" | sed "s/SIDEKIQ_INSTANCE_COUNT/$SIDEKIQ_INGEST_INSTANCE_COUNT/g" | sed "s/SIDEKIQ_QUEUE_NAME/ingest/g" | sed "s/SIDEKIQ_CONCURRENCY/$SIDEKIQ_INGEST_CONCURRENCY/g" > "$CF_SPACE.sidekiq.ingest.manifest.yml"
 
 # push API
 cd .. || exit
@@ -130,4 +142,5 @@ cf v3-zdt-push ccs-rmi-api-"$CF_SPACE"
 
 # push API sidekiq
 # this is not a blue green deploy because that doesnt work with apps with not route
-cf push -f CF/"$CF_SPACE".sidekiq.manifest.yml -b python_buildpack -b ruby_buildpack
+cf push -f CF/"$CF_SPACE".sidekiq.default.manifest.yml -b python_buildpack -b ruby_buildpack
+cf push -f CF/"$CF_SPACE".sidekiq.ingest.manifest.yml -b python_buildpack -b ruby_buildpack

--- a/CF/sidekiq-manifest-template.yml
+++ b/CF/sidekiq-manifest-template.yml
@@ -22,6 +22,7 @@ applications:
       RAILS_MAX_THREADS: SIDEKIQ_CONCURRENCY
       SUBMIT_INVOICES: 'true'
       NEW_INGEST: 'true'
+      MALLOC_ARENA_MAX: 2
     command: bundle exec sidekiq -q SIDEKIQ_QUEUE_NAME
     health-check-type: process
     no-route: true

--- a/CF/sidekiq-manifest-template.yml
+++ b/CF/sidekiq-manifest-template.yml
@@ -1,8 +1,8 @@
 ---
 applications:
-  - name: ccs-rmi-api-sidekiq-CF_SPACE
+  - name: ccs-rmi-api-sidekiq-SIDEKIQ_QUEUE_NAME-CF_SPACE
     memory: SIDEKIQ_MEMORY_LIMIT
-    instance: SIDEKIQ_INSTANCE_COUNT
+    instances: SIDEKIQ_INSTANCE_COUNT
     services:
       - ccs-rmi-api-CF_SPACE
       - ccs-rmi-logging-CF_SPACE
@@ -19,9 +19,9 @@ applications:
       - AZURE
     env:
       RAILS_ENV: production
-      RAILS_MAX_THREADS: 5
+      RAILS_MAX_THREADS: SIDEKIQ_CONCURRENCY
       SUBMIT_INVOICES: 'true'
       NEW_INGEST: 'true'
-    command: bundle exec sidekiq
+    command: bundle exec sidekiq -q SIDEKIQ_QUEUE_NAME
     health-check-type: process
     no-route: true

--- a/app/jobs/submission_ingestion_job.rb
+++ b/app/jobs/submission_ingestion_job.rb
@@ -1,4 +1,6 @@
 class SubmissionIngestionJob < ApplicationJob
+  queue_as :ingest
+
   discard_on(Ingest::Loader::MissingInvoiceColumns) do |job, exception|
     handle_unretryable_job_failure(job, exception)
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,1 +1,5 @@
 concurrency: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>
+
+queues:
+  - default
+  - ingest


### PR DESCRIPTION
We've had issues with large ingest jobs crashing the Sidekiq instance, which causes any jobs currently running to be lost. This meant that other jobs such as the data warehouse export could fail to be executed.

To workaround this, I've split the 'ingest' jobs into their own queue which runs on a different set of Sidekiq worker instances. Additionally, they run with different concurrency and memory limits due their very different footprints.

NB: This runs only one instance of the default queue at present, as I'm not sure if the `sidekiq-cron` (which runs against the `default` queue) would cause these tasks to run once on each instance, which could cause issues.

In the future, we could even have a 'huge spreadsheet' queue for files over a certain threshold, which would allow us to up the concurrency for regular files.