### PR TITLE
Whitelist "Utility Spend" as an OtherFields sheet name

### DIFF
--- a/app/models/ingest/converter.rb
+++ b/app/models/ingest/converter.rb
@@ -14,7 +14,7 @@ module Ingest
     SHEET_NAME_PATTERNS = {
       'invoice' => /(booking|finance|management|invoice)/i,
       'order'   => /(order|contract)/i,
-      'other'   => /Briefs Received|ITQs|Bid Invitations|Live Sites/i
+      'other'   => /Briefs Received|ITQs|Bid Invitations|Live Sites|Utility Spend/i
     }.freeze
 
     attr_reader :excel_temp_file


### PR DESCRIPTION


## Changes in this PR:

Ticket: https://dxw.zendesk.com/agent/tickets/11245

A new framework has "Utility Spend" as a new OtherFields sheet name


