### PR TITLE
Validate multi-column management charge calcs

### DIFF
--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -77,9 +77,15 @@ class Framework
         end
 
         def raise_when_management_field_invalid(info)
-          referenced_field_name = [info.dig(:column_based, :column_names), info.dig(:flat_rate, :column)].compact.first(&:present?)
-          return if referenced_field_name.nil?
+          management_charge_modifier = [info.dig(:column_based, :column_names), info.dig(:flat_rate, :column)].compact.first(&:present?)
+          return if management_charge_modifier.blank?
 
+          Array(management_charge_modifier).each do |referenced_field_name|
+            validate_management_field(referenced_field_name)
+          end
+        end
+
+        def validate_management_field(referenced_field_name)
           field = ast.field_by_sheet_name(:invoice, referenced_field_name)
           raise Transpiler::Error, "Management charge references '#{referenced_field_name}' which does not exist" if field.nil?
           raise Transpiler::Error, "Management charge references '#{referenced_field_name}' so it cannot be optional" if field.optional?

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -385,6 +385,37 @@ RSpec.describe Framework::Definition::Generator do
       end
     end
 
+    context 'with multi column management charge calculations' do
+      let(:source) do
+        <<~FDL
+          Framework 3787 {
+            Name 'Fake framework'
+            ManagementCharge varies_by 'Lot Number', 'Spend Code' {
+              '1', 'Lease Rental' -> 0.5%
+              '1', 'Damage' -> 0%
+              '2', 'Lease Rental' -> 1.5%
+            }
+
+            Lots {
+              '1' -> 'Lease of passenger motor vehicles and light commercial vehicles up to 3.5 tonnes'
+              '2' -> 'Lease of commercial vehicles 3.5 tonnes and above, including buses, coaches, tra'
+              '3' -> 'Provision of Fleet Management Services, including the management, sourcing and s'
+            }
+
+            InvoiceFields {
+              LotNumber from 'Lot Number'
+              PromotionCode from 'Spend Code'
+              InvoiceValue from 'Supplier Price'
+            }
+          }
+        FDL
+      end
+
+      it 'does not have any errors' do
+        expect(generator.error).to eq(nil)
+      end
+    end
+
     context 'Composing lookups from other lookups - RM3787' do
       let(:source) do
         <<~FDL


### PR DESCRIPTION
In the last feature (#556), we forgot to do an end to end test that included the validations. Currently, if we try to add a framework with a multi-column management charge, it chokes, because `raise_when_management_field_invalid` expects the modifier to always be a string. This updates the checker to cope with arrays too. I considered always casting the modifier to an array, and then flattening it, but I think checking the type and looping over if it's an array is less obtuse.