### PR TITLE
Rollbar #150 - management_charge may be a string (?)

### DIFF
--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -6,7 +6,7 @@
       = task.period_date.to_s(:month_year)
   - if task.active_submission
     %td.govuk-table__cell.govuk-table__cell--numeric
-      - unless task.active_submission.management_charge.zero? && task.active_submission.total_spend.zero?
+      - unless task.active_submission.management_charge.to_f.zero? && task.active_submission.total_spend.to_f.zero?
         = number_to_currency(task.active_submission.management_charge, unit: '£')
         %br/
         %small


### PR DESCRIPTION
It seems that management_charge may be a string in this check, so cast it to a
float first, then check if it's zero or not

https://rollbar.com/dxw/ccs-reportmi-api/items/150/

