### PR TITLE
Fix fdl:transpile

### DIFF
--- a/lib/tasks/fdl.rake
+++ b/lib/tasks/fdl.rake
@@ -1,8 +1,11 @@
 namespace :fdl do
   desc 'Transpile a framework from source'
-  task :transpile, %i[framework_short_name] => [:environment] do |_task, args|
-    framework_short_name = args[:framework_short_name] or raise ArgumentError, 'framework_short_name required'
+  task :transpile, %i[file_name] => [:environment] do |_task, args|
+    file_name = args[:file_name] or raise ArgumentError, 'file_name required'
 
-    Framework::Definition::Language[framework_short_name]
+    fdl_source = File.read(file_name)
+    generator = Framework::Definition::Generator.new(fdl_source)
+    # Transpiles using STDERR as output. If all ok, no output
+    generator.success?
   end
 end


### PR DESCRIPTION
After the refactoring removing `Framework::Definition::Language`, and
after having moved FDL almost entirely to the database, this task
wasn't working any more.

Make it take a filename instead of a framework so we can check
the transpilation of things locally during dev with syntax errors
 going to `STDERR`.