### PR TITLE
(fix) Support integer column headings in mgnmt charge calculation

### DIFF
--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -9,7 +9,7 @@ class Framework
       end
 
       def calculate_for(entry)
-        column_names_for_entry = Array(varies_by).map { |column| entry.data.dig(column).downcase }
+        column_names_for_entry = Array(varies_by).map { |column| entry.data.dig(column).to_s.downcase }
         percentage = percentage_for(column_names_for_entry)
 
         if percentage.nil?

--- a/spec/models/framework/management_charge_calculator/column_based_spec.rb
+++ b/spec/models/framework/management_charge_calculator/column_based_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     expect(calculator.calculate_for(entry)).to eq(6.1725) # 5% of 123.45
   end
 
+  it 'handles column values that are integers' do
+    entry = FactoryBot.create(:submission_entry, total_value: 123.45, data: { test_value: 1 })
+
+    calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
+      varies_by: 'test_value',
+      value_to_percentage: {
+        '1': BigDecimal('5')
+      }
+    )
+
+    expect(calculator.calculate_for(entry)).to eq(6.1725) # 5% of 123.45
+  end
+
   it 'rounds to four decimal places' do
     entry = FactoryBot.create(:submission_entry, total_value: 42.424242, data: { test_value: 'test' })
 


### PR DESCRIPTION
Some submissions are using integers rather than strings as
column headings. e.g. the number `1` rather than the string
`'One'`

See:

Trello
: https://trello.com/c/xc3U8hth/1165

Zendesk
: https://dxw.zendesk.com/agent/tickets/10518
