### PR TITLE
Fix local Docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,8 @@ terraform.tfstate
 ./*.tfstate
 .terraform/
 .terraform.tfstate.lock.info
+
+# Large things that bloat the build context in development
+backups
+log
+tmp

--- a/bin/drails
+++ b/bin/drails
@@ -1,3 +1,3 @@
 #!/bin/sh
 set +e
-docker-compose run --rm web rails "$@"
+docker-compose run --rm web bin/rails "$@"

--- a/bin/drake
+++ b/bin/drake
@@ -1,3 +1,3 @@
 #!/bin/sh
 set +e
-docker-compose run --rm web rake "$@"
+docker-compose run --rm web bundle exec rake "$@"

--- a/docker-compose.env.sample
+++ b/docker-compose.env.sample
@@ -1,5 +1,5 @@
 SECRET_KEY_BASE=1e68bf00783c255cf545c4b2a4548f1d863019323c705b0d210416b1db4746a553ff364b282069c0de45dc6d5f449265539faa9a91e8d7f4effc6798143547d2
-DATABASE_URL=postgres://postgres@db:5432/DataSubmissionServiceApi_development?template=template0&pool=5&encoding=unicode
+DATABASE_URL=postgres://postgres:password@db:5432/DataSubmissionServiceApi_development?template=template0&pool=5&encoding=unicode
 RAILS_MAX_THREADS=5
 SIDEKIQ_USERNAME=sidekiq
 SIDEKIQ_PASSWORD=sidekiq

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,7 +8,7 @@ services:
         RAILS_ENV: "test"
     environment:
       RAILS_ENV: "test"
-      DATABASE_URL: "postgres://postgres@db-test:5432/DataSubmissionServiceApi_test?template=template0&pool=5&encoding=unicode"
+      DATABASE_URL: "postgres://postgres:password@db-test:5432/DataSubmissionServiceApi_test?template=template0&pool=5&encoding=unicode"
       AWS_S3_REGION: 'eu-west-2'
     env_file:
       - docker-compose.env
@@ -31,6 +31,8 @@ services:
       - tests
     restart: on-failure
     container_name: data-submission-service-api_db-test
+    environment:
+      POSTGRES_PASSWORD: "password"
 
 networks:
   tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     volumes:
       - .:/srv/dss-api:cached
       - node_modules:/srv/dss-api/node_modules:cached
-    command: bash -c "rm -f tmp/pids/server.pid && rails s -b 0.0.0.0"
+    command: bash -c "rm -f tmp/pids/server.pid && bin/rails s -b 0.0.0.0 -p 3000"
     container_name: "data-submission-service-api_web"
     networks:
       public:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
     container_name: "data-submission-service-api_db"
     networks:
       private:
+    environment:
+      POSTGRES_PASSWORD: "password"
   redis:
     image: redis
     container_name: "data-submission-service-api_redis"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,12 +8,12 @@ setup_database()
   echo "Checking database setup is up-to-date…"
   # Rails will throw an error if no database exists"
   #   PG::ConnectionBad: FATAL:  database "tvs_development" does not exist
-  if rake db:migrate:status &> /dev/null; then
+  if bundle exec rake db:migrate:status &> /dev/null; then
     echo "Database found, running db:migrate…"
-    rake db:migrate
+    bundle exec rake db:migrate
   else
     echo "No database found, running db:create db:schema:load…"
-    rake db:create db:schema:load
+    bundle exec rake db:create db:schema:load
   fi
   echo "Finished database setup"
 }


### PR DESCRIPTION
## Changes in this PR:

This fixes the local Docker development environment, which has been broken for a while. I can now successfully:

- run the server with `bin/dstart` and access it at `http://localhost:3000/admin`
- run the tests with `bin/dtest-server` and `bin/dspec`

## Updating your local environment

You'll need to update your local `docker-compose.env` with the new `DATABASE_URL` from `docker-compose.env.sample`.

## Caveats

There are some database-related errors on first startup:
- `ActiveRecord::ConcurrentMigrationError`, or
- `PG::DuplicateObject: ERROR:  constraint "fk_rails_11d9b07d76" for relation "agreement_framework_lots" already exists`

I think these come from the web and worker containers both trying to set up the database at the same time. But I'm pretty sure this is not a new issue. I remember it happening a while back too. If I have a chance, I'll see what we can do about that, too. I worked around it by running `docker-compose up web` before `bin/dstart`.