### PR TITLE
(1184) Allow management charge to combine 'varies_by' and 'of ...'

### DIFF
--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -77,12 +77,24 @@ class Framework
         end
 
         def raise_when_management_field_invalid(info)
-          management_charge_modifier = [info.dig(:column_based, :column_names), info.dig(:flat_rate, :column)].compact.first(&:present?)
-          return if management_charge_modifier.blank?
+          of_columns_for(info).each { |referenced_field_name| validate_management_field(referenced_field_name) }
+        end
 
-          Array(management_charge_modifier).each do |referenced_field_name|
-            validate_management_field(referenced_field_name)
-          end
+        def of_columns_for(info)
+          Array(
+            if info[:column_based]
+              varies_by = Array(info[:column_based][:column_names])
+
+              percentage_columns = info[:column_based][:value_to_percentage]
+                                     .values
+                                     .select { |percentage_details| percentage_details[:column].present? }
+                                     .map    { |percentage_details| percentage_details[:column] }
+
+              varies_by.concat percentage_columns
+            elsif info[:flat_rate]
+              info.dig(:flat_rate, :column)
+            end
+          )
         end
 
         def validate_management_field(referenced_field_name)

--- a/app/models/framework/definition/parser.rb
+++ b/app/models/framework/definition/parser.rb
@@ -22,8 +22,7 @@ class Framework
       end
       rule(:framework_name)       { str('Name') >> spaced(string.as(:framework_name)) }
       rule(:management_charge)    { str('ManagementCharge') >> (column_based | flat_rate | sector_based).as(:management_charge) }
-      rule(:flat_rate)            { (spaced(percentage).as(:value) >> flat_rate_column.maybe).as(:flat_rate) }
-      rule(:flat_rate_column)     { spaced(str('of')) >> string.as(:column) }
+      rule(:flat_rate)            { percentage_exp.as(:flat_rate) }
       rule(:column_based)         { spaced(str('varies_by')) >> (column_names.as(:column_names) >> multi_key_dictionary.as(:value_to_percentage)).as(:column_based) }
       rule(:sector_based)         { spaced(str('sector_based')) >> spaced(dictionary).as(:sector_based) }
 
@@ -63,7 +62,7 @@ class Framework
       rule(:metadata)             { framework_name >> management_charge }
 
       rule(:allowable_key)        { string | pascal_case_identifier }
-      rule(:allowable_value)      { percentage | lookup_reference | string }
+      rule(:allowable_value)      { percentage_exp | lookup_reference | string }
       rule(:dictionary)           { braced(map_with(allowable_key).repeat(1).as(:dictionary)) }
 
       rule(:allowable_multi_keys) { allowable_multi_key >> (spaced(str(',')) >> allowable_multi_key).repeat }
@@ -83,7 +82,11 @@ class Framework
 
       rule(:integer)    { match(/[0-9]/).repeat.as(:integer) }
       rule(:decimal)    { (match(/[0-9]/).repeat >> (str('.') >> match(/[0-9]/).repeat >> space?)).as(:decimal) }
-      rule(:percentage) { (decimal | integer) >> str('%') }
+
+      rule(:percentage)     { (decimal | integer) >> str('%') }
+      rule(:of_column)      { spaced(str('of')) >> string.as(:column) }
+      rule(:percentage_exp) { spaced(percentage).as(:percentage) >> of_column.maybe }
+
       rule(:range)      { (range_exp | integer.as(:is)).as(:range) }
       rule(:range_exp)  { integer.as(:min).maybe >> str('..') >> integer.as(:max).maybe }
 

--- a/app/models/framework/definition/transpiler.rb
+++ b/app/models/framework/definition/transpiler.rb
@@ -76,12 +76,12 @@ class Framework
           )
         elsif info[:sector_based]
           ManagementChargeCalculator::SectorBased.new(
-            central_government:  info[:sector_based][:central_government],
-            wider_public_sector: info[:sector_based][:wider_public_sector]
+            central_government:  info[:sector_based][:central_government][:percentage],
+            wider_public_sector: info[:sector_based][:wider_public_sector][:percentage]
           )
         elsif info[:flat_rate]
           ManagementChargeCalculator::FlatRate.new(
-            percentage: info[:flat_rate][:value],
+            percentage: info[:flat_rate][:percentage],
             column:     info[:flat_rate][:column]
           )
         end

--- a/spec/models/framework/management_charge_calculator/column_based_spec.rb
+++ b/spec/models/framework/management_charge_calculator/column_based_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
       varies_by: 'test_value',
       value_to_percentage: {
-        'other': 0,
-        'test': BigDecimal('10')
+        'other': { percentage: 0 },
+        'test': { percentage: BigDecimal('10') }
       }
     )
 
@@ -21,7 +21,7 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
       varies_by: 'test_value',
       value_to_percentage: {
-        'Test': BigDecimal('5')
+        'Test': { percentage: BigDecimal('5') }
       }
     )
 
@@ -34,7 +34,7 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
       varies_by: 'test_value',
       value_to_percentage: {
-        '1': BigDecimal('5')
+        '1': { percentage: BigDecimal('5') }
       }
     )
 
@@ -47,7 +47,7 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
       varies_by: 'test_value',
       value_to_percentage: {
-        'test': BigDecimal('0.5')
+        'test': { percentage: BigDecimal('0.5') }
       }
     )
 
@@ -60,7 +60,7 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
       varies_by: 'test_value',
       value_to_percentage: {
-        'test': 1
+        'test': { percentage: 1 }
       }
     )
 
@@ -73,7 +73,7 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
     calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
       varies_by: 'test_value',
       value_to_percentage: {
-        'test': BigDecimal('0.5')
+        'test': { percentage: BigDecimal('0.5') }
       }
     )
 
@@ -93,12 +93,32 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
       calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
         varies_by: ['Lot Number', 'Spend Code'],
         value_to_percentage: {
-          ['1', 'Other Re-charges'] => BigDecimal('0.5'),
-          ['2', 'Other Re-charges'] => BigDecimal('1.5')
+          ['1', 'Other Re-charges'] => { percentage: BigDecimal('0.5') },
+          ['2', 'Other Re-charges'] => { percentage: BigDecimal('1.5') }
         }
       )
 
       expect(calculator.calculate_for(entry)).to eql(36) # 1.5% of 2,400.00
+    end
+
+    context 'percentage is calculated from another column for a particular lot number' do
+      it 'calculates the management charge for an entry' do
+        entry = FactoryBot.create(:submission_entry,
+                                  total_value: 2400.0,
+                                  data: {
+                                    'Lot Number': '2',
+                                    'Other Price': 100.00
+                                  })
+
+        calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
+          varies_by: ['Lot Number'],
+          value_to_percentage: {
+            ['2'] => { percentage: BigDecimal('1.5'), column: 'Other Price' }
+          }
+        )
+
+        expect(calculator.calculate_for(entry)).to eql(1.5) # 1.5% of 100.00
+      end
     end
 
     context 'dictionary includes wildcards' do
@@ -106,9 +126,9 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
         Framework::ManagementChargeCalculator::ColumnBased.new(
           varies_by: ['Lot Number', 'Spend Code'],
           value_to_percentage: {
-            [Framework::Definition::AST::Any, Framework::Definition::AST::Any] => BigDecimal('2.0'),
-            ['1', Framework::Definition::AST::Any] => BigDecimal('1.5'),
-            ['1', 'Damages'] => BigDecimal('0.5')
+            [Framework::Definition::AST::Any, Framework::Definition::AST::Any] => { percentage: BigDecimal('2.0') },
+            ['1', Framework::Definition::AST::Any] => { percentage: BigDecimal('1.5') },
+            ['1', 'Damages'] => { percentage: BigDecimal('0.5') }
           }
         )
       end
@@ -151,7 +171,7 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
           Framework::ManagementChargeCalculator::ColumnBased.new(
             varies_by: ['Lot Number', 'Spend Code'],
             value_to_percentage: {
-              ['1', Framework::Definition::AST::Any] => BigDecimal('1.5')
+              ['1', Framework::Definition::AST::Any] => { percentage: BigDecimal('1.5') }
             }
           )
         end
@@ -184,9 +204,9 @@ RSpec.describe Framework::ManagementChargeCalculator::ColumnBased do
       calculator = Framework::ManagementChargeCalculator::ColumnBased.new(
         varies_by: ['Lot Number', 'Spend Code', 'Secondary Spend Code'],
         value_to_percentage: {
-          ['1', 'Other Re-charges', 'Additional'] => BigDecimal('0.5'),
-          ['2', 'Other Re-charges', 'Normal'] => BigDecimal('1.5'),
-          ['2', 'Other Re-charges', 'Additional'] => BigDecimal('1.0'),
+          ['1', 'Other Re-charges', 'Additional'] => { percentage: BigDecimal('0.5') },
+          ['2', 'Other Re-charges', 'Normal'] => { percentage: BigDecimal('1.5') },
+          ['2', 'Other Re-charges', 'Additional'] => { percentage: BigDecimal('1.0') },
         }
       )
 


### PR DESCRIPTION
Calculate column-based charges from other column

Allow column-based management charges to be optionally calculated from
another column. This is specified in FDL using the following form (the
'of' part is new):

```
ManagementCharge varies_by ‘a’, ‘b’ {
  ‘x’, ‘y’ -> 1% of ‘c’
  ‘x’, ‘z’ -> 2% of ‘d’
}
```

To do this we annotate the syntax tree differently. We have renamed
`:value` to `:percentage` in the parser. Because we've introduced the
concept of a `column`, percentages are always represented as hashes
rather than primitives. This means the transpiler has to pass a
different level of the hash to SectorBased management charges to
preserve the interface, whereas FlatRate only needed a rename.
ColumnBased deals with the percentage hashes directly.
