### PR TITLE
Ensure only valid ISO8601 dates are parsed and converted

### DIFF
--- a/app/models/ingest/loader/process_csv_row.rb
+++ b/app/models/ingest/loader/process_csv_row.rb
@@ -37,7 +37,7 @@ module Ingest
         date_fields.each do |field|
           next if row[field].blank?
 
-          row[field] = Date.parse(row[field]).strftime('%d/%m/%Y') if row[field].match?(/\d{4}-\d{2}-\d{2}/)
+          row[field] = Date.parse(row[field]).strftime('%d/%m/%Y') if valid_iso8601_date?(row[field])
           row[field] = (Date.new(1899, 12, 30) + row[field].to_i.days).strftime('%d/%m/%Y') if valid_float?(row[field])
         end
 
@@ -73,6 +73,12 @@ module Ingest
 
       def valid_float?(value)
         !!Float(value)
+      rescue ArgumentError
+        false
+      end
+
+      def valid_iso8601_date?(value)
+        !!Date.iso8601(value)
       rescue ArgumentError
         false
       end

--- a/spec/models/ingest/loader/process_csv_row_spec.rb
+++ b/spec/models/ingest/loader/process_csv_row_spec.rb
@@ -43,12 +43,12 @@ RSpec.describe Ingest::Loader::ProcessCsvRow do
 
       it 'leaves invalid ISO8601 dates alone, so it is caught by a validator' do
         data = {
-          'Customer Invoice Date' => '30/02/2019'
+          'Customer Invoice Date' => '2020-02-30'
         }
 
         result = process_csv_row.process(data)
 
-        expect(result['Customer Invoice Date']).to eql '30/02/2019'
+        expect(result['Customer Invoice Date']).to eql '2020-02-30'
       end
 
       it 'leaves bad data alone, so it is caught by a validator' do


### PR DESCRIPTION
We allow dates that are in ISO8601 format to be ingested, but we transform them in to dd/mm/yyyy format to be consistent with other expected dates.

The issue we saw was that certain invalid ISO8601 dates (eg. 2020-02-30) were attempting to be parsed because they matched the regex `\d{4}-\d{2}-\d{2}` causing an ArgumentError.

We expect these dates to be left alone so that they are caught by the `IngestedDateValidator` and surfaced to the user.

## Changes in this PR:

- Only transform valid IS8601 dates