### PR TITLE
Add missing indexes to speed up daily export

### DIFF
--- a/db/migrate/20191204154559_add_missing_indexes.rb
+++ b/db/migrate/20191204154559_add_missing_indexes.rb
@@ -1,0 +1,9 @@
+class AddMissingIndexes < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :submissions,        :updated_at, using: :brin, algorithm: :concurrently
+    add_index :submission_entries, :updated_at, using: :brin, algorithm: :concurrently
+    add_index :tasks,              :updated_at, using: :brin, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_04_094848) do
+ActiveRecord::Schema.define(version: 2019_12_04_154559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -139,6 +139,7 @@ ActiveRecord::Schema.define(version: 2019_12_04_094848) do
     t.index ["source"], name: "index_submission_entries_on_source", using: :gin
     t.index ["submission_file_id"], name: "index_submission_entries_on_submission_file_id"
     t.index ["submission_id"], name: "index_submission_entries_on_submission_id"
+    t.index ["updated_at"], name: "index_submission_entries_on_updated_at", using: :brin
   end
 
   create_table "submission_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -178,6 +179,7 @@ ActiveRecord::Schema.define(version: 2019_12_04_094848) do
     t.index ["submitted_by_id"], name: "index_submissions_on_submitted_by_id"
     t.index ["supplier_id"], name: "index_submissions_on_supplier_id"
     t.index ["task_id"], name: "index_submissions_on_task_id"
+    t.index ["updated_at"], name: "index_submissions_on_updated_at", using: :brin
   end
 
   create_table "suppliers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -200,6 +202,7 @@ ActiveRecord::Schema.define(version: 2019_12_04_094848) do
     t.index ["framework_id"], name: "index_tasks_on_framework_id"
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["supplier_id"], name: "index_tasks_on_supplier_id"
+    t.index ["updated_at"], name: "index_tasks_on_updated_at", using: :brin
   end
 
   create_table "urn_lists", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
The indexes on the 3 fields have been defined as BRIN
(Block Range Index) as these are much smaller than B-Tree
when indexing timestamps. See:

https://karolgalanciak.com/blog/2018/08/19/indexes-on-rails-how-to-make-the-most-of-your-postgres-database/

This work has been requested in order to improve the
problematic daily export procedure invoked via
`DataWarehouseExport.generate!` which runs out of memory
and times out regularly.

We believe that the 2 problem extractions are:

- `Export::Invoices::Extract`
- `Export::Contracts::Extract`

and that improvements to these may be brought about by
adding the following indexes:

- `tasks.updated_at`
- `submissions.updated_at`
- `submission_entries.updated_at`

But we actually believe that the main problem is Postgres
memory:

- the index on SubmissionEntry no longer fits in memory: we
  are going to look into increasing the memory allocation in
  Postgres

- the `submission_entries.*` glob in the SELECT statement
  may include more data than is required: we will
  explore whether a sub-set of the SubmissionEntry fields can
  be returned by the DB

Zendesk
: https://dxw.zendesk.com/agent/tickets/10463

Trello
: https://trello.com/c/GeaLyAWy/1162

## Changes in this PR:

## Screenshots of UI changes:

### Before

### After
