### PR TITLE
(1183) Expose 'other_count' on submission API endpoint

### DIFF
--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -20,6 +20,10 @@ class SerializableSubmission < JSONAPI::Serializable::Resource
     submission.entries.orders.count
   end
 
+  attribute :other_count do
+    submission.entries.others.count
+  end
+
   attribute :invoice_total_value do
     submission.total_spend
   end

--- a/spec/factories/submission_entry.rb
+++ b/spec/factories/submission_entry.rb
@@ -20,6 +20,11 @@ FactoryBot.define do
       sheet_name 'OrdersReceived'
     end
 
+    factory :other_entry do
+      entry_type 'other'
+      sheet_name 'Bid Invitations'
+    end
+
     trait :valid do
       aasm_state :validated
     end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe '/v1' do
       expect(response).to be_successful
 
       expect(json['data']).to have_id(submission.id)
+
+      expect(json['data']).to have_attributes(
+        :framework_id, :supplier_id, :task_id,
+        :purchase_order_number, :status,
+        :invoice_count, :order_count, :other_count,
+        :invoice_total_value, :order_total_value,
+        :sheet_errors, :report_no_business?, :submitted_at,
+        :file_key, :filename
+      )
     end
 
     it 'optionally includes submission files' do

--- a/spec/serializable/serializable_submission_spec.rb
+++ b/spec/serializable/serializable_submission_spec.rb
@@ -1,8 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe SerializableSubmission do
-  context 'given a submission with invoices and orders' do
-    let(:submission) { FactoryBot.create(:completed_submission) }
+  context 'given a submission with invoices, orders and others' do
+    let(:submission) do
+      FactoryBot.create(:completed_submission) do |submission|
+        FactoryBot.create(:other_entry, submission: submission)
+      end
+    end
+
     let(:serialized_submission) { SerializableSubmission.new(object: submission) }
 
     it 'exposes a count of the number of invoice entries' do
@@ -11,6 +16,10 @@ RSpec.describe SerializableSubmission do
 
     it 'exposes a count of the number of order entries' do
       expect(serialized_submission.as_jsonapi[:attributes][:order_count]).to eq(1)
+    end
+
+    it 'exposes a count of the number of other entries' do
+      expect(serialized_submission.as_jsonapi[:attributes][:other_count]).to eq(1)
     end
 
     it 'exposes the total value of invoice entries' do
@@ -27,7 +36,9 @@ RSpec.describe SerializableSubmission do
 
     it 'exposes a sheet_errors hash' do
       expect(serialized_submission.as_jsonapi[:attributes][:sheet_errors]).to eq(
-        'InvoicesRaised' => [], 'OrdersReceived' => []
+        'InvoicesRaised' => [],
+        'OrdersReceived' => [],
+        'Bid Invitations' => []
       )
     end
 


### PR DESCRIPTION
We need to show the end user the number of 'other' fields that were
submitted on the submission summary page, therefore we need to expose it
from the API.

NB: This will be followed up by a change to the frontend application to use the new `other_count` attribute.