### PR TITLE
Add missing index on 'submissions.created_at'

### DIFF
--- a/db/migrate/20191204094848_add_index_on_submissions_created_at.rb
+++ b/db/migrate/20191204094848_add_index_on_submissions_created_at.rb
@@ -1,7 +1,10 @@
 class AddIndexOnSubmissionsCreatedAt < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
   def change
     add_index :submissions,
               :created_at,
-              order: { created_at: :desc }
+              order: { created_at: :desc },
+              algorithm: :concurrently
   end
 end

--- a/db/migrate/20191204094848_add_index_on_submissions_created_at.rb
+++ b/db/migrate/20191204094848_add_index_on_submissions_created_at.rb
@@ -1,0 +1,7 @@
+class AddIndexOnSubmissionsCreatedAt < ActiveRecord::Migration[5.2]
+  def change
+    add_index :submissions,
+              :created_at,
+              order: { created_at: :desc }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_23_072354) do
+ActiveRecord::Schema.define(version: 2019_12_04_094848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -172,6 +172,7 @@ ActiveRecord::Schema.define(version: 2019_10_23_072354) do
     t.decimal "management_charge_total", precision: 18, scale: 4
     t.decimal "invoice_total", precision: 18, scale: 4
     t.index ["aasm_state"], name: "index_submissions_on_aasm_state"
+    t.index ["created_at"], name: "index_submissions_on_created_at", order: :desc
     t.index ["created_by_id"], name: "index_submissions_on_created_by_id"
     t.index ["framework_id"], name: "index_submissions_on_framework_id"
     t.index ["submitted_by_id"], name: "index_submissions_on_submitted_by_id"


### PR DESCRIPTION
In July 2018 it was noted that the `submissions.created_at`
field ought to be indexed as it was now used in a query:

https://github.com/dxw/DataSubmissionServiceAPI/issues/23

This is `Task#latest_submission`
(https://github.com/dxw/DataSubmissionServiceAPI/commit/f46dd46f88e3347995a4504c5dad11130c9dbbd6)
which is used by the 'no_business' endpoint
(`/v1/tasks/#{task.id}/no_business`)

As the query selecting the most recent submission uses:

`has_one :latest_submission, -> { order(created_at: :desc) }`

I've opted for an index which is 'sorted' to suit.

This work was requested in order to improve the problematic
daily export procedure invoked via
`DataWarehouseExport.generate!` which runs out of memory
and times out regularly.

This unindexed field (`submissions.created_at`) isn't
actually involved in any of the 4 "extractions" which run.
We believe that the 2 problem extractions are

- `Export::Invoices::Extract`
- `Export::Contracts::Extract`

and that improvements to these may be brought about by
adding the following indexes:

- `tasks.updated_at`
- `submissions.updated_at`
- `submission_entries.updated_at`

The following PR will add these indexes.

