### PR TITLE
Don’t retry ingestion job when submission has been marked ingest_failed

### DIFF
--- a/spec/jobs/submission_ingestion_job_spec.rb
+++ b/spec/jobs/submission_ingestion_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionIngestionJob do
+  describe '#perform' do
+    context 'when a submission is marked as ingest_failed' do
+      let(:submission_file) { create(:submission_file, submission: build(:submission, aasm_state: :ingest_failed)) }
+
+      it 'raises an exception that will discard the job' do
+        expect_any_instance_of(SubmissionIngestionJob).not_to receive(:retry_job)
+        expect do
+          SubmissionIngestionJob.new.perform(submission_file)
+        end.to raise_error(SubmissionIngestionJob::IngestFailed)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR:

It is possible for submissions to be manually marked as `ingest_failed`, in these cases we don't want to retry the job.

Resolves: https://dxw.zendesk.com/agent/tickets/10405

