### PR TITLE
Fix/1166 multi column management charge calculation

### DIFF
--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -31,7 +31,7 @@ class Framework
       end
 
       def percentage_for(column_names_for_entry)
-        percentage = value_to_percentage.dig(*column_names_for_entry)
+        percentage = value_to_percentage.dig(column_names_for_entry.to_s)
         return percentage unless percentage.nil?
 
         # Fallback to the most relevant wildcard lookup

--- a/spec/models/framework/definition/language/generator_spec.rb
+++ b/spec/models/framework/definition/language/generator_spec.rb
@@ -414,7 +414,21 @@ RSpec.describe Framework::Definition::Generator do
       it 'does not have any errors' do
         expect(generator.error).to eq(nil)
       end
+
+      # rubocop:disable Style/StringLiterals
+      it 'uses escaped Array literal keys for lookup' do
+        value_to_percentage = generator.definition
+                                       .management_charge
+                                       .value_to_percentage
+
+        expect(value_to_percentage).to eq(
+          "[\"1\", \"lease rental\"]" => 0.5e0,
+          "[\"1\", \"damage\"]"       => 0,
+          "[\"2\", \"lease rental\"]" => 0.15e1
+        )
+      end
     end
+    # rubocop:enable Style/StringLiterals
 
     context 'Composing lookups from other lookups - RM3787' do
       let(:source) do


### PR DESCRIPTION
When a management charge uses a multi-column
management charge lookup, each lookup key is composed
of two column names in a list (a literal array).

Importantly, we note that the double quotes are escaped.

eg in order to retrieve a given percentage we will need to
address the lookup with an escaped key e.g.

 `"[\"1\", \"transactional\"]"`

rather than with:

`["1", "transactional"]`

For background see:

Trello
: https://trello.com/c/ByWy1brb/1166

Zendesk
: https://dxw.zendesk.com/agent/tickets/10523
