### PR TITLE
(Zendesk 11247) Catch and log InvalidSalesforceId exceptions

### DIFF
--- a/spec/jobs/user_import_job_spec.rb
+++ b/spec/jobs/user_import_job_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe UserImportJob do
       UserImportJob.perform_now('users.csv')
     end
 
+    it 'logs Import::Users::InvalidSalesforceId error in Rollbar at info level' do
+      allow(importer).to receive(:run).and_raise Import::Users::InvalidSalesforceId.new('fake')
+      allow(Rollbar).to receive(:info)
+      log_message = 'Bulk user import failed for: user.csv due to: fake'
+
+      UserImportJob.perform_now('user.csv')
+
+      expect(Rollbar).to have_received(:info).with(log_message)
+    end
+
     it 'does not retry the job when the import raises an Import::Users::InvalidSalesforceId error' do
       allow(importer).to receive(:run).and_raise Import::Users::InvalidSalesforceId.new('fake')
 


### PR DESCRIPTION
## Changes in this PR:

Catch InvalidSalesforceId exceptions and log them in Rollbar.

Any invalid SalesforceId invalidates the whole bulk file. The user has to manually remove the invalid ID from the input file and restart the import process with the new file.

In order for the user to know that the file contains an invalid ID, and which ID that is, we want to log the occurrence in Rollbar, which is already being monitored by the user of this feature (currently this is mainly Timur). (See also [1].)

We don’t want the job to be retried, as this is a “terminal” (unrecoverable) error, so rescuing the exception is fine.

In addition, the ActiveJob instruction to discard the job is not being respected by Sidekiq, which has an exponential retry mechanism that it applies *regardless* of what ActiveJob is trying to do, so we can remove that instruction as redundant. (See also [2].)

BACKGROUND

[1]. Previously, when the bulk import detected an unrecognised SalesforceId and raised an `InvalidSalesforceId` exception, this exception was only logged in Papertrail (as the default logger), but not in Rollbar. The process was thus failing invisibly, and the user was not alerted of the invalid data.

[2]. The job cleans up after itself, including after encountering an unrecoverable exception, by deleting both the temporary file and the uploaded file (because the user will have to upload a new file with valid data).

However, due to the fact that Sidekiq’s retry mechanism kicks in despite the job being discarded by ActiveJob, from Sidekiq’s first retry the code was trying to load a file that wasn’t on s3 anymore, leading to a confusing `NoSuchKey` exception being raised. This *was* visible in Rollbar, leading to the developer(s) on support trying to diagnose the wrong thing.

Sidekiq allows overwriting its default settings from 6.0.1 onwards, but the project is currently at 5.x. The overwrites are simplistic, allowing to turn off retrying or modify the number of maximum retries, but not conditional overwriting on exceptions.

The default Sidekiq retry mechanism is good when the error is in the code rather than the data, so we don’t want to turn it off indiscriminately. The closest way to the “Sidekiq way” is to exit gracefully, while alerting the end user that they need to take some action to fix the data.