### PR TITLE
Raise exception if required sheets are missing

### DIFF
--- a/app/jobs/submission_ingestion_job.rb
+++ b/app/jobs/submission_ingestion_job.rb
@@ -11,6 +11,10 @@ class SubmissionIngestionJob < ApplicationJob
     handle_unretryable_job_failure(job, exception)
   end
 
+  discard_on(Ingest::Orchestrator::MissingSheets) do |job, exception|
+    handle_unretryable_job_failure(job, exception)
+  end
+
   discard_on IngestFailed
 
   def perform(submission_file)

--- a/spec/models/ingest/orchestrator_spec.rb
+++ b/spec/models/ingest/orchestrator_spec.rb
@@ -90,6 +90,16 @@ RSpec.describe Ingest::Orchestrator do
       end
     end
 
+    context 'with an invalid spreadsheet missing required sheets' do
+      let(:filename) { 'rm1557viii-with-no-invoices.xls' }
+
+      it 'raises MissingSheets' do
+        orchestrator = Ingest::Orchestrator.new(file)
+
+        expect { orchestrator.perform }.to raise_error(Ingest::Orchestrator::MissingSheets)
+      end
+    end
+
     context 'with an invalid submission' do
       let(:filename) { 'rm1557-10-test.xls' }
 


### PR DESCRIPTION
## Changes in this PR:

Rejecting (raising an UnrecoverableError) submission spreadsheets that are missing any sheets corresponding to the types of sheets defined by the submission framework.

The error is raised by the orchestrator class, after the file has been converted, but before the data has been loaded.

## Screenshots of UI changes:

I cannot take a screenshot locally as my Docker setup is failing.

### Before

### After
