### PR TITLE
Bump Python to v3.7.6

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.4
+python-3.7.6


### PR DESCRIPTION
The version (3.7.4) we were previously using is no longer available on GPaaS, so
any infrastructure changes were causing the Sidekiq instance to fail to
build.