### PR TITLE
 management_charge total stored on submissions (Zendesk #10151)

### DIFF
--- a/app/jobs/submission_management_charge_calculation_job.rb
+++ b/app/jobs/submission_management_charge_calculation_job.rb
@@ -39,6 +39,7 @@ class SubmissionManagementChargeCalculationJob < ApplicationJob
       entry.update! management_charge: framework_definition.calculate_management_charge(entry)
     end
 
+    @submission.update!(management_charge_total: @submission.entries.invoices.sum(:management_charge))
     @submission.ready_for_review!
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -79,7 +79,9 @@ class Submission < ApplicationRecord
   end
 
   def management_charge
-    entries.invoices.sum(:management_charge)
+    return management_charge_total unless management_charge_total.nil?
+
+    self.management_charge_total = entries.invoices.sum(:management_charge)
   end
 
   def total_spend

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -79,9 +79,7 @@ class Submission < ApplicationRecord
   end
 
   def management_charge
-    return management_charge_total unless management_charge_total.nil?
-
-    self.management_charge_total = entries.invoices.sum(:management_charge)
+    self.management_charge_total ||= entries.invoices.sum(:management_charge)
   end
 
   def total_spend

--- a/db/data_migrate/201910091570631985_add_management_charge_total_to_one_supplier.rb
+++ b/db/data_migrate/201910091570631985_add_management_charge_total_to_one_supplier.rb
@@ -1,0 +1,20 @@
+# Zendesk ticket: https://dxw.zendesk.com/agent/tickets/10151
+#
+# Execute with:
+#
+#   rails runner db/data_migrate/201910091570631985_add_management_charge_total_to_one_supplier.rb
+#
+
+puts 'Backfilling management_charge_total for CORPORATE TRAVEL MANAGEMENT (NORTH) LIMITED'
+
+supplier = Supplier.find_by(name: 'CORPORATE TRAVEL MANAGEMENT (NORTH) LIMITED')
+raise 'Supplier not found!' unless supplier
+
+Submission.transaction do
+  supplier.submissions.each do |submission|
+    next unless submission.management_charge_total.nil?
+
+    submission.management_charge_total = submission.entries.invoices.sum(:management_charge)
+    submission.save!
+  end
+end

--- a/db/data_migrate/201910091570631985_add_management_charge_total_to_one_supplier.rb
+++ b/db/data_migrate/201910091570631985_add_management_charge_total_to_one_supplier.rb
@@ -5,16 +5,18 @@
 #   rails runner db/data_migrate/201910091570631985_add_management_charge_total_to_one_supplier.rb
 #
 
-puts 'Backfilling management_charge_total for CORPORATE TRAVEL MANAGEMENT (NORTH) LIMITED'
+puts 'Backfilling management_charge_total for CORPORATE TRAVEL MANAGEMENT (NORTH) LIMITED and Lex Autolease'
 
-supplier = Supplier.find_by(name: 'CORPORATE TRAVEL MANAGEMENT (NORTH) LIMITED')
-raise 'Supplier not found!' unless supplier
+['Lex Autolease', 'CORPORATE TRAVEL MANAGEMENT (NORTH) LIMITED'].each do |supplier_name|
+  supplier = Supplier.find_by(name: supplier_name)
+  raise 'Supplier not found!' unless supplier
 
-Submission.transaction do
-  supplier.submissions.each do |submission|
-    next unless submission.management_charge_total.nil?
+  Submission.transaction do
+    supplier.submissions.each do |submission|
+      next unless submission.management_charge_total.nil?
 
-    submission.management_charge_total = submission.entries.invoices.sum(:management_charge)
-    submission.save!
+      submission.management_charge_total = submission.entries.invoices.sum(:management_charge)
+      submission.save!
+    end
   end
 end

--- a/db/migrate/20191009133133_add_management_charge_total_to_submissions.rb
+++ b/db/migrate/20191009133133_add_management_charge_total_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddManagementChargeTotalToSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submissions, :management_charge_total, :decimal, precision: 18, scale: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 2019_10_09_133133) do
 
   # These are extensions that must be enabled in order to support this database
-  nable_extension "citext"
+  enable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_20_105032) do
+ActiveRecord::Schema.define(version: 2019_10_09_133133) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "citext"
+  nable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2019_08_20_105032) do
     t.uuid "created_by_id"
     t.uuid "submitted_by_id"
     t.datetime "submitted_at"
+    t.decimal "management_charge_total", precision: 18, scale: 4
     t.index ["aasm_state"], name: "index_submissions_on_aasm_state"
     t.index ["created_by_id"], name: "index_submissions_on_created_by_id"
     t.index ["framework_id"], name: "index_submissions_on_framework_id"

--- a/spec/jobs/submission_management_charge_calculation_job_spec.rb
+++ b/spec/jobs/submission_management_charge_calculation_job_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe SubmissionManagementChargeCalculationJob do
         expect(order_entry.reload.management_charge).to be_nil
       end
 
+      it 'updates the submission with the management charge total' do
+        total = invoice_entry_1.reload.management_charge + invoice_entry_2.reload.management_charge
+        expect(submission.management_charge_total).to eq(total)
+      end
+
       it 'marks the submission as ready for review' do
         expect(submission).to be_in_review
       end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -172,8 +172,20 @@ RSpec.describe Submission do
     end
 
     describe '#management_charge' do
-      it 'returns the sum of all the management charges for the entries of type "invoice"' do
-        expect(submission.management_charge).to eq BigDecimal('5.60')
+      context 'a submission that already has its management_charge_total calculated' do
+        before do
+          allow(submission).to receive(:management_charge_total).and_return(BigDecimal('0.7'))
+        end
+
+        it 'returns the value in the management_charge_total column' do
+          expect(submission.management_charge).to eq BigDecimal('0.7')
+        end
+      end
+
+      context 'a submission whose management_charge is nil' do
+        it 'returns the sum of all the management charges for the entries of type "invoice"' do
+          expect(submission.management_charge).to eq BigDecimal('5.60')
+        end
       end
     end
 


### PR DESCRIPTION
## Changes in this PR:

https://dxw.zendesk.com/agent/tickets/10151

The client complained that viewing submissions for 'CORPORATE TRAVEL MANAGEMENT (NORTH) LIMITED' on either the supplier app or the admin app was resulting in a 504 and the entire RMI site crashing. Investigation revealed that for every submission, the `management_charge` total is calculated on the fly from a total of all the `management_charge`s on the submission's entries. 

It was suggested that we add the `management_charge` for a submission to the database. However doing so would require backfilling the management charges for 74157+ submissions and would probably bring down the production server. 

I propose we change the `management_charge()` method on the submission to either attempt to get the value from the database, or if that is nil, backfill it on the fly _once only_. Because many submissions are never viewed after they're completed, this should be low overhead for the production servers (the management charge is only calculated once when requested for the first time).

For the troublesome supplier who precipitated this issue - 'CORPORATE TRAVEL MANAGEMENT (NORTH) LIMITED' - I have written a script to be executed once this PR is merged. It may be an expensive process but it will only need to be run once, for one supplier. We can test it first on staging to see if it has acceptable speed/consumption.