### PR TITLE
(1211) Deactivate Suppliers when removing them from all their lots

### DIFF
--- a/app/models/offboard/remove_suppliers_from_lots/row.rb
+++ b/app/models/offboard/remove_suppliers_from_lots/row.rb
@@ -17,6 +17,7 @@ module Offboard
 
           agreement = find_agreement(supplier)
           remove_agreement_framework_lot(agreement)
+          agreement.deactivate! if no_lots_on_agreement?(agreement)
         end
       end
 
@@ -40,6 +41,10 @@ module Offboard
 
       def remove_agreement_framework_lot(agreement)
         agreement.agreement_framework_lots.where(framework_lot: framework_lot).destroy_all
+      end
+
+      def no_lots_on_agreement?(agreement)
+        agreement.agreement_framework_lots.empty?
       end
     end
   end

--- a/app/models/onboard/framework_suppliers/row.rb
+++ b/app/models/onboard/framework_suppliers/row.rb
@@ -15,6 +15,7 @@ module Onboard
         find_or_create_supplier.tap do |supplier|
           agreement = find_or_create_agreement(supplier)
           find_or_create_agreement_framework_lot(agreement)
+          agreement.activate!
         end
       end
 

--- a/spec/features/admin_can_bulk_remove_suppliers_from_framework_lots_spec.rb
+++ b/spec/features/admin_can_bulk_remove_suppliers_from_framework_lots_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Admin can bulk remove suppliers from lots' do
   end
 
   context 'with a valid CSV' do
-    scenario 'off-boards suppliers from specified framework lots' do
+    scenario 'removes suppliers from specified framework lots' do
       visit admin_suppliers_path
       click_link 'Remove suppliers from lots'
 
@@ -49,6 +49,25 @@ RSpec.feature 'Admin can bulk remove suppliers from lots' do
       expect(aardvark.coda_reference).to eql 'C099999'
       expect(aardvark.salesforce_id).to eql '001b000003FAKEFAKE'
       expect(aardvark_fm1234_lots).to match_array %w[1]
+    end
+
+    scenario 'deactivates supplier from framework if they are remove from all lots' do
+      visit admin_suppliers_path
+      click_link 'Remove suppliers from lots'
+
+      expect(page).to have_text 'Remove suppliers from lots'
+
+      attach_file 'Choose', Rails.root.join('spec', 'fixtures', 'remove-supplier-from-all-framework-lots.csv')
+      click_button 'Upload'
+
+      expect(page).to have_text 'Successfully off-boarded suppliers'
+
+      aardvark = Supplier.find_by(name: 'Aardvark (UK) Ltd')
+      aardvark_fm1234_agreement = aardvark.agreements.find_by(framework: fm1234)
+      aardvark_fm1234_lots = aardvark_fm1234_agreement.framework_lots.pluck(:number)
+
+      expect(aardvark_fm1234_lots).to be_empty
+      expect(aardvark_fm1234_agreement).not_to be_active
     end
   end
 

--- a/spec/fixtures/remove-supplier-from-all-framework-lots.csv
+++ b/spec/fixtures/remove-supplier-from-all-framework-lots.csv
@@ -1,0 +1,3 @@
+framework_short_name,lot_number,salesforce_id,supplier_name,coda_reference
+FM1234,1,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999
+FM1234,2a,001b000003FAKEFAKE,Aardvark (UK) Ltd,C099999


### PR DESCRIPTION
## Changes in this PR:

When bulk removing suppliers from lots, the respective agreement will be marked as inactive to ensure a supplier doesn't get tasks for that agreement.

Because we're now marking agreements as inactive in this way, we now also find any matching agreements and mark them as "active" when adding a supplier to a lot.