### PR TITLE
(1206) Bulk remove suppliers from framework lots

### DIFF
--- a/app/controllers/admin/supplier_bulk_offboards_controller.rb
+++ b/app/controllers/admin/supplier_bulk_offboards_controller.rb
@@ -1,0 +1,27 @@
+class Admin::SupplierBulkOffboardsController < AdminController
+  def new; end
+
+  def create
+    return redirect_to new_admin_supplier_bulk_offboard_path, alert: 'Uploaded file is not a CSV file' unless csv?
+
+    csv_path = uploaded_file.tempfile.path
+    Offboard::FrameworkSuppliers.new(csv_path, logger: Rails.logger).run
+
+    redirect_to new_admin_supplier_bulk_offboard_path, notice: 'Successfully off-boarded suppliers'
+  rescue ActionController::ParameterMissing
+    redirect_to new_admin_supplier_bulk_offboard_path, alert: 'Please choose a file to upload'
+  rescue ActiveRecord::RecordNotFound, ArgumentError, ActiveRecord::RecordInvalid => e
+    redirect_to new_admin_supplier_bulk_offboard_path, alert: e.message
+  end
+
+  private
+
+  def uploaded_file
+    params.require(:bulk_offboard).require(:csv_file)
+  end
+
+  def csv?
+    File.extname(uploaded_file.original_filename) == '.csv' &&
+      ['text/csv', 'application/vnd.ms-excel'].include?(uploaded_file.content_type)
+  end
+end

--- a/app/controllers/admin/supplier_bulk_onboards_controller.rb
+++ b/app/controllers/admin/supplier_bulk_onboards_controller.rb
@@ -5,7 +5,7 @@ class Admin::SupplierBulkOnboardsController < AdminController
     return redirect_to new_admin_supplier_bulk_onboard_path, alert: 'Uploaded file is not a CSV file' unless csv?
 
     csv_path = uploaded_file.tempfile.path
-    Import::FrameworkSuppliers.new(csv_path, logger: Rails.logger).run
+    Onboard::FrameworkSuppliers.new(csv_path, logger: Rails.logger).run
 
     redirect_to new_admin_supplier_bulk_onboard_path, notice: 'Successfully on-boarded suppliers'
   rescue ActionController::ParameterMissing

--- a/app/models/offboard/framework_suppliers.rb
+++ b/app/models/offboard/framework_suppliers.rb
@@ -1,0 +1,57 @@
+require 'csv'
+
+# Performs a bulk off-board of suppliers from a framework lot
+#
+# Pass in a path to a CSV file with the following headers:
+#
+#   framework_short_name  - the short identifier for the framework, e.g. 'RM606'
+#   lot_number            - the lot number the supplier should be off-boarded from
+#   supplier_name         - the name of the supplier
+#   salesforce_id         - the Salesforce ID for the supplier
+#   coda_reference        - the Coda reference for the supplier
+#
+# For each row in the CSV, the following will happen:
+#
+#   - the supplier will be off-boarded from the lot in that framework
+#
+# Example:
+#
+#   Offboard::FrameworkSuppliers.new('/tmp/framework_suppliers.csv').run
+#
+module Offboard
+  class FrameworkSuppliers
+    EXPECTED_HEADERS = %I[framework_short_name lot_number supplier_name salesforce_id coda_reference].freeze
+
+    attr_reader :logger, :wait_time
+
+    def initialize(csv_path, logger: Logger.new(STDOUT))
+      @csv = CSV.read(csv_path, headers: true, header_converters: :symbol)
+      @logger = logger
+      verify_csv_headers!
+    end
+
+    def run
+      ActiveRecord::Base.transaction do
+        @csv.each do |row_data|
+          Row.new(row_data).offboard!
+          log "Supplier #{row_data.fetch(:supplier_name)} removed from Lot #{row_data.fetch(:lot_number)} " \
+              "on #{row_data.fetch(:framework_short_name)}"
+        end
+      end
+    end
+
+    private
+
+    def log(message)
+      logger.info message
+    end
+
+    def verify_csv_headers!
+      raise ArgumentError, "Missing headers in CSV file: #{missing_headers.to_sentence}" if missing_headers.any?
+    end
+
+    def missing_headers
+      EXPECTED_HEADERS - @csv.headers
+    end
+  end
+end

--- a/app/models/offboard/framework_suppliers/row.rb
+++ b/app/models/offboard/framework_suppliers/row.rb
@@ -1,0 +1,46 @@
+module Offboard
+  class FrameworkSuppliers
+    class Row
+      attr_reader :supplier_name, :salesforce_id, :coda_reference, :framework_short_name, :lot_number
+
+      def initialize(supplier_name:, salesforce_id:, coda_reference:, framework_short_name:, lot_number:)
+        @supplier_name = supplier_name
+        @salesforce_id = salesforce_id
+        @coda_reference = coda_reference
+        @framework_short_name = framework_short_name
+        @lot_number = lot_number
+      end
+
+      def offboard!
+        find_supplier.tap do |supplier|
+          break unless supplier
+
+          agreement = find_agreement(supplier)
+          remove_agreement_framework_lot(agreement)
+        end
+      end
+
+      private
+
+      def framework
+        @framework ||= Framework.published.find_by!(short_name: framework_short_name)
+      end
+
+      def framework_lot
+        framework.lots.find_by!(number: lot_number)
+      end
+
+      def find_supplier
+        Supplier.find_by(salesforce_id: salesforce_id)
+      end
+
+      def find_agreement(supplier)
+        supplier.agreements.find_by!(framework: framework)
+      end
+
+      def remove_agreement_framework_lot(agreement)
+        agreement.agreement_framework_lots.where(framework_lot: framework_lot).destroy_all
+      end
+    end
+  end
+end

--- a/app/models/onboard/framework_suppliers.rb
+++ b/app/models/onboard/framework_suppliers.rb
@@ -1,6 +1,6 @@
 require 'csv'
 
-# Performs a bulk import of suppliers to a framework
+# Performs a bulk on-board of suppliers to a framework
 #
 # Pass in a path to a CSV file with the following headers:
 #
@@ -20,9 +20,9 @@ require 'csv'
 #
 # Example:
 #
-#   Import::FrameworkSuppliers.new('/tmp/new_framework_suppliers.csv').run
+#   Onboard::FrameworkSuppliers.new('/tmp/new_framework_suppliers.csv').run
 #
-module Import
+module Onboard
   class FrameworkSuppliers
     EXPECTED_HEADERS = %I[framework_short_name lot_number supplier_name salesforce_id coda_reference].freeze
 
@@ -37,7 +37,7 @@ module Import
     def run
       ActiveRecord::Base.transaction do
         @csv.each do |row_data|
-          Row.new(row_data).import!
+          Row.new(row_data).onboard!
           log "Supplier #{row_data.fetch(:supplier_name)} added to Lot #{row_data.fetch(:lot_number)} " \
               "on #{row_data.fetch(:framework_short_name)}"
         end

--- a/app/models/onboard/framework_suppliers/row.rb
+++ b/app/models/onboard/framework_suppliers/row.rb
@@ -1,4 +1,4 @@
-module Import
+module Onboard
   class FrameworkSuppliers
     class Row
       attr_reader :supplier_name, :salesforce_id, :coda_reference, :framework_short_name, :lot_number
@@ -11,7 +11,7 @@ module Import
         @lot_number = lot_number
       end
 
-      def import!
+      def onboard!
         find_or_create_supplier.tap do |supplier|
           agreement = find_or_create_agreement(supplier)
           find_or_create_agreement_framework_lot(agreement)

--- a/app/views/admin/supplier_bulk_offboards/new.html.haml
+++ b/app/views/admin/supplier_bulk_offboards/new.html.haml
@@ -1,0 +1,25 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl Bulk off-board suppliers
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = simple_form_for :bulk_offboard, url: admin_supplier_bulk_offboard_path do |form|
+      %fieldset.govuk-fieldset
+        %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
+          %h2.govuk-fieldset__heading
+            CSV
+
+        = form.input :csv_file, as: :file, label: 'Choose a CSV file to upload.', hide_optional: true
+        = form.button :submit, 'Upload'
+
+        %p
+          This file should contain the following columns:
+
+        %ul.govuk-list.govuk-list--bullet
+          %li framework_short_name (e.g. RM1043.5)
+          %li lot_number
+          %li supplier_name
+          %li salesforce_id
+          %li coda_reference
+

--- a/app/views/admin/suppliers/index.html.haml
+++ b/app/views/admin/suppliers/index.html.haml
@@ -19,6 +19,8 @@
       %ul.govuk-page-actions--actions
         %li.govuk-page-actions--action
           = link_to 'Bulk on-board suppliers', new_admin_supplier_bulk_onboard_path
+        %li.govuk-page-actions--action
+          = link_to 'Bulk off-board suppliers', new_admin_supplier_bulk_offboard_path
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,13 @@ Rails.application.routes.draw do
       resources :tasks, only: %i[new create]
 
       collection do
-        resource :bulk_onboard, only: %i[new create], controller: 'supplier_bulk_onboards', as: :supplier_bulk_onboard
+        resource :bulk_onboard, only: %i[new create],
+                 controller: 'supplier_bulk_onboards',
+                 as: :supplier_bulk_onboard
+
+        resource :bulk_offboard, only: %i[new create],
+                 controller: 'supplier_bulk_offboards',
+                 as: :supplier_bulk_offboard
       end
     end
 

--- a/db/data_migrate/20190326164302_onboard_april_suppliers.rb
+++ b/db/data_migrate/20190326164302_onboard_april_suppliers.rb
@@ -5,4 +5,4 @@
 #   rails runner db/data_migrate/20190326164302_onboard_april_suppliers.rb
 #
 
-Import::FrameworkSuppliers.new(Rails.root.join('db', 'data_migrate', '20190326164302_onboard_april_suppliers.csv')).run
+Onboard::FrameworkSuppliers.new(Rails.root.join('db', 'data_migrate', '20190326164302_onboard_april_suppliers.csv')).run

--- a/spec/features/admin_can_bulk_offboard_suppliers_spec.rb
+++ b/spec/features/admin_can_bulk_offboard_suppliers_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin can bulk off-board suppliers' do
+  let!(:supplier) do
+    supplier = create(:supplier,
+                      name: 'Aardvark (UK) Ltd',
+                      coda_reference: 'C099999',
+                      salesforce_id: '001b000003FAKEFAKE')
+
+    agreement = supplier.agreements.create!(framework: fm1234)
+
+    agreement.agreement_framework_lots.create!(framework_lot: lot_1)
+    agreement.agreement_framework_lots.create!(framework_lot: lot_2a)
+
+    supplier
+  end
+
+  let(:fm1234) do
+    create(:framework, short_name: 'FM1234')
+  end
+
+  let(:lot_1) do
+    create(:framework_lot, number: '1', framework: fm1234)
+  end
+
+  let(:lot_2a) do
+    create(:framework_lot, number: '2a', framework: fm1234)
+  end
+
+  before do
+    sign_in_as_admin
+  end
+
+  context 'with a valid CSV' do
+    scenario 'off-boards suppliers from specified framework lots' do
+      visit new_admin_supplier_bulk_offboard_path
+
+      expect(page).to have_text 'Bulk off-board suppliers'
+
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'supplier-offboard.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Successfully off-boarded suppliers'
+
+      aardvark = Supplier.find_by(name: 'Aardvark (UK) Ltd')
+      aardvark_fm1234_lots = aardvark.agreements.find_by(framework: fm1234).framework_lots.pluck(:number)
+
+      expect(aardvark.coda_reference).to eql 'C099999'
+      expect(aardvark.salesforce_id).to eql '001b000003FAKEFAKE'
+      expect(aardvark_fm1234_lots).to match_array %w[1]
+    end
+  end
+
+  context 'with a CSV which references an unpublished framework' do
+    before { fm1234.update(published: false) }
+
+    scenario 'displays an error' do
+      visit new_admin_supplier_bulk_offboard_path
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'supplier-offboard.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Couldn\'t find Framework'
+    end
+  end
+
+  context 'with a CSV with missing columns' do
+    scenario 'displays an error, showing which columns are missing' do
+      visit new_admin_supplier_bulk_offboard_path
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'suppliers_with_missing_columns.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Missing headers in CSV file: framework_short_name'
+    end
+  end
+
+  context 'with a non-CSV file' do
+    scenario 'displays an error' do
+      visit new_admin_supplier_bulk_offboard_path
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'not-really-an.xls')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Uploaded file is not a CSV file'
+    end
+  end
+
+  context 'without attaching a file' do
+    scenario 'displays an error' do
+      visit new_admin_supplier_bulk_offboard_path
+      click_button 'Upload'
+
+      expect(page).to have_text 'Please choose a file to upload'
+    end
+  end
+end

--- a/spec/features/admin_can_bulk_offboard_suppliers_spec.rb
+++ b/spec/features/admin_can_bulk_offboard_suppliers_spec.rb
@@ -33,7 +33,8 @@ RSpec.feature 'Admin can bulk off-board suppliers' do
 
   context 'with a valid CSV' do
     scenario 'off-boards suppliers from specified framework lots' do
-      visit new_admin_supplier_bulk_offboard_path
+      visit admin_suppliers_path
+      click_link 'Bulk off-board suppliers'
 
       expect(page).to have_text 'Bulk off-board suppliers'
 

--- a/spec/features/admin_can_bulk_onboard_suppliers_spec.rb
+++ b/spec/features/admin_can_bulk_onboard_suppliers_spec.rb
@@ -23,7 +23,8 @@ RSpec.feature 'Admin can bulk on-board suppliers' do
 
   context 'with a valid CSV' do
     scenario 'creates suppliers that do not exist' do
-      visit new_admin_supplier_bulk_onboard_path
+      visit admin_suppliers_path
+      click_link 'Bulk on-board suppliers'
 
       expect(page).to have_text 'Bulk on-board suppliers'
 

--- a/spec/features/admin_can_bulk_onboard_suppliers_spec.rb
+++ b/spec/features/admin_can_bulk_onboard_suppliers_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Admin can bulk import suppliers' do
+RSpec.feature 'Admin can bulk on-board suppliers' do
   let!(:fm1234) do
     create(:framework, short_name: 'FM1234') do |framework|
       create(:framework_lot, number: '1', framework: framework)

--- a/spec/fixtures/supplier-offboard.csv
+++ b/spec/fixtures/supplier-offboard.csv
@@ -1,0 +1,2 @@
+framework_short_name,lot_number,salesforce_id,supplier_name,coda_reference
+FM1234,2a,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999

--- a/spec/models/offboard/framework_suppliers/row_spec.rb
+++ b/spec/models/offboard/framework_suppliers/row_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Offboard::FrameworkSuppliers::Row do
+  describe '#offboard!' do
+    let!(:framework) { FactoryBot.create(:framework) }
+    let(:framework_short_name) { framework.short_name }
+
+    let!(:lot_1) { framework.lots.create!(number: '1') }
+    let!(:lot_2) { framework.lots.create!(number: '2') }
+    let(:lot_number) { lot_1.number }
+
+    let(:supplier_name) { 'Big Dog Limited' }
+    let(:salesforce_id) { 'salesforce123' }
+    let(:coda_reference) { 'C012345' }
+
+    let!(:supplier) do
+      supplier = create(:supplier,
+                        name: supplier_name,
+                        salesforce_id: salesforce_id,
+                        coda_reference: coda_reference)
+
+      agreement = supplier.agreements.create!(framework: framework)
+
+      [lot_1, lot_2].each do |lot|
+        agreement.agreement_framework_lots.create!(framework_lot: lot)
+      end
+
+      supplier
+    end
+
+    subject(:row) do
+      Offboard::FrameworkSuppliers::Row.new(
+        framework_short_name: framework_short_name,
+        lot_number: lot_number,
+        supplier_name: supplier_name,
+        salesforce_id: salesforce_id,
+        coda_reference: coda_reference,
+      )
+    end
+
+    context 'with an existing supplier' do
+      it 'disassociates it from the lot' do
+        row.offboard!
+
+        agreement = supplier.agreements.first
+        expect(agreement.framework).to eq framework
+        expect(agreement).to be_active
+        expect(agreement.framework_lots).to match_array [lot_2]
+      end
+    end
+
+    context 'with a framework that is not published' do
+      before { framework.update(published: false) }
+
+      it 'raises an ActiveRecord::RecordNotFound exception' do
+        expect { row.offboard! }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/models/offboard/framework_suppliers_spec.rb
+++ b/spec/models/offboard/framework_suppliers_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Offboard::FrameworkSuppliers do
+  it 'raises an error if the expected headers are not present' do
+    bad_headers_csv_path = Rails.root.join('spec', 'fixtures', 'framework_suppliers_bad_headers.csv')
+
+    expect { Offboard::FrameworkSuppliers.new(bad_headers_csv_path) }.to raise_error(
+      ArgumentError, /Missing headers in CSV file: salesforce_id/
+    )
+  end
+
+  describe '#run' do
+    let(:csv_path) { Rails.root.join('spec', 'fixtures', 'supplier-offboard.csv') }
+    let(:offboarder) { Offboard::FrameworkSuppliers.new(csv_path, logger: Logger.new('/dev/null')) }
+
+    let!(:framework) do
+      FactoryBot.create(:framework, short_name: 'FM1234')
+    end
+
+    let(:lot_1) { framework.lots.create!(number: '1') }
+    let(:lot_2a) { framework.lots.create!(number: '2a') }
+
+    let!(:supplier) do
+      FactoryBot.create(:supplier, salesforce_id: '001b000003FAKEFAKE')
+    end
+
+    let!(:agreement) do
+      FactoryBot.create(:agreement, supplier: supplier, framework: framework) do |agreement|
+        [lot_1, lot_2a].each do |framework_lot|
+          agreement.agreement_framework_lots.create!(framework_lot: framework_lot)
+        end
+      end
+    end
+
+    it 'offboards the suppliers' do
+      expect { offboarder.run }.to change { agreement.agreement_framework_lots.count }.by(-1)
+    end
+
+    context 'when the CSV references a framework that is not published' do
+      it 'raises an error' do
+        framework.update(published: false)
+
+        expect { offboarder.run }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/models/onboard/framework_suppliers/row_spec.rb
+++ b/spec/models/onboard/framework_suppliers/row_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe Import::FrameworkSuppliers::Row do
-  describe '#import!' do
+RSpec.describe Onboard::FrameworkSuppliers::Row do
+  describe '#onboard!' do
     let!(:framework) { FactoryBot.create(:framework) }
     let(:framework_short_name) { framework.short_name }
     let!(:lot_1) { framework.lots.create!(number: '1') }
@@ -11,7 +11,7 @@ RSpec.describe Import::FrameworkSuppliers::Row do
     let(:coda_reference) { 'C012345' }
 
     subject(:row) do
-      Import::FrameworkSuppliers::Row.new(
+      Onboard::FrameworkSuppliers::Row.new(
         framework_short_name: framework_short_name,
         lot_number: lot_number,
         supplier_name: supplier_name,
@@ -22,7 +22,7 @@ RSpec.describe Import::FrameworkSuppliers::Row do
 
     context 'with a new supplier (i.e. a new salesforce_id)' do
       it 'persists and returns a record for the supplier' do
-        supplier = row.import!
+        supplier = row.onboard!
 
         expect(supplier).to be_a Supplier
         expect(supplier).to be_persisted
@@ -32,7 +32,7 @@ RSpec.describe Import::FrameworkSuppliers::Row do
       end
 
       it 'creates an active agreeement for the supplier and associates it with the lot' do
-        supplier = row.import!
+        supplier = row.onboard!
 
         expect(supplier.agreements.count).to eq 1
         agreement = supplier.agreements.first
@@ -46,11 +46,11 @@ RSpec.describe Import::FrameworkSuppliers::Row do
       let!(:matching_supplier) { FactoryBot.create(:supplier, salesforce_id: salesforce_id) }
 
       it 'doesn’t create a new record' do
-        expect { row.import! }.not_to change { Supplier.count }
+        expect { row.onboard! }.not_to change { Supplier.count }
       end
 
       it 'creates an active agreeement for the existing supplier and associates it with the lot' do
-        row.import!
+        row.onboard!
 
         expect(matching_supplier.agreements.count).to eq 1
         agreement = matching_supplier.agreements.first
@@ -63,11 +63,12 @@ RSpec.describe Import::FrameworkSuppliers::Row do
         let!(:matching_agreeement) { matching_supplier.agreements.create!(framework: framework) }
 
         it 'doesn’t create a duplicate agreement' do
-          expect { row.import! }.not_to change { Agreement.count }
+          expect { row.onboard! }.not_to change { Agreement.count }
         end
 
         it 'adds the lot to the supplier’s agreement' do
-          row.import!
+          row.onboard!
+
           expect(matching_agreeement.framework_lots).to match_array [lot_1]
         end
       end
@@ -79,11 +80,11 @@ RSpec.describe Import::FrameworkSuppliers::Row do
         end
 
         it 'doesn’t create a duplicate agreement' do
-          expect { row.import! }.not_to change { Agreement.count }
+          expect { row.onboard! }.not_to change { Agreement.count }
         end
 
         it 'doesn’t create a duplicate agreement_framework_lot' do
-          expect { row.import! }.not_to change { AgreementFrameworkLot.count }
+          expect { row.onboard! }.not_to change { AgreementFrameworkLot.count }
         end
       end
     end
@@ -92,7 +93,7 @@ RSpec.describe Import::FrameworkSuppliers::Row do
       before { framework.update(published: false) }
 
       it 'raises an ActiveRecord::RecordNotFound exception' do
-        expect { row.import! }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { row.onboard! }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/models/onboard/framework_suppliers_spec.rb
+++ b/spec/models/onboard/framework_suppliers_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
-RSpec.describe Import::FrameworkSuppliers do
+RSpec.describe Onboard::FrameworkSuppliers do
   it 'raises an error if the expected headers are not present' do
     bad_headers_csv_path = Rails.root.join('spec', 'fixtures', 'framework_suppliers_bad_headers.csv')
 
-    expect { Import::FrameworkSuppliers.new(bad_headers_csv_path) }.to raise_error(
+    expect { Onboard::FrameworkSuppliers.new(bad_headers_csv_path) }.to raise_error(
       ArgumentError, /Missing headers in CSV file: salesforce_id/
     )
   end
 
   describe '#run' do
     let(:csv_path) { Rails.root.join('spec', 'fixtures', 'framework_suppliers.csv') }
-    let(:importer) { Import::FrameworkSuppliers.new(csv_path, logger: Logger.new('/dev/null')) }
+    let(:onboarder) { Onboard::FrameworkSuppliers.new(csv_path, logger: Logger.new('/dev/null')) }
 
     let!(:framework) do
       FactoryBot.create(:framework, short_name: 'RM123') do |framework|
@@ -20,8 +20,8 @@ RSpec.describe Import::FrameworkSuppliers do
       end
     end
 
-    it 'imports the suppliers' do
-      expect { importer.run }.to change { Supplier.count }.by 2
+    it 'on-boards the suppliers' do
+      expect { onboarder.run }.to change { Supplier.count }.by 2
     end
 
     context 'when there is bad data in the CSV' do
@@ -30,7 +30,7 @@ RSpec.describe Import::FrameworkSuppliers do
       it 'rolls back any changes to the database' do
         supplier_count_before = Supplier.count
 
-        expect { importer.run }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { onboarder.run }.to raise_error(ActiveRecord::RecordInvalid)
 
         expect(Supplier.count).to eq supplier_count_before
       end
@@ -44,7 +44,7 @@ RSpec.describe Import::FrameworkSuppliers do
       it 'rolls back any changes to the database' do
         supplier_count_before = Supplier.count
 
-        expect { importer.run }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { onboarder.run }.to raise_error(ActiveRecord::RecordNotFound)
 
         expect(Supplier.count).to eq supplier_count_before
       end


### PR DESCRIPTION
## Changes in this PR:

Allow admins to upload a CSV, which is then used to remove suppliers from individual lots within their frameworks.

## Suppliers admin page

<img width="1045" alt="Screenshot 2020-06-17 at 11 35 37" src="https://user-images.githubusercontent.com/3166/84888118-b531b600-b08e-11ea-9aeb-950ead8313f3.png">

## Off-boarding 

<img width="1057" alt="Screenshot 2020-06-17 at 11 36 13" src="https://user-images.githubusercontent.com/3166/84888156-c5499580-b08e-11ea-9ad3-7433c5dafaa7.png">
