### PR TITLE
(1155) Multi-column management charge calculation

### DIFF
--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -77,7 +77,7 @@ class Framework
         end
 
         def raise_when_management_field_invalid(info)
-          referenced_field_name = [info.dig(:column_based, :column_name), info.dig(:flat_rate, :column)].compact.first(&:present?)
+          referenced_field_name = [info.dig(:column_based, :column_names), info.dig(:flat_rate, :column)].compact.first(&:present?)
           return if referenced_field_name.nil?
 
           field = ast.field_by_sheet_name(:invoice, referenced_field_name)

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -24,8 +24,9 @@ class Framework
       rule(:management_charge)    { str('ManagementCharge') >> (column_based | flat_rate | sector_based).as(:management_charge) }
       rule(:flat_rate)            { (spaced(percentage).as(:value) >> flat_rate_column.maybe).as(:flat_rate) }
       rule(:flat_rate_column)     { spaced(str('of')) >> string.as(:column) }
-      rule(:column_based)         { spaced(str('varies_by')) >> (spaced(string).as(:column_name) >> spaced(dictionary).as(:value_to_percentage)).as(:column_based) }
+      rule(:column_based)         { spaced(str('varies_by')) >> (column_names.as(:column_names) >> multi_key_dictionary.as(:value_to_percentage)).as(:column_based) }
       rule(:sector_based)         { spaced(str('sector_based')) >> spaced(dictionary).as(:sector_based) }
+
       rule(:invoice_fields)       { str('InvoiceFields') >> spaced(fields_block.as(:invoice_fields)) }
       rule(:contract_fields)      { str('ContractFields') >> spaced(fields_block.as(:contract_fields)) }
       rule(:fields_blocks)        { (invoice_fields >> contract_fields.maybe) | (contract_fields >> invoice_fields.maybe) }
@@ -53,6 +54,9 @@ class Framework
       rule(:depends_on)           { (spaced(str('depends_on')) >> dependent_fields.as(:dependent_fields) >> multi_key_dictionary.as(:values)).as(:depends_on) }
       rule(:dependent_fields)     { dependent_field >> (spaced(str(',')) >> dependent_field).repeat }
       rule(:dependent_field)      { spaced(string) }
+
+      rule(:column_names)         { column_name >> (spaced(str(',')) >> column_name).repeat }
+      rule(:column_name)          { spaced(string) }
 
       rule(:metadata)             { framework_name >> management_charge }
 

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -66,7 +66,7 @@ class Framework
       def choose_management_charge_calculator(info)
         if info[:column_based]
           ManagementChargeCalculator::ColumnBased.new(
-            varies_by:           info[:column_based][:column_name],
+            varies_by:           info[:column_based][:column_names],
             value_to_percentage: info[:column_based][:value_to_percentage]
           )
         elsif info[:sector_based]

--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -9,12 +9,12 @@ class Framework
       end
 
       def calculate_for(entry)
-        column_name_for_entry = entry.data.dig(varies_by).to_s
-        percentage = value_to_percentage[column_name_for_entry.downcase]
+        column_names_for_entry = entry.data.dig(varies_by).to_s
+        percentage = value_to_percentage[column_names_for_entry.downcase]
 
         if percentage.nil?
           Rollbar.error(
-            "Got value '#{column_name_for_entry}' for '#{varies_by}' on #{entry.framework.short_name}"\
+            "Got value '#{column_names_for_entry}' for '#{varies_by}' on #{entry.framework.short_name}"\
             "from entry #{entry.id}. Missing validation?"
           )
 

--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -9,8 +9,8 @@ class Framework
       end
 
       def calculate_for(entry)
-        column_names_for_entry = entry.data.dig(varies_by).to_s
-        percentage = value_to_percentage[column_names_for_entry.downcase]
+        column_names_for_entry = Array(varies_by).map { |column| entry.data.dig(column).downcase }
+        percentage = value_to_percentage.dig(*column_names_for_entry)
 
         if percentage.nil?
           Rollbar.error(
@@ -27,7 +27,7 @@ class Framework
       private
 
       def prepare_hash(hash)
-        hash.map { |k, v| [k.to_s.downcase, v] }.to_h
+        hash.deep_transform_keys(&:downcase).with_indifferent_access
       end
     end
   end

--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -27,7 +27,7 @@ class Framework
       private
 
       def prepare_hash(hash)
-        hash.deep_transform_keys(&:downcase).with_indifferent_access
+        hash.deep_transform_keys { |key| key.to_s.downcase }.with_indifferent_access
       end
 
       def percentage_for(column_names_for_entry)

--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -31,11 +31,13 @@ class Framework
       end
 
       def percentage_for(column_names_for_entry)
-        column_count = column_names_for_entry.size
-        percentage = nil
+        percentage = value_to_percentage.dig(*column_names_for_entry)
+        return percentage unless percentage.nil?
 
         # Fallback to the most relevant wildcard lookup
-        (column_count + 1).downto(0) do |position|
+        column_count = column_names_for_entry.size
+
+        column_count.downto(0) do |position|
           column_names_with_wildcards = column_names_for_entry.fill('*', position)
           percentage ||= value_to_percentage.dig(*column_names_with_wildcards)
         end

--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -10,7 +10,7 @@ class Framework
 
       def calculate_for(entry)
         column_names_for_entry = Array(varies_by).map { |column| entry.data.dig(column).downcase }
-        percentage = value_to_percentage.dig(*column_names_for_entry)
+        percentage = percentage_for(column_names_for_entry)
 
         if percentage.nil?
           Rollbar.error(
@@ -28,6 +28,19 @@ class Framework
 
       def prepare_hash(hash)
         hash.deep_transform_keys(&:downcase).with_indifferent_access
+      end
+
+      def percentage_for(column_names_for_entry)
+        column_count = column_names_for_entry.size
+        percentage = nil
+
+        # Fallback to the most relevant wildcard lookup
+        (column_count + 1).downto(0) do |position|
+          column_names_with_wildcards = column_names_for_entry.fill('*', position)
+          percentage ||= value_to_percentage.dig(*column_names_with_wildcards)
+        end
+
+        percentage
       end
     end
   end

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -164,6 +164,48 @@ RSpec.describe Framework::Definition::Parser do
             }
           )
         }
+
+        context 'with wildcards' do
+          let(:source) do
+            <<~FDL.strip
+              ManagementCharge varies_by 'Lot Number', 'Spend Code' {
+                '1', '*' -> 0.5%
+                '1', 'Lease Rental' -> 1.5%
+              }
+            FDL
+          end
+
+          it {
+            is_expected.to parse(source).as(
+              management_charge: {
+                column_based: {
+                  column_names: [
+                    { string: 'Lot Number' },
+                    { string: 'Spend Code' }
+                  ],
+                  value_to_percentage: {
+                    dictionary: [
+                      {
+                        key: [
+                          { string: '1' },
+                          { string: '*' }
+                        ],
+                        value: { decimal: '0.5' }
+                      },
+                      {
+                        key: [
+                          { string: '1' },
+                          { string: 'Lease Rental' }
+                        ],
+                        value: { decimal: '1.5' }
+                      }
+                    ]
+                  }
+                }
+              }
+            )
+          }
+        end
       end
     end
 

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -169,8 +169,9 @@ RSpec.describe Framework::Definition::Parser do
           let(:source) do
             <<~FDL.strip
               ManagementCharge varies_by 'Lot Number', 'Spend Code' {
-                '1', '*' -> 0.5%
+                '1', * -> 0.5%
                 '1', 'Lease Rental' -> 1.5%
+                *, * -> 2%
               }
             FDL
           end
@@ -188,7 +189,7 @@ RSpec.describe Framework::Definition::Parser do
                       {
                         key: [
                           { string: '1' },
-                          { string: '*' }
+                          { any_operator: '*' }
                         ],
                         value: { decimal: '0.5' }
                       },
@@ -198,6 +199,13 @@ RSpec.describe Framework::Definition::Parser do
                           { string: 'Lease Rental' }
                         ],
                         value: { decimal: '1.5' }
+                      },
+                      {
+                        key: [
+                          { any_operator: '*' },
+                          { any_operator: '*' }
+                        ],
+                        value: { integer: '2' }
                       }
                     ]
                   }

--- a/spec/models/framework/definition/parser_spec.rb
+++ b/spec/models/framework/definition/parser_spec.rb
@@ -87,30 +87,84 @@ RSpec.describe Framework::Definition::Parser do
     end
 
     context 'column based' do
-      let(:source) do
-        <<~FDL.strip
-          ManagementCharge varies_by 'Spend Code' {
-            'Lease Rental' -> 0.5%
-            'Damage'       -> 0%
-           }
-        FDL
-      end
+      context 'with one column' do
+        let(:source) do
+          <<~FDL.strip
+            ManagementCharge varies_by 'Spend Code' {
+              'Lease Rental' -> 0.5%
+              'Damage'       -> 0%
+             }
+          FDL
+        end
 
-      it {
-        is_expected.to parse(source).as(
-          management_charge: {
-            column_based: {
-              column_name: { string: 'Spend Code' },
-              value_to_percentage: {
-                dictionary: [
-                  { key: { string: 'Lease Rental' }, value: { decimal: '0.5' } },
-                  { key: { string: 'Damage' }, value: { integer: '0' } }
-                ]
+        it {
+          is_expected.to parse(source).as(
+            management_charge: {
+              column_based: {
+                column_names: {
+                  string: 'Spend Code'
+                },
+                value_to_percentage: {
+                  dictionary: [
+                    { key: { string: 'Lease Rental' }, value: { decimal: '0.5' } },
+                    { key: { string: 'Damage' }, value: { integer: '0' } }
+                  ]
+                }
               }
             }
-          }
-        )
-      }
+          )
+        }
+      end
+
+      context 'with two columns' do
+        let(:source) do
+          <<~FDL.strip
+            ManagementCharge varies_by 'Lot Number', 'Spend Code' {
+              '1', 'Lease Rental' -> 0.5%
+              '1', 'Damage' -> 0%
+              '2', 'Lease Rental' -> 1.5%
+            }
+          FDL
+        end
+
+        it {
+          is_expected.to parse(source).as(
+            management_charge: {
+              column_based: {
+                column_names: [
+                  { string: 'Lot Number' },
+                  { string: 'Spend Code' }
+                ],
+                value_to_percentage: {
+                  dictionary: [
+                    {
+                      key: [
+                        { string: '1' },
+                        { string: 'Lease Rental' }
+                      ],
+                      value: { decimal: '0.5' }
+                    },
+                    {
+                      key: [
+                        { string: '1' },
+                        { string: 'Damage' }
+                      ],
+                      value: { integer: '0' }
+                    },
+                    {
+                      key: [
+                        { string: '2' },
+                        { string: 'Lease Rental' }
+                      ],
+                      value: { decimal: '1.5' }
+                    }
+                  ]
+                }
+              }
+            }
+          )
+        }
+      end
     end
 
     context 'sector_based' do

--- a/spec/models/framework/management_charge_calculator/column_based_spec.rb
+++ b/spec/models/framework/management_charge_calculator/column_based_spec.rb
@@ -84,11 +84,11 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
         Framework::ManagementChargeCalculator::ColumnBased.new(
           varies_by: ['Lot Number', 'Spend Code'],
           value_to_percentage: {
-            '*': {
-              '*': BigDecimal('2.0')
+            Framework::Definition::AST::Any => {
+              Framework::Definition::AST::Any => BigDecimal('2.0')
             },
             '1': {
-              '*': BigDecimal('1.5'),
+              Framework::Definition::AST::Any => BigDecimal('1.5'),
               'Damages': BigDecimal('0.5')
             }
           }


### PR DESCRIPTION
## Changes in this PR:

Allow management charges to be calculated for multi-columns. This extends the `column_based` management charge calculation based of some of the work @jcoglan did for multi-column dependent fields.

This makes the following FDL management charge rule possible:

```ruby
ManagementCharge varies_by 'Lot Number', 'Spend Code' {
  '1', 'Lease Rental' -> 0.5%
  '1', 'Other Re-charges' -> 0.5%
  '1', 'Damages' -> 1%
  '2', 'Lease Rental' -> 1.5%
  '3', 'Lease Rental' -> 1.5%
  '4', 'Lease Rental' -> 1.5%
  '5', 'Lease Rental' -> 1.5%
}
```

Additionally, by adding treating the `*` as a wildcard, we can reduce the size of the lookup dictionary quite significantly (and even more so with three or more columns!):

```ruby
ManagementCharge varies_by 'Lot Number', 'Spend Code' {
  *, * -> 1.5%
  '1', * -> 0.5%
  '1', 'Damages' -> 1%
  }
```

Because we search first for an exact match, followed by the most relevant wildcard down to the "catch-all" rule (`*, * -> 1.5%`), these can be specified in an order.