### PR TITLE
(1208) Admins can download suppliers and users on a framework

### DIFF
--- a/app/controllers/admin/frameworks/reports_controller.rb
+++ b/app/controllers/admin/frameworks/reports_controller.rb
@@ -1,0 +1,34 @@
+class Admin::Frameworks::ReportsController < AdminController
+  def users
+    send_file csv_file, type: 'text/csv', filename: csv_filename
+  end
+
+  private
+
+  def framework
+    @framework ||= Framework.find(params[:framework_id])
+  end
+
+  def short_name
+    framework.short_name.downcase.tr('/.', '_')
+  end
+
+  def csv_file
+    Tempfile.new.tap do |file|
+      Export::FrameworkUsers.new(
+        Export::FrameworkUsers::Extract.all_relevant(framework),
+        file
+      ).run
+
+      file.rewind
+    end
+  end
+
+  def csv_filename
+    "framework_#{short_name}_users-#{current_date}.csv"
+  end
+
+  def current_date
+    Time.zone.today
+  end
+end

--- a/app/models/export/framework_users.rb
+++ b/app/models/export/framework_users.rb
@@ -1,0 +1,15 @@
+require 'csv'
+
+module Export
+  class FrameworkUsers < ToIO
+    HEADER = %w[
+      framework_reference
+      framework_name
+      supplier_salesforce_id
+      supplier_name
+      supplier_active
+      user_email
+      user_name
+    ].freeze
+  end
+end

--- a/app/models/export/framework_users/extract.rb
+++ b/app/models/export/framework_users/extract.rb
@@ -1,0 +1,20 @@
+module Export
+  class FrameworkUsers
+    module Extract
+      def self.all_relevant(framework)
+        User.select(
+          <<~POSTGRESQL
+            users.id                        AS id,
+            '#{framework.short_name}'::text AS _framework_reference,
+            '#{framework.name}'::text       AS _framework_name,
+            suppliers.name                  AS _supplier_name,
+            suppliers.salesforce_id         AS _supplier_salesforce_id,
+            agreements.active               AS _supplier_active,
+            users.name                      AS _user_name,
+            users.email                     AS _user_email
+          POSTGRESQL
+        ).joins(suppliers: :agreements).merge(Agreement.where(framework_id: framework.id))
+      end
+    end
+  end
+end

--- a/app/models/export/framework_users/row.rb
+++ b/app/models/export/framework_users/row.rb
@@ -1,0 +1,21 @@
+module Export
+  class FrameworkUsers
+    class Row < Export::CsvRow
+      def row_values
+        [
+          model._framework_reference,
+          model._framework_name,
+          model._supplier_salesforce_id,
+          model._supplier_name,
+          supplier_active,
+          model._user_email,
+          model._user_name
+        ]
+      end
+
+      def supplier_active
+        model._supplier_active ? 'Y' : 'N'
+      end
+    end
+  end
+end

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -8,6 +8,8 @@
       %ul.govuk-page-actions--actions
         %li.govuk-page-actions--action
           = link_to 'Edit definition', edit_admin_framework_path(@framework.id)
+        %li.govuk-page-actions--action
+          = link_to 'Download users (CSV)', users_admin_framework_reports_path(@framework.id)
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,12 @@ Rails.application.routes.draw do
     end
 
     resources :frameworks, only: %i[index new create show edit update] do
+      resources :reports, only: [], controller: 'frameworks/reports' do
+        collection do
+          get :users
+        end
+      end
+
       member do
         patch :update_fdl
         patch :publish

--- a/spec/features/admin_can_download_users_on_a_framework_spec.rb
+++ b/spec/features/admin_can_download_users_on_a_framework_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin can download a list of users/suppliers on a framework' do
+  before do
+    sign_in_as_admin
+  end
+
+  scenario 'everything is fine' do
+    create(:framework, name: 'G-Cloud 42', short_name: 'RM1234')
+
+    travel_to Date.new(2020, 6, 17) do
+      visit admin_frameworks_path
+      click_link 'G-Cloud 42'
+      click_link 'Download users'
+    end
+
+    expect(page.response_headers['Content-Type'])
+      .to include 'text/csv'
+    expect(page.response_headers['Content-Disposition'])
+      .to eq 'attachment; filename="framework_rm1234_users-2020-06-17.csv"'
+
+    expect(page.body).to include 'framework_reference,framework_name,supplier_salesforce_id' \
+    ',supplier_name,supplier_active,user_email,user_name'
+  end
+end

--- a/spec/models/export/framework_users/extract_spec.rb
+++ b/spec/models/export/framework_users/extract_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe Export::FrameworkUsers::Extract do
+  describe '#all_relevant' do
+    let(:all_relevant) { Export::FrameworkUsers::Extract.all_relevant(framework) }
+
+    context 'with suppliers that have both active and inactive agreements on a framework' do
+      let!(:framework) do
+        create(:framework, name: 'G-Cloud 42', short_name: 'RM5678.42')
+      end
+
+      let!(:active_supplier) do
+        create(:supplier, name: 'Active Technologies', salesforce_id: 'ACT123') do |supplier|
+          create(:agreement, supplier: supplier, framework: framework, active: true)
+
+          create_list(:user, 2) do |user|
+            create(:membership, user: user, supplier: supplier)
+          end
+        end
+      end
+
+      let!(:inactive_supplier) do
+        create(:supplier, name: 'Inactive Ltd', salesforce_id: 'INACT456') do |supplier|
+          create(:agreement, supplier: supplier, framework: framework, active: false)
+
+          create_list(:user, 3) do |user|
+            create(:membership, user: user, supplier: supplier)
+          end
+        end
+      end
+
+      let!(:other_framework) do
+        create(:framework, name: 'Other Framework') do |framework|
+          create(:agreement, supplier: active_supplier, framework: framework)
+        end
+      end
+
+      it 'includes both suppliers and their users for a given framework' do
+        expect(all_relevant.size).to eql(5)
+      end
+
+      describe '#_framework_reference as a projection on the User model' do
+        it 'is included in every result' do
+          all_relevant.map(&:_framework_reference).each do |relevant|
+            expect(relevant).to eql framework.short_name
+          end
+        end
+      end
+
+      describe '#_framework_name as a projection on the User model' do
+        it 'is included in every result' do
+          all_relevant.map(&:_framework_name).each do |relevant|
+            expect(relevant).to eql framework.name
+          end
+        end
+      end
+
+      describe '#_supplier_name as a projection on the User model' do
+        it 'contains both the active and inactive supplier the correct number of times' do
+          extracted_supplier_names = all_relevant.map(&:_supplier_name)
+
+          expect(extracted_supplier_names).to match_array(
+            [
+              active_supplier.name,
+              active_supplier.name,
+              inactive_supplier.name,
+              inactive_supplier.name,
+              inactive_supplier.name
+            ]
+          )
+        end
+      end
+
+      describe '#_supplier_salesforce_id as a projection on the User model' do
+        it 'contains both the active and inactive supplier the correct number of times' do
+          extracted_supplier_salesforce_ids = all_relevant.map(&:_supplier_salesforce_id)
+
+          expect(extracted_supplier_salesforce_ids).to match_array(
+            [
+              active_supplier.salesforce_id,
+              active_supplier.salesforce_id,
+              inactive_supplier.salesforce_id,
+              inactive_supplier.salesforce_id,
+              inactive_supplier.salesforce_id
+            ]
+          )
+        end
+      end
+
+      describe '#_supplier_active as a projection on the User model' do
+        it 'contains both the active and inactive supplier the correct number of times' do
+          extracted_supplier_statuses = all_relevant.map(&:_supplier_active)
+
+          expect(extracted_supplier_statuses).to match_array(
+            [
+              true,
+              true,
+              false,
+              false,
+              false
+            ]
+          )
+        end
+      end
+
+      describe '#_user_name as a projection on the User model' do
+        it 'is included in every result' do
+          user_names = User.all.pluck(:name)
+          extracted_user_names = all_relevant.map(&:_user_name)
+
+          expect(extracted_user_names).to match_array(user_names)
+        end
+      end
+
+      describe '#_user_email as a projection on the User model' do
+        it 'is included in every result' do
+          user_emails = User.all.pluck(:email)
+          extracted_user_emails = all_relevant.map(&:_user_email)
+
+          expect(extracted_user_emails). to match_array(user_emails)
+        end
+      end
+
+      it 'excludes frameworks that were not requested' do
+        expect(all_relevant.map(&:_framework_name)).not_to include 'Other Framework'
+      end
+    end
+  end
+end

--- a/spec/models/export/framework_users/row_spec.rb
+++ b/spec/models/export/framework_users/row_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe Export::FrameworkUsers::Row do
+  let(:input) do
+    OpenStruct.new(
+      _framework_reference: 'RM1234.42',
+      _framework_name: 'G-Cloud 42',
+      _supplier_salesforce_id: 'ACT1234',
+      _supplier_name: 'Active Technologies',
+      _supplier_active: false,
+      _user_name: 'F Beane',
+      _user_email: 'fbeane@gmail.com'
+    )
+  end
+
+  describe '#row_values' do
+    it 'maps the projected values to an array' do
+      row = Export::FrameworkUsers::Row.new(input, {})
+
+      expect(row.row_values).to match_array(
+        [
+          'RM1234.42',
+          'G-Cloud 42',
+          'ACT1234',
+          'Active Technologies',
+          'N',
+          'fbeane@gmail.com',
+          'F Beane'
+        ]
+      )
+    end
+  end
+
+  describe '#supplier_active' do
+    it 'converts true to Y' do
+      input[:_supplier_active] = true
+      row = Export::FrameworkUsers::Row.new(input, {})
+
+      expect(row.supplier_active).to eql 'Y'
+    end
+
+    it 'converts false to N' do
+      input[:_supplier_active] = false
+      row = Export::FrameworkUsers::Row.new(input, {})
+
+      expect(row.supplier_active).to eql 'N'
+    end
+  end
+end


### PR DESCRIPTION
Add a new link on the individual framework pages that allows admins to download a list of users, their suppliers and framework details.

<img width="1056" alt="Screenshot 2020-06-23 at 09 37 10" src="https://user-images.githubusercontent.com/3166/85380707-2660e580-b535-11ea-8b15-a97236ccd93a.png">

The generated CSV has the following fields:
 - framework_reference
 - framework_name
 - supplier_salesforce_id
 - supplier_name
 - supplier_active
 - user_email
 - user_name
