### PR TITLE
(1171) Stop coercing URNs to integer

### DIFF
--- a/app/models/framework/definition/ast/field.rb
+++ b/app/models/framework/definition/ast/field.rb
@@ -103,12 +103,6 @@ class Framework
           known? ? warehouse_name : source_type
         end
 
-        ##
-        # The implementation type. Usually :string
-        def activemodel_type
-          %i[urn].include?(primitive_type) ? :integer : :string
-        end
-
         def validators?
           PRIMITIVE_TYPE_VALIDATIONS.fetch(primitive_type).any?
         end

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -62,7 +62,7 @@ class Framework
             # Always use a case_insensitive_inclusion validator if
             # there's a lookup with the same name as the field
             lookup_values = ast.lookups[field.lookup_name]
-            field field.sheet_name, field.activemodel_type, field.options(lookup_values)
+            field field.sheet_name, :string, field.options(lookup_values)
           end
         end
       end

--- a/app/validators/urn_validator.rb
+++ b/app/validators/urn_validator.rb
@@ -1,7 +1,14 @@
 class UrnValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if Customer.exists?(urn: value)
+    return if numeric?(value) && Customer.exists?(urn: value)
 
     record.errors.add(attribute, :invalid_urn)
+  end
+
+  private
+
+  def numeric?(value)
+    # This is cheaper than 'Integer(value) rescue false'
+    value.to_i.to_s == value
   end
 end

--- a/spec/models/framework/definition/generator_spec.rb
+++ b/spec/models/framework/definition/generator_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Framework::Definition::Generator do
 
           it 'is a valid URN' do
             expect(invoice_class).to have_field('Customer URN')
-              .with_activemodel_type(:integer)
+              .with_activemodel_type(:string)
               .validated_by(:urn)
               .not_validated_by(:presence)
           end

--- a/spec/validators/urn_validator_spec.rb
+++ b/spec/validators/urn_validator_spec.rb
@@ -13,17 +13,29 @@ RSpec.describe UrnValidator do
     end
   end
 
-  it 'is valid for URNs that exist' do
-    FactoryBot.create(:customer, urn: 12345678)
-
-    entry_data = entry_data_class.new(SubmissionEntry.new(data: { 'Customer URN' => '12345678' }))
-
-    expect(entry_data).to be_valid
+  subject(:entry_data) do
+    entry_data_class.new(SubmissionEntry.new(data: { 'Customer URN' => urn }))
   end
 
-  it 'is invalid for a missing URN' do
-    entry_data = entry_data_class.new(SubmissionEntry.new(data: { 'Customer URN' => '88888888' }))
+  before do
+    create(:customer, urn: 12345678)
+  end
 
-    expect(entry_data).not_to be_valid
+  context 'URN exists' do
+    let(:urn) { '12345678' }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'URN is missing' do
+    let(:urn) { '88888888' }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with a value that Ruby would incorrectly coerce with to_i to 12345678' do
+    let(:urn) { '12345678 Hey Duggee' }
+
+    it { is_expected.not_to be_valid }
   end
 end


### PR DESCRIPTION
The data warehouse export contained invalid URNs when a customer submitted a value which contained a valid URN *followed by* additional data (e.g. "12345 invalid").

This revealed two cases where Rails was unexpectedly calling `to_i` on the URN:

1) In our anonymous ActiveModel-like class, we were declaring the URN field as integer and `to_i` was biting us as the URN attribute was being set via the [initializer in `EntryData`](https://github.com/dxw/DataSubmissionServiceAPI/blob/204bf64a7dd6167524f0ade4ab84f4866fcde9e8/app/models/framework/entry_data.rb#L16)
2) In URNValidator, `Customer.exists?(urn: value)`

This caused an unexpected behaviour which lead to invalid URNs being
incorrectly marked as valid, and subsequently an invalid submission
being submitted to CCS.

Stopping treating the URN as an integer in our anonymous class means no
coercion happens when setting the attribute.