### PR TITLE
Fix local docker development environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     volumes:
       - .:/srv/dss-api:cached
       - node_modules:/srv/dss-api/node_modules:cached
-    command: bash -c "rm -f tmp/pids/server.pid && rails s"
+    command: bash -c "rm -f tmp/pids/server.pid && rails s -b 0.0.0.0"
     container_name: "data-submission-service-api_web"
     networks:
       public:


### PR DESCRIPTION
This is what I did to get the applicaiton working in Docker locally. There are two main things that seem to have changed and become issues:

1. Bundler
A recent version of bundler (2.1.0) introduced an issue where binstubs paths are not as expected (I think) so commands no longer work without `bundle exec` in-front of them. Change the PATH allows the comands to be located correctly.

See the recommended solution here:
https://github.com/bundler/bundler/issues/7494

2. Puma address binding
Puma seems to default to binding to `localhost` which stops Docker address mappings working. By specifying `0.0.0.0` this issue goes away. I am not sure if this 'hammer to crack a nut' approach is the best one, but it gets the app working locally at least.
