### PR TITLE
(1189) Stop background jobs reporting to Rollbar twice

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,2 @@
 class ApplicationJob < ActiveJob::Base
-  include Rollbar::ActiveJob
 end


### PR DESCRIPTION
Stop including `Rollbar::ActiveJob` as the Rollbar gem already reports background job errors via its Sidekiq support.

---

On several occasions, we noticed two exceptions being raised by background jobs in Rollbar for the same error in quick succession.

One referenced the `*Job` class itself, whilst the other `ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper`.

We had enabled *both* the Sidekiq and ActiveJob support in Rollbar, which the [documentation](https://docs.rollbar.com/docs/activejob-integration) advises against for this very reason.