### PR TITLE
Don't use concat in SemanticChecker

### DIFF
--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -90,7 +90,7 @@ class Framework
                                      .select { |percentage_details| percentage_details[:column].present? }
                                      .map    { |percentage_details| percentage_details[:column] }
 
-              varies_by.concat percentage_columns
+              varies_by + percentage_columns
             elsif info[:flat_rate]
               info.dig(:flat_rate, :column)
             end


### PR DESCRIPTION
It's mutable state, even though it doesn't have a bang!

Return the two lists varies_by and percentage_columns as a list to
check without permanently modifying varies_by.

This was causing a huge number of Rollbar errors when calculating
the management charge, and causing the management charge to be
incorrectly calculated as 0.0.

There's no spec for this because we literally fed it the same
(un-anonymised) return that caused all the Rollbar errors on staging. We
could theoretically write a spec but this is unlikely to regress.

## Changes in this PR:

## Screenshots of UI changes:

### Before

### After
