### PR TITLE
(1192) Simplify notify CSV uploads

### DIFF
--- a/app/models/task/anticipated_user_notification_list.rb
+++ b/app/models/task/anticipated_user_notification_list.rb
@@ -38,7 +38,7 @@ class Task
 
     def csv_line_for(user, supplier)
       CSV.generate_line(
-        [user.email, due_date, user.name, supplier.name, reporting_month] + framework_participation(supplier)
+        [user.email, due_date, user.name, supplier.name, reporting_month] + framework_csv_columns_for(supplier)
       )
     end
 
@@ -61,11 +61,19 @@ class Task
     end
 
     def frameworks_header
-      frameworks.map(&:short_name)
+      Array.new(framework_column_count, 'framework')
     end
 
-    def framework_participation(supplier)
-      frameworks.map { |framework| supplier.active_frameworks.include?(framework) ? 'yes' : 'no' }
+    def framework_column_count
+      @framework_column_count ||= suppliers.map { |supplier| supplier.active_frameworks.ids.uniq.size }.max || 0
+    end
+
+    def framework_csv_columns_for(supplier)
+      framework_names = supplier.active_frameworks
+                                .map { |framework| "#{framework.short_name} - #{framework.name}" }
+                                .sort
+
+      framework_names.fill(nil, framework_names.size...framework_column_count)
     end
 
     def suppliers

--- a/app/models/task/overdue_user_notification_list.rb
+++ b/app/models/task/overdue_user_notification_list.rb
@@ -67,7 +67,9 @@ class Task
     end
 
     def framework_csv_columns_for(supplier)
-      frameworks_with_incomplete_tasks = supplier.tasks.map { |task| task.framework.short_name }.sort
+      frameworks_with_incomplete_tasks = supplier.tasks
+                                                 .map { |task| "#{task.framework.short_name} - #{task.framework.name}" }
+                                                 .sort
 
       frameworks_with_incomplete_tasks.fill(nil, frameworks_with_incomplete_tasks.size...framework_column_count)
     end

--- a/app/models/task/overdue_user_notification_list.rb
+++ b/app/models/task/overdue_user_notification_list.rb
@@ -34,11 +34,11 @@ class Task
     private
 
     def csv_line_for(user, supplier)
-      framework_presence = late_task_framework_presence(supplier)
-      return if framework_presence.all?('no')
+      framework_csv_columns = framework_csv_columns_for(supplier)
+      return if framework_csv_columns.all?(nil)
 
       CSV.generate_line(
-        [user.email, due_date, user.name, supplier.name, reporting_month] + framework_presence
+        [user.email, due_date, user.name, supplier.name, reporting_month] + framework_csv_columns
       )
     end
 
@@ -59,13 +59,17 @@ class Task
     end
 
     def frameworks_header
-      frameworks.map(&:short_name)
+      Array.new(framework_column_count, 'framework')
     end
 
-    def late_task_framework_presence(supplier)
-      frameworks.map do |framework|
-        supplier.tasks.any? { |task| task.incomplete? && task.framework_id == framework.id } ? 'yes' : 'no'
-      end
+    def framework_column_count
+      @framework_column_count ||= suppliers.map { |supplier| supplier.tasks.pluck(:framework_id).uniq.size }.max || 0
+    end
+
+    def framework_csv_columns_for(supplier)
+      frameworks_with_incomplete_tasks = supplier.tasks.map { |task| task.framework.short_name }.sort
+
+      frameworks_with_incomplete_tasks.fill(nil, frameworks_with_incomplete_tasks.size...framework_column_count)
     end
 
     def suppliers

--- a/spec/models/task/anticipated_user_notification_list_spec.rb
+++ b/spec/models/task/anticipated_user_notification_list_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Task::AnticipatedUserNotificationList do
         FactoryBot.create(:membership, user: frank, supplier: supplier_a)
         FactoryBot.create(:membership, user: alice, supplier: supplier_c)
 
-        framework1 = FactoryBot.create(:framework, short_name: 'RM0001')
-        framework2 = FactoryBot.create(:framework, short_name: 'RM0002')
+        framework1 = FactoryBot.create(:framework, short_name: 'RM001', name: 'Framework 1')
+        framework2 = FactoryBot.create(:framework, short_name: 'RM002', name: 'Framework 2')
 
         supplier_a.agreements.create!(framework: framework1)
         supplier_b.agreements.create!(framework: framework1)
-        supplier_b.agreements.create!(framework: framework2, active: false)
+        supplier_b.agreements.create!(framework: framework2)
         supplier_c.agreements.create!(framework: framework1, active: false)
 
         list.generate
@@ -41,12 +41,19 @@ RSpec.describe Task::AnticipatedUserNotificationList do
       subject(:lines) { output.string.split("\n") }
 
       it 'has a header row that lists all the frameworks' do
-        expect(lines.first).to eql('email address,due_date,person_name,supplier_name,reporting_month,RM0001,RM0002')
+        expect(lines.first).to eql(
+          'email address,due_date,person_name,supplier_name,reporting_month,framework,framework'
+        )
       end
 
       it 'has a line for each user including the frameworks their supplier is active on' do
-        expect(lines).to include('alice@example.com,7 February 2019,Alice Example,Supplier A,January 2019,yes,no')
-        expect(lines).to include('bob@example.com,7 February 2019,Bob Example,Supplier B,January 2019,yes,no')
+        expect(lines).to include(
+          'alice@example.com,7 February 2019,Alice Example,Supplier A,January 2019,RM001 - Framework 1,'
+        )
+
+        expect(lines).to include(
+          'bob@example.com,7 February 2019,Bob Example,Supplier B,January 2019,RM001 - Framework 1,RM002 - Framework 2'
+        )
       end
 
       it 'ignores inactive agreements' do

--- a/spec/models/task/overdue_user_notification_list_spec.rb
+++ b/spec/models/task/overdue_user_notification_list_spec.rb
@@ -46,21 +46,27 @@ RSpec.describe Task::OverdueUserNotificationList do
 
       subject(:lines) { output.string.split("\n") }
 
-      it 'has a header row that lists all the frameworks' do
+      it 'adds the optimal number of columns to hold the names of the frameworks users need to report on' do
         expect(lines.first).to eql(
-          'email address,due_date,person_name,supplier_name,reporting_month,COMPLETE0001,RM0001,RM0002'
+          'email address,due_date,person_name,supplier_name,reporting_month,framework,framework'
+        )
+      end
+
+      it 'has a line for each user and supplier, listing the frameworks they have late tasks for' do
+        expect(lines.size).to eq 4
+        expect(lines).to include(
+          'alice@example.com,7 February 2019,Alice Example,Supplier A,January 2019,RM0001,RM0002'
+        )
+        expect(lines).to include(
+          'alice@example.com,7 February 2019,Alice Example,Supplier B,January 2019,RM0001,'
+        )
+        expect(lines).to include(
+          'bob@example.com,7 February 2019,Bob Example,Supplier B,January 2019,RM0001,'
         )
       end
 
       it 'does not include columns for unpublished frameworks' do
         expect(lines.first).not_to include('NOTPUBLISHED0001')
-      end
-
-      it 'has a line for each user and supplier, listing the frameworks they have late tasks for' do
-        expect(lines.size).to eq 4
-        expect(lines).to include('alice@example.com,7 February 2019,Alice Example,Supplier A,January 2019,no,yes,yes')
-        expect(lines).to include('alice@example.com,7 February 2019,Alice Example,Supplier B,January 2019,no,yes,no')
-        expect(lines).to include('bob@example.com,7 February 2019,Bob Example,Supplier B,January 2019,no,yes,no')
       end
 
       it 'does not include inactive users' do

--- a/spec/models/task/overdue_user_notification_list_spec.rb
+++ b/spec/models/task/overdue_user_notification_list_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Task::OverdueUserNotificationList do
       let(:frank)      { create(:user, :inactive, name: 'Frank Inactive', email: 'frank.inactive@example.com') }
 
       before do
-        framework1 = create :framework, short_name: 'RM0001'
-        framework2 = create :framework, short_name: 'RM0002'
+        framework1 = create :framework, short_name: 'RM0001', name: 'Framework 1'
+        framework2 = create :framework, short_name: 'RM0002', name: 'Framework 2'
         framework3 = create :framework, short_name: 'COMPLETE0001'
         create :framework, short_name: 'NOTPUBLISHED0001', published: false
 
@@ -53,16 +53,18 @@ RSpec.describe Task::OverdueUserNotificationList do
       end
 
       it 'has a line for each user and supplier, listing the frameworks they have late tasks for' do
+        # rubocop:disable Metrics/LineLength
         expect(lines.size).to eq 4
         expect(lines).to include(
-          'alice@example.com,7 February 2019,Alice Example,Supplier A,January 2019,RM0001,RM0002'
+          'alice@example.com,7 February 2019,Alice Example,Supplier A,January 2019,RM0001 - Framework 1,RM0002 - Framework 2'
         )
         expect(lines).to include(
-          'alice@example.com,7 February 2019,Alice Example,Supplier B,January 2019,RM0001,'
+          'alice@example.com,7 February 2019,Alice Example,Supplier B,January 2019,RM0001 - Framework 1,'
         )
         expect(lines).to include(
-          'bob@example.com,7 February 2019,Bob Example,Supplier B,January 2019,RM0001,'
+          'bob@example.com,7 February 2019,Bob Example,Supplier B,January 2019,RM0001 - Framework 1,'
         )
+        # rubocop:enable Metrics/LineLength
       end
 
       it 'does not include columns for unpublished frameworks' do


### PR DESCRIPTION
## Changes in this PR:

Optimise GOV.UK Notify CSVs

We were previously generating a CSV with one boolean column per framework, which would be used by GOV.UK Notify to generate overdue notification emails.

This was fine when RMI only had a few frameworks. Now there are hundreds and the CSV is unwieldy - frequently it goes over the Notify upload limit.

Now we generate multiple columns labelled 'framework', and populate the optimal number of columns to hold all the combinations of overdue frameworks.
