### PR TITLE
Add 'maintenance_work_mem' setting for Postgres

### DIFF
--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -22,5 +22,6 @@ applications:
     env:
       RAILS_ENV: production
       RAILS_MAX_THREADS: 5
+      PG_MAINTENANCE_WORK_MEM: '1GB'
       SUBMIT_INVOICES: 'true'
       NEW_INGEST: 'true'

--- a/CF/sidekiq-manifest-template.yml
+++ b/CF/sidekiq-manifest-template.yml
@@ -21,6 +21,7 @@ applications:
     env:
       RAILS_ENV: production
       RAILS_MAX_THREADS: SIDEKIQ_CONCURRENCY
+      PG_MAINTENANCE_WORK_MEM: '1GB'
       SUBMIT_INVOICES: 'true'
       NEW_INGEST: 'true'
       MALLOC_ARENA_MAX: 2

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,6 +8,7 @@ default: &default
   pool: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>
   variables:
     work_mem: <%= ENV.fetch('PG_WORK_MEM') { '16MB' } %>
+    maintenance_work_mem: <%= ENV.fetch('PG_MAINTENANCE_WORK_MEM') { '128MB' } %>
 
 development:
   <<: *default


### PR DESCRIPTION
Adding indexes can be memory intensive so we now set the
Postgres `maintenance_work_mem` parameter explicitly.

Following the advice on:

http://rhaas.blogspot.com/2019/01/how-much-maintenanceworkmem-do-i-need.html

We set the production value (via the
`PG_MAINTENANCE_WORK_MEM` environment variable) to 1GB and
default to 128MB in other environments.

