### PR TITLE
(1153) management charge percentage isn't interpreted correctly

### DIFF
--- a/app/models/framework/management_charge_calculator/column_based.rb
+++ b/app/models/framework/management_charge_calculator/column_based.rb
@@ -21,7 +21,7 @@ class Framework
           return 0.0
         end
 
-        (entry.total_value * (percentage / 100)).truncate(4)
+        (entry.total_value * (BigDecimal(percentage) / 100)).truncate(4)
       end
 
       private

--- a/app/models/framework/management_charge_calculator/sector_based.rb
+++ b/app/models/framework/management_charge_calculator/sector_based.rb
@@ -17,7 +17,7 @@ class Framework
       def percentage(entry)
         urn = entry.customer_urn
         sector = Customer.select(:sector).find_by(urn: urn).sector
-        send(sector)
+        BigDecimal(send(sector))
       end
     end
   end

--- a/spec/models/framework/management_charge_calculator/column_based_spec.rb
+++ b/spec/models/framework/management_charge_calculator/column_based_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     expect(calculator.calculate_for(entry)).to eq(0.2121) # 0.5% of 123.45
   end
 
+  it 'correctly calculates charges when FDL gives integer percentages' do
+    entry = FactoryBot.create(:submission_entry, total_value: 42.424242, data: { test_value: 'test' })
+
+    calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
+      varies_by: 'test_value',
+      value_to_percentage: {
+        'test': 1
+      }
+    )
+
+    expect(calculator.calculate_for(entry)).to eq(0.4242) # 1% of 42.424242
+  end
+
   it 'when the lookup fails, which should have been caught by validation, assume zero rate' do
     entry = FactoryBot.create(:submission_entry, total_value: 42.424242, data: { test_value: 'invalid' })
 

--- a/spec/models/framework/management_charge_calculator/sector_based_spec.rb
+++ b/spec/models/framework/management_charge_calculator/sector_based_spec.rb
@@ -2,9 +2,16 @@ require 'rails_helper'
 
 RSpec.describe Framework::ManagementChargeCalculator::SectorBased do
   let(:calculator) do
+    # Comes from an imagined piece of FDL that has both
+    # integer and decimal and looks like:
+    #
+    # ManagementCharge sector_based {
+    #   CentralGovernment -> 50%
+    #   WiderPublicSector -> 100.0%
+    # }
     Framework::ManagementChargeCalculator::SectorBased.new(
-      central_government: BigDecimal('50'),
-      wider_public_sector: BigDecimal('100')
+      central_government:  Integer('50'),
+      wider_public_sector: BigDecimal('100.0')
     )
   end
   let(:data)     { { 'Customer URN' => customer.urn } }


### PR DESCRIPTION
Prior to this PR, column- and sector-based `Integer` percentages were incorrectly calculated as zero. This was due to us not casting percentages to a floating point type before allowing them to participate in calculations.
