### PR TITLE
Adding users in bulk results in 504 error if >100 users are added in a single file

### DIFF
--- a/app/jobs/user_import_job.rb
+++ b/app/jobs/user_import_job.rb
@@ -1,0 +1,31 @@
+require 'tempfile'
+require 'aws-sdk-s3'
+
+class UserImportJob < ApplicationJob
+  retry_on Aws::S3::Errors::ServiceError
+  discard_on Import::Users::InvalidSalesforceId
+
+  def perform(user_list_key)
+    temp_file = Tempfile.new(user_list_key)
+    temp_file.binmode
+
+    s3_client.get_object({ bucket: bucket, key: user_list_key }, target: temp_file)
+
+    Rollbar.info("Bulk user import started for: #{user_list_key}")
+    Import::Users.new(temp_file).run
+  ensure
+    temp_file.close
+    temp_file.unlink
+    s3_client.delete_object(bucket: bucket, key: user_list_key)
+  end
+
+  private
+
+  def s3_client
+    @s3_client ||= Aws::S3::Client.new(region: ENV['AWS_S3_REGION'])
+  end
+
+  def bucket
+    ENV.fetch('AWS_S3_BUCKET')
+  end
+end

--- a/app/models/import/users.rb
+++ b/app/models/import/users.rb
@@ -33,6 +33,7 @@ module Import
     attr_reader :logger, :wait_time
 
     def initialize(csv_path, wait_time: DEFAULT_WAIT, logger: Logger.new(STDOUT))
+      @csv_path = csv_path
       @csv = CSV.read(csv_path, headers: true, header_converters: :symbol)
       @logger = logger
       @wait_time = wait_time
@@ -49,6 +50,7 @@ module Import
           wait
         end
       end
+      Rollbar.info("Bulk user import completed: #{@csv_path}")
     end
 
     private

--- a/app/services/upload_user_list.rb
+++ b/app/services/upload_user_list.rb
@@ -1,0 +1,34 @@
+require 'aws-sdk-s3'
+require 'tmpdir'
+
+class UploadUserList
+  class UploadError < StandardError
+    def message
+      'Uploading the user list to S3 failed.'
+    end
+  end
+
+  def initialize(user_list_path)
+    @user_list_path = user_list_path
+  end
+
+  def call
+    csv_key = "#{SecureRandom.urlsafe_base64}-#{@user_list_path.gsub(%r{.*?/}, '')}"
+
+    s3 = Aws::S3::Resource.new(region: region)
+    obj = s3.bucket(bucket).object(csv_key)
+    raise UploadError unless obj.upload_file(@user_list_path)
+
+    csv_key
+  end
+
+  private
+
+  def bucket
+    ENV.fetch('AWS_S3_BUCKET')
+  end
+
+  def region
+    ENV.fetch('AWS_S3_REGION')
+  end
+end

--- a/spec/jobs/user_import_job_spec.rb
+++ b/spec/jobs/user_import_job_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe UserImportJob do
+  around do |example|
+    ClimateControl.modify AWS_S3_BUCKET: 'fake', AWS_S3_REGION: 'zz-north-1' do
+      example.run
+    end
+  end
+
+  describe '#perform' do
+    before do
+      Aws.config[:s3] = { stub_responses: true }
+      allow(Import::Users).to receive(:new).and_return(importer)
+    end
+
+    let(:importer) { double('User Importer') }
+
+    it 'passes the user list to Import::Users' do
+      allow(importer).to receive(:run).and_return true
+
+      expect(importer).to receive(:run)
+      UserImportJob.perform_now('users.csv')
+    end
+
+    it 'does not retry the job when the import raises an Import::Users::InvalidSalesforceId error' do
+      allow(importer).to receive(:run).and_raise Import::Users::InvalidSalesforceId.new('fake')
+
+      expect_any_instance_of(UserImportJob).not_to receive(:retry_job)
+      UserImportJob.perform_now('user.csv')
+    end
+
+    it 'retries when the import raises a Aws::S3::Errors::ServiceError' do
+      s3_client = double
+      allow(Aws::S3::Client).to receive(:new).and_return s3_client
+      allow(s3_client).to receive(:get_object).and_raise Aws::S3::Errors::ServiceError.new('fake', 'fake')
+      allow(s3_client).to receive(:delete_object).and_return(Aws::S3::Types::DeleteObjectOutput.new)
+
+      expect_any_instance_of(UserImportJob).to receive(:retry_job)
+      UserImportJob.perform_now('user.csv')
+    end
+  end
+end

--- a/spec/services/upload_user_list_spec.rb
+++ b/spec/services/upload_user_list_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe UploadUserList do
+  around do |example|
+    ClimateControl.modify AWS_S3_BUCKET: 'fake', AWS_S3_REGION: 'zz-north-1' do
+      example.run
+    end
+  end
+
+  before do
+    allow(SecureRandom).to receive(:urlsafe_base64).and_return('foofoofoo')
+
+    Aws.config[:s3] = { stub_responses: true }
+  end
+
+  describe '#call' do
+    it 'uploads the file to S3 and returns the key' do
+      user_list_path = Rails.root.join('spec', 'fixtures', 'users.csv').to_s
+
+      expect(described_class.new(user_list_path).call).to eq('foofoofoo-users.csv')
+    end
+
+    it 'raises an error when something goes wrong' do
+      allow_any_instance_of(Aws::S3::Object).to receive(:upload_file).and_return(false)
+
+      user_list_path = Rails.root.join('spec', 'fixtures', 'users.csv').to_s
+
+      expect { described_class.new(user_list_path).call }.to raise_error UploadUserList::UploadError
+    end
+
+    it 'raises an error when a file split into parts does not upload' do
+      s3_upload_error = Aws::S3::MultipartUploadError.new('error', [])
+
+      allow_any_instance_of(Aws::S3::Object).to receive(:upload_file).and_raise(s3_upload_error)
+
+      user_list_path = Rails.root.join('spec', 'fixtures', 'users.csv').to_s
+
+      expect { described_class.new(user_list_path).call }.to raise_error s3_upload_error
+    end
+  end
+end


### PR DESCRIPTION
The main goal of this work is to successfully bulk import large numbers of users so that CCS can on-board DOS4. With that in mind, we've skipped the UI part as it is too much scope for now. 

Instead we'll log to rollbar, which CCS can access to allow them to complete the task and we'll create a new card to followup with UI so it can be prioritised.

----

This is unfinished but I hope it won't take *too* much effort to finish. Feel free to grab me if you need an explanation.

Previously the users CSV was being uploaded and the users created synchronously. This was timing out.

My strategy has been to:
1. The admin uploads the Users CSV to S3 and sees a message saying the import will happen asynchronously
2. Create a job (`UserImportJob`) to download that file from S3 and pass it to `Import::Users`
3. `Import::Users` processes the users as before (unchanged)

There isn't *loads* left to do, as far as I can tell what's missing is:

1. Add a failure scenario to `UploadUserList` spec
2. Delete the temp Users CSV from S3 once the job is finished
3. Previously, errors in the CSV (e.g. incorrect column names; `InvalidSalesforceId` for users) were shown to the admin user right away on the page; now we need to pass them and log them *somewhere* and (presumably) tell the admin later on if a problem occurred.