### PR TITLE
(1207) Admins can download suppliers and their lots for a given framework

### DIFF
--- a/app/controllers/admin/frameworks/reports_controller.rb
+++ b/app/controllers/admin/frameworks/reports_controller.rb
@@ -3,6 +3,10 @@ class Admin::Frameworks::ReportsController < AdminController
     send_file csv_file, type: 'text/csv', filename: csv_filename
   end
 
+  def lots
+    send_file csv_file, type: 'text/csv', filename: csv_filename
+  end
+
   private
 
   def framework
@@ -15,8 +19,8 @@ class Admin::Frameworks::ReportsController < AdminController
 
   def csv_file
     Tempfile.new.tap do |file|
-      Export::FrameworkUsers.new(
-        Export::FrameworkUsers::Extract.all_relevant(framework),
+      export_klass.new(
+        export_klass::Extract.all_relevant(framework),
         file
       ).run
 
@@ -25,10 +29,21 @@ class Admin::Frameworks::ReportsController < AdminController
   end
 
   def csv_filename
-    "framework_#{short_name}_users-#{current_date}.csv"
+    "framework_#{short_name}_#{action_name}-#{current_date}.csv"
   end
 
   def current_date
     Time.zone.today
+  end
+
+  def export_klass
+    case action_name
+    when 'users'
+      Export::FrameworkUsers
+    when 'lots'
+      Export::FrameworkSuppliersLots
+    else
+      raise 'Unexpected action in Admin::Frameworks::ReportsController'
+    end
   end
 end

--- a/app/models/export/framework_suppliers_lots.rb
+++ b/app/models/export/framework_suppliers_lots.rb
@@ -1,0 +1,14 @@
+require 'csv'
+
+module Export
+  class FrameworkSuppliersLots < ToIO
+    HEADER = %w[
+      framework_reference
+      framework_name
+      supplier_salesforce_id
+      supplier_name
+      supplier_active
+      lot_number
+    ].freeze
+  end
+end

--- a/app/models/export/framework_suppliers_lots/extract.rb
+++ b/app/models/export/framework_suppliers_lots/extract.rb
@@ -1,0 +1,19 @@
+module Export
+  class FrameworkSuppliersLots
+    module Extract
+      def self.all_relevant(framework)
+        AgreementFrameworkLot.select(
+          <<~POSTGRESQL
+            agreement_framework_lots.id     AS id,
+            '#{framework.short_name}'::text AS _framework_reference,
+            '#{framework.name}'::text       AS _framework_name,
+            suppliers.name                  AS _supplier_name,
+            suppliers.salesforce_id         AS _supplier_salesforce_id,
+            agreements.active               AS _supplier_active,
+            framework_lots.number           AS _lot_number
+          POSTGRESQL
+        ).joins(:framework_lot, agreement: :supplier).merge(FrameworkLot.where(framework_id: framework.id))
+      end
+    end
+  end
+end

--- a/app/models/export/framework_suppliers_lots/row.rb
+++ b/app/models/export/framework_suppliers_lots/row.rb
@@ -1,0 +1,20 @@
+module Export
+  class FrameworkSuppliersLots
+    class Row < Export::CsvRow
+      def row_values
+        [
+          model._framework_reference,
+          model._framework_name,
+          model._supplier_salesforce_id,
+          model._supplier_name,
+          supplier_active,
+          model._lot_number,
+        ]
+      end
+
+      def supplier_active
+        model._supplier_active ? 'Y' : 'N'
+      end
+    end
+  end
+end

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -10,6 +10,8 @@
           = link_to 'Edit definition', edit_admin_framework_path(@framework.id)
         %li.govuk-page-actions--action
           = link_to 'Download users (CSV)', users_admin_framework_reports_path(@framework.id)
+        %li.govuk-page-actions--action
+          = link_to 'Download suppliers/lots (CSV)', lots_admin_framework_reports_path(@framework.id)
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -7,11 +7,11 @@
       %h2#page-actions-title.govuk-heading-s{"aria-label" => "Page actions"} Actions
       %ul.govuk-page-actions--actions
         %li.govuk-page-actions--action
-          = link_to 'Edit definition', edit_admin_framework_path(@framework.id)
+          = link_to 'Edit definition', edit_admin_framework_path(@framework)
         %li.govuk-page-actions--action
-          = link_to 'Download users (CSV)', users_admin_framework_reports_path(@framework.id)
+          = link_to 'Download users (CSV)', users_admin_framework_reports_path(@framework)
         %li.govuk-page-actions--action
-          = link_to 'Download suppliers/lots (CSV)', lots_admin_framework_reports_path(@framework.id)
+          = link_to 'Download suppliers/lots (CSV)', lots_admin_framework_reports_path(@framework)
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,7 @@ Rails.application.routes.draw do
       resources :reports, only: [], controller: 'frameworks/reports' do
         collection do
           get :users
+          get :lots
         end
       end
 

--- a/spec/features/admin_can_download_lots_for_suppliers_on_a_framework_spec.rb
+++ b/spec/features/admin_can_download_lots_for_suppliers_on_a_framework_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin can download a list of lots and their suppliers on a framework' do
+  before do
+    sign_in_as_admin
+  end
+
+  scenario 'everything is fine' do
+    create(:framework, name: 'G-Cloud 42', short_name: 'RM1234')
+
+    travel_to Date.new(2020, 6, 17) do
+      visit admin_frameworks_path
+      click_link 'G-Cloud 42'
+      click_link 'Download suppliers/lots'
+    end
+
+    expect(page.response_headers['Content-Type'])
+      .to include 'text/csv'
+    expect(page.response_headers['Content-Disposition'])
+      .to eq 'attachment; filename="framework_rm1234_lots-2020-06-17.csv"'
+
+    expect(page.body).to include 'framework_reference,framework_name,supplier_salesforce_id' \
+    ',supplier_name,supplier_active,lot_number'
+  end
+end

--- a/spec/models/export/framework_suppliers_lots/extract_spec.rb
+++ b/spec/models/export/framework_suppliers_lots/extract_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe Export::FrameworkSuppliersLots::Extract do
+  describe '#all_relevant' do
+    let(:all_relevant) { Export::FrameworkSuppliersLots::Extract.all_relevant(framework) }
+
+    context 'with suppliers that have both active and inactive lots on a framework' do
+      let!(:framework) do
+        create(:framework, name: 'G-Cloud 42', short_name: 'RM5678.42')
+      end
+
+      let!(:active_supplier) do
+        create(:supplier, name: 'Active Technologies', salesforce_id: 'ACT123') do |supplier|
+          create(:agreement, supplier: supplier, framework: framework, active: true) do |agreement|
+            create(:agreement_framework_lot, agreement: agreement, framework_lot: lot_1a)
+            create(:agreement_framework_lot, agreement: agreement, framework_lot: lot_2b)
+          end
+        end
+      end
+
+      let!(:inactive_supplier) do
+        create(:supplier, name: 'Inactive Ltd', salesforce_id: 'INACT456') do |supplier|
+          create(:agreement, supplier: supplier, framework: framework, active: false) do |agreement|
+            create(:agreement_framework_lot, agreement: agreement, framework_lot: lot_3)
+          end
+        end
+      end
+
+      let!(:supplier_not_on_lots) do
+        create(:supplier, name: 'Forget Me Lots Ltd', salesforce_id: 'NOT000') do |supplier|
+          create(:agreement, supplier: supplier, framework: framework, active: false)
+        end
+      end
+
+      let!(:lot_1a) { create(:framework_lot, framework: framework, number: '1a') }
+
+      let!(:lot_2b) { create(:framework_lot, framework: framework, number: '2b') }
+
+      let!(:lot_3) { create(:framework_lot, framework: framework, number: '3') }
+
+      let!(:other_framework) do
+        create(:framework, name: 'Other Framework') do |framework|
+          create(:agreement, supplier: active_supplier, framework: framework)
+        end
+      end
+
+      it 'includes all suppliers and their lots for a given framework' do
+        expect(all_relevant.size).to eql(3)
+      end
+
+      describe '#_framework_reference as a projection on the AgreementFrameworkLot model' do
+        it 'is included in every result' do
+          all_relevant.map(&:_framework_reference).each do |relevant|
+            expect(relevant).to eql framework.short_name
+          end
+        end
+      end
+
+      describe '#_framework_name as a projection on the AgreementFrameworkLot model' do
+        it 'is included in every result' do
+          all_relevant.map(&:_framework_name).each do |relevant|
+            expect(relevant).to eql framework.name
+          end
+        end
+      end
+
+      describe '#_supplier_name as a projection on the AgreementFrameworkLot model' do
+        it 'contains the suppliers the correct number of times' do
+          extracted_supplier_names = all_relevant.map(&:_supplier_name)
+
+          expect(extracted_supplier_names).to match_array(
+            [
+              active_supplier.name,
+              active_supplier.name,
+              inactive_supplier.name
+            ]
+          )
+        end
+      end
+
+      describe '#_supplier_salesforce_id as a projection on the AgreementFrameworkLot model' do
+        it 'contains the suppliers the correct number of times' do
+          extracted_supplier_salesforce_ids = all_relevant.map(&:_supplier_salesforce_id)
+
+          expect(extracted_supplier_salesforce_ids).to match_array(
+            [
+              active_supplier.salesforce_id,
+              active_supplier.salesforce_id,
+              inactive_supplier.salesforce_id
+            ]
+          )
+        end
+      end
+
+      describe '#_supplier_active as a projection on the AgreementFrameworkLot model' do
+        it 'contains the suppliers on one or more lots' do
+          extracted_supplier_statuses = all_relevant.map(&:_supplier_active)
+
+          expect(extracted_supplier_statuses).to match_array(
+            [
+              true,
+              true,
+              false
+            ]
+          )
+        end
+      end
+
+      describe '#_lot_number as a projection on the AgreementFrameworkLot model' do
+        it 'contains the lot numbers of frameworks the suppliers belongs to' do
+          extracted_lot_numbers = all_relevant.map(&:_lot_number)
+
+          expect(extracted_lot_numbers).to match_array(
+            [
+              '1a',
+              '2b',
+              '3'
+            ]
+          )
+        end
+      end
+
+      it 'excludes frameworks that were not requested' do
+        expect(all_relevant.map(&:_framework_name)).not_to include 'Other Framework'
+      end
+
+      it 'excludes suppliers not on any lots' do
+        expect(all_relevant.map(&:_supplier_name)).not_to include 'Forget Me Lots Ltd'
+      end
+    end
+  end
+end

--- a/spec/models/export/framework_suppliers_lots/row_spec.rb
+++ b/spec/models/export/framework_suppliers_lots/row_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe Export::FrameworkSuppliersLots::Row do
+  let(:input) do
+    OpenStruct.new(
+      _framework_reference: 'RM1234.42',
+      _framework_name: 'G-Cloud 42',
+      _supplier_salesforce_id: 'ACT1234',
+      _supplier_name: 'Active Technologies',
+      _supplier_active: false,
+      _lot_number: '1a',
+    )
+  end
+
+  describe '#row_values' do
+    it 'maps the projected values to an array' do
+      row = Export::FrameworkSuppliersLots::Row.new(input, {})
+
+      expect(row.row_values).to match_array(
+        [
+          'RM1234.42',
+          'G-Cloud 42',
+          'ACT1234',
+          'Active Technologies',
+          'N',
+          '1a',
+        ]
+      )
+    end
+  end
+
+  describe '#supplier_active' do
+    it 'converts true to Y' do
+      input[:_supplier_active] = true
+      row = Export::FrameworkSuppliersLots::Row.new(input, {})
+
+      expect(row.supplier_active).to eql 'Y'
+    end
+
+    it 'converts false to N' do
+      input[:_supplier_active] = false
+      row = Export::FrameworkSuppliersLots::Row.new(input, {})
+
+      expect(row.supplier_active).to eql 'N'
+    end
+  end
+end


### PR DESCRIPTION
Add a new link on the individual framework pages that allows admins to download a list of users, their suppliers and framework details.

<img width="1057" alt="Screenshot 2020-06-23 at 12 26 13" src="https://user-images.githubusercontent.com/3166/85398190-c2e2b200-b54c-11ea-9fb3-6daccc5932b5.png">

The generated CSV has the following fields:

 - framework_reference
 - framework_name
 - supplier_salesforce_id
 - supplier_name
 - supplier_active
 - lot_number