### PR TITLE
Extract log event for completed user import to UserImportJob

### DIFF
--- a/app/jobs/user_import_job.rb
+++ b/app/jobs/user_import_job.rb
@@ -12,7 +12,9 @@ class UserImportJob < ApplicationJob
     s3_client.get_object({ bucket: bucket, key: user_list_key }, target: temp_file)
 
     Rollbar.info("Bulk user import started for: #{user_list_key}")
+
     Import::Users.new(temp_file).run
+    Rollbar.info("Bulk user import completed for: #{user_list_key}")
   ensure
     temp_file.close
     temp_file.unlink

--- a/app/models/import/users.rb
+++ b/app/models/import/users.rb
@@ -50,7 +50,6 @@ module Import
           wait
         end
       end
-      Rollbar.info("Bulk user import completed: #{@csv_path}")
     end
 
     private


### PR DESCRIPTION
The client would like a way to tie together the log entries for the user import starting and finishing.

At the moment the log entries look like this:

```
Bulk user import started for: <random-string>-20200123-9-12smexd.csv
Bulk user import completed: #<File:0x000055ca51ba4fc0>
```

I considered just logging `temp_file.path` as both methods have access to `temp_file` however it wouldn't necessarily be unique per upload. I didn't want to change the method signature for `Import::Users#run` as it already has quite a few optional arguments.
