### PR TITLE
Allow update template to fail gracefully if a file is forgotten

### DIFF
--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -40,8 +40,13 @@ class Admin::FrameworksController < AdminController
   def edit; end
 
   def update
-    @framework.update!(framework_params)
-    flash[:success] = 'Framework saved successfully.'
+    if params.dig(:framework, :template_file).present?
+      @framework.update!(framework_params)
+      flash[:success] = 'Framework saved successfully.'
+    else
+      flash[:failure] = I18n.t('errors.message.missing_template_file')
+    end
+
     redirect_to admin_framework_path(@framework)
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,4 @@ en:
       invalid_lot_number: 'is not included in the supplier framework agreement'
       invalid_dependent_field: '"%{value}" is not a valid %{attr} for the given %{parent_field_name} of "%{parent_field_value}". Please refer to the lookups tab in the template.'
       error_adding_user_to_auth0: 'There was an error adding the user to Auth0. Please try again.'
+      missing_template_file: 'Missing template file'

--- a/spec/features/admin_can_upload_template_to_framework_spec.rb
+++ b/spec/features/admin_can_upload_template_to_framework_spec.rb
@@ -28,4 +28,16 @@ RSpec.feature 'Uploading a template to a Framework' do
       expect(page).to have_content('test.xls')
     end
   end
+
+  context 'when no file was provided' do
+    let!(:framework) { create(:framework, published: true) }
+
+    it 'responds with a meaningful error message' do
+      visit admin_frameworks_path
+      click_on framework.name
+      # Omit step to provide a file to simulate the bug
+      click_button 'Upload Template'
+      expect(page).to have_content(I18n.t('errors.message.missing_template_file'))
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR:

* For any framework regardless of its published state, if a 'Upload Template' button was clicked but no file was attached the app would crash. This code catches that error and provides a simple flash error message explaining the issue.
* Related to Rollbar https://rollbar.com/dxw/ccs-reportmi-api/items/160/?item_page=0&#instances and associated Zendesk ticket

## Screenshots of UI changes:

### Before

![Screenshot 2019-10-29 at 16 03 41](https://user-images.githubusercontent.com/912473/67786302-8ff02900-fa66-11e9-9dbb-d81fc891cb99.png)

### After

![Screenshot 2019-10-29 at 16 03 21](https://user-images.githubusercontent.com/912473/67786317-967ea080-fa66-11e9-9135-fbea8398bf38.png)
