### PR TITLE
(1160) Prevent nils breaking running total

### DIFF
--- a/app/models/ingest/loader.rb
+++ b/app/models/ingest/loader.rb
@@ -90,7 +90,7 @@ module Ingest
 
         entry.validate_against!(sheet_definition)
 
-        running_total += entry.total_value
+        running_total += entry.total_value || 0
         entries << entry
       end
 


### PR DESCRIPTION
The running_total was being calculated by adding the total value column
for each row up. However, on occassions this value would be `nil`, which
would raise an error.

Now, we just treat `nil` as zero, preventing this issue.