### PR TITLE
(1159) Replace URNs rather than appending to the list of existing URNs when URN spreadsheet imported

### DIFF
--- a/app/jobs/urn_list_importer_job.rb
+++ b/app/jobs/urn_list_importer_job.rb
@@ -24,7 +24,11 @@ class UrnListImporterJob < ApplicationJob
     downloader.download!
 
     convert_to_csv(downloader.temp_file.path)
-    upsert!(customers_from_csv)
+
+    customers = customers_from_csv
+
+    soft_delete!(customers)
+    upsert!(customers)
 
     urn_list.update!(aasm_state: :processed)
 
@@ -75,5 +79,14 @@ class UrnListImporterJob < ApplicationJob
         on_duplicate_key_update: { conflict_target: [:urn], columns: %i[name postcode sector] }
       )
     end
+  end
+
+  def soft_delete!(customers)
+    existing_urns = Customer.pluck(:urn)
+    importing_urns = customers.map(&:urn)
+
+    urns_to_be_deleted = existing_urns - importing_urns
+
+    Customer.where(urn: urns_to_be_deleted).update(deleted: true)
   end
 end

--- a/app/jobs/urn_list_importer_job.rb
+++ b/app/jobs/urn_list_importer_job.rb
@@ -61,7 +61,8 @@ class UrnListImporterJob < ApplicationJob
         name: row['CustomerName'],
         urn: row['URN'].to_i,
         postcode: row['PostCode'],
-        sector: (row['Sector'] == 'Central Government' ? :central_government : :wider_public_sector)
+        sector: (row['Sector'] == 'Central Government' ? :central_government : :wider_public_sector),
+        deleted: false
       )
     end
 
@@ -76,7 +77,10 @@ class UrnListImporterJob < ApplicationJob
       Customer.import(
         customers,
         batch_size: 100,
-        on_duplicate_key_update: { conflict_target: [:urn], columns: %i[name postcode sector] }
+        on_duplicate_key_update: {
+          conflict_target: [:urn],
+          columns: %i[name postcode sector deleted]
+        }
       )
     end
   end

--- a/app/validators/urn_validator.rb
+++ b/app/validators/urn_validator.rb
@@ -1,6 +1,6 @@
 class UrnValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if numeric?(value) && Customer.exists?(urn: value)
+    return if numeric?(value) && Customer.exists?(urn: value, deleted: false)
 
     record.errors.add(attribute, :invalid_urn)
   end

--- a/db/migrate/20200610143814_add_soft_delete_to_customer.rb
+++ b/db/migrate/20200610143814_add_soft_delete_to_customer.rb
@@ -1,0 +1,5 @@
+class AddSoftDeleteToCustomer < ActiveRecord::Migration[5.2]
+  def change
+    add_column :customers, :deleted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_04_154559) do
+ActiveRecord::Schema.define(version: 2020_06_10_143814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2019_12_04_154559) do
     t.integer "sector", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "deleted", default: false
     t.index ["postcode"], name: "index_customers_on_postcode"
     t.index ["sector"], name: "index_customers_on_sector"
     t.index ["urn"], name: "index_customers_on_urn", unique: true

--- a/spec/jobs/urn_list_importer_job_spec.rb
+++ b/spec/jobs/urn_list_importer_job_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe UrnListImporterJob do
         expect(customer.sector).to eql 'central_government'
         expect(urn_list).to be_processed
       end
+
+      it 'soft deletes obsolete customer records' do
+        customer = create(:customer, urn: 10009656, name: 'Deleted organisation')
+
+        UrnListImporterJob.perform_now(urn_list)
+
+        customer.reload
+
+        expect(customer.urn).to eql 10009656
+        expect(customer.name).to eql 'Deleted organisation'
+        expect(customer).to be_deleted
+        expect(urn_list).to be_processed
+      end
     end
 
     context 'given a URN list which fails to download' do

--- a/spec/jobs/urn_list_importer_job_spec.rb
+++ b/spec/jobs/urn_list_importer_job_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe UrnListImporterJob do
         expect(customer).to be_deleted
         expect(urn_list).to be_processed
       end
+
+      it 'restores a previously deleted customer now back in the list' do
+        customer = create(:customer,
+                          urn: 10009655,
+                          deleted: true,
+                          name: 'Crown Commercial Service')
+
+        UrnListImporterJob.perform_now(urn_list)
+
+        customer.reload
+
+        expect(customer.urn).to eql 10009655
+        expect(customer.name).to eql 'Crown Commercial Service'
+        expect(customer).not_to be_deleted
+        expect(urn_list).to be_processed
+      end
     end
 
     context 'given a URN list which fails to download' do

--- a/spec/validators/urn_validator_spec.rb
+++ b/spec/validators/urn_validator_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe UrnValidator do
   end
 
   before do
-    create(:customer, urn: 12345678)
+    create(:customer, urn: 12345678, deleted: deleted)
   end
+
+  let(:deleted) { false }
 
   context 'URN exists' do
     let(:urn) { '12345678' }
@@ -29,6 +31,13 @@ RSpec.describe UrnValidator do
 
   context 'URN is missing' do
     let(:urn) { '88888888' }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'URN is soft-deleted' do
+    let(:urn) { '12345678' }
+    let(:deleted) { true }
 
     it { is_expected.not_to be_valid }
   end


### PR DESCRIPTION
## Changes in this PR:

Replaces URNs rather than appending to the list of existing URNs when uploading URN spreadsheet.

If there's an existing Customer record that is not in the uploaded spreadsheet, we mark it as `deleted` (or rather "soft-deleted" for data integrity).
