### PR TITLE
(1161) Run the daily data warehouse export at 20:30

### DIFF
--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -3,6 +3,6 @@ monthly_tasks_generation:
   class: 'MonthlyTasksGenerationJob'
   queue: default
 daily_data_warehouse_export:
-  cron: '30 22 * * * Europe/London'
+  cron: '30 20 * * * Europe/London'
   class: DataWarehouseExportJob
   queue: default


### PR DESCRIPTION
Previously, this ran at 22:30, which would often mean that it hadn't completed by the time the data warehouse stored procedures ran.