### PR TITLE
1158 db calls take down the service

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -83,7 +83,7 @@ class Submission < ApplicationRecord
   end
 
   def total_spend
-    entries.invoices.sum(:total_value)
+    self.invoice_total ||= entries.invoices.sum(:total_value)
   end
 
   def order_total_value

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,6 +6,8 @@ default: &default
   username: postgres
   password:
   pool: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>
+  variables:
+    work_mem: <%= ENV.fetch('PG_WORK_MEM') { '16MB' } %>
 
 development:
   <<: *default

--- a/db/data_migrate/201910231438301312_backfill_submission_invoice_totals.rb
+++ b/db/data_migrate/201910231438301312_backfill_submission_invoice_totals.rb
@@ -1,0 +1,25 @@
+# The problem:
+#
+# Viewing the supplier view for a supplier with many submissions and a large number of entries
+# would bring the site to a crawl calculating totals on the fly. We will calculate invoice_total
+# at ingest time, but we need to backfill existing values.
+#
+# Backfill all of submissions.invoice_total for completed and in_review submissions.
+#
+# Run on a 15 Oct 2019 morning production cut this would UPDATE 12676 submissions
+#
+# rails runner db/data_migrate/201910231438301312_backfill_submission_invoice_totals.rb
+ActiveRecord::Base.connection.execute(
+  <<~POSTGRESQL
+    UPDATE submissions
+    SET invoice_total = invoice_totals.total
+    FROM (
+             SELECT s.id AS submission_id, SUM(se.total_value) as total
+             FROM submissions s
+               INNER JOIN submission_entries se on s.id = se.submission_id AND se.entry_type = 'invoice'
+             GROUP BY s.id
+             HAVING SUM(se.total_value) IS NOT NULL
+         ) AS invoice_totals
+    WHERE submissions.id = invoice_totals.submission_id
+  POSTGRESQL
+)

--- a/db/migrate/20191023072354_add_summary_invoice_total_to_submission.rb
+++ b/db/migrate/20191023072354_add_summary_invoice_total_to_submission.rb
@@ -1,0 +1,5 @@
+class AddSummaryInvoiceTotalToSubmission < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submissions, :invoice_total, :decimal, precision: 18, scale: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_09_133133) do
+ActiveRecord::Schema.define(version: 2019_10_23_072354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -170,6 +170,7 @@ ActiveRecord::Schema.define(version: 2019_10_09_133133) do
     t.uuid "submitted_by_id"
     t.datetime "submitted_at"
     t.decimal "management_charge_total", precision: 18, scale: 4
+    t.decimal "invoice_total", precision: 18, scale: 4
     t.index ["aasm_state"], name: "index_submissions_on_aasm_state"
     t.index ["created_by_id"], name: "index_submissions_on_created_by_id"
     t.index ["framework_id"], name: "index_submissions_on_framework_id"

--- a/spec/models/ingest/loader_spec.rb
+++ b/spec/models/ingest/loader_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Ingest::Loader do
       fake_order_row.map { |k, _| [k, '   '] }.to_h
     end
 
-    it 'loads data from the converter into the database' do
+    it 'loads data from the converter into the database and saves the invoice total' do
       create(:customer, urn: '12345')
 
       framework.lots.each do |lot|
@@ -111,6 +111,8 @@ RSpec.describe Ingest::Loader do
 
       expect(file.entries.orders.first.total_value).to eql 22000
       expect(file.entries.orders.first.customer_urn).to eql 12345
+
+      expect(file.submission.invoice_total).to eql 25.98
     end
 
     it 'ignores empty rows when loading data' do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -190,8 +190,18 @@ RSpec.describe Submission do
     end
 
     describe '#total_spend' do
-      it 'returns the sum of all the total_values for the entries of type "invoice"' do
-        expect(submission.total_spend).to eq BigDecimal('560')
+      context 'there is a backfilled invoice_total value for performance' do
+        before { submission.invoice_total = BigDecimal('999') }
+        it 'returns that value in preference' do
+          expect(submission.total_spend).to eq BigDecimal('999')
+        end
+      end
+
+      context 'there is no backfilled invoice_total value' do
+        before { submission.invoice_total = nil }
+        it 'returns the sum of all the total_values for the entries of type "invoice"' do
+          expect(submission.total_spend).to eq BigDecimal('560')
+        end
       end
     end
 


### PR DESCRIPTION
Large submissions take down the service in three places (see Trello [card](https://trello.com/c/bAfRxHxt/1158-db-calls-take-down-the-service)). We have found that the performance in these places is related in varying degrees to `Submission#total_spend`, so create a `submissions.invoice_total` column which holds pre-calculated invoice totals for all submission entries within a submission.

This comes with a backfill data migration such that invoice totals are filled in for existing entries and adds a running total to the ingest process for invoices such that `submissions.invoice_total` is calculated on ingest for subsequent returns.

In addition, make the Postgres `work_mem` setting configurable at connection level and default to `16MB`. This makes certain queries related to totals and triggered by `SerializableSubmission` and `Submission` (particularly `Submission#sheet_names`, which reaches into the JSONB `source` column for all `submission_entries` in a submission) use a more efficient query plan.

## Note

In theory a `Submission` can be composed of multiple `SubmissionFile`s, which would mean this running total/ingest wouldn't work. In practice, this *never* happens*

\* has happened once somehow

```sql
psql DataSubmissionServiceApi_development on [local] as russ
=> select s.id, COUNT(f.*) from submissions s LEFT JOIN submission_files f on f.submission_id = s.id GROUP BY s.id HAVING COUNT(f.*) > 1;
                  id                  │ count
──────────────────────────────────────┼───────
 5fbf5fe9-1268-48c1-9d68-af556b6f2c9f │     2
(1 row)
```